### PR TITLE
[FIX] report_id required on new KPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ coverage.xml
 .project
 .pydevproject
 
+# Eclipse
+.settings
+
 # Rope
 .ropeproject
 

--- a/mis_builder/__manifest__.py
+++ b/mis_builder/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'MIS Builder',
-    'version': '10.0.3.0.2',
+    'version': '10.0.3.0.3',
     'category': 'Reporting',
     'summary': """
         Build 'Management Information System' Reports and Dashboards

--- a/mis_builder/views/mis_report.xml
+++ b/mis_builder/views/mis_report.xml
@@ -79,7 +79,10 @@
                     <field name="accumulation_method"/>
                     <field name="style_id"/>
                     <field name="style_expression"/>
-                    <field name="report_id" invisible="1"/>
+                    <field name='id' invisible='1'/>
+                    <field name="report_id"
+                           invisible="1"
+                           attrs="{'required': [('id', '!=', False)]}"/>
                 </group>
                 <notebook>
                     <page string="Expressions">


### PR DESCRIPTION
When adding a new KPI to an unsaved report, the report_id is required and fails on the popup.

Fixes #18 