### PR TITLE
[ADD] enrich the evaluation context of move lines domains

### DIFF
--- a/mis_builder/CHANGES.rst
+++ b/mis_builder/CHANGES.rst
@@ -15,6 +15,11 @@ New features:
   date ranges for the most common case.
 * [ADD] multi-company consolidation support, with currency conversion
   (the conversion rate date is the end of the reporting period)
+* [ADD] provide ref, datetime, dateutil, time, user in the evaluation 
+  context of move line domains; among other things, this allows using 
+  references to xml ids (such as account types or tax tags) when 
+  querying move lines 
+  (`#26 <https://github.com/OCA/mis-builder/issues/26>`_).
 
 10.0.3.0.4 (2017-10-14)
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/mis_builder/models/aep.py
+++ b/mis_builder/models/aep.py
@@ -2,9 +2,12 @@
 # Copyright 2014-2017 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
+import datetime
+import dateutil
 import re
 from collections import defaultdict
 from itertools import izip
+import time
 
 from odoo import fields, _
 from odoo.models import expression
@@ -138,7 +141,14 @@ class AccountingExpressionProcessor(object):
         else:
             account_codes = [None]  # None means we want all accounts
         domain = domain or '[]'
-        domain = tuple(safe_eval(domain))
+        eval_context = {
+            'ref': self.env.ref,
+            'user': self.env.user,
+            'time': time,
+            'datetime': datetime,
+            'dateutil': dateutil,
+        }
+        domain = tuple(safe_eval(domain, eval_context))
         return field, mode, account_codes, domain
 
     def parse_expr(self, expr):

--- a/mis_builder/tests/test_aep.py
+++ b/mis_builder/tests/test_aep.py
@@ -81,6 +81,13 @@ class TestAEP(common.TransactionCase):
         self.aep.parse_expr("crdp[700I%]")
         self.aep.parse_expr("bali[400%]")
         self.aep.parse_expr("bale[700%]")
+        self.aep.parse_expr(
+            "balp[]"
+            "[('account_id.code', '=', '400AR')]")
+        self.aep.parse_expr(
+            "balp[]"
+            "[('account_id.user_type_id', '=', "
+            "  ref('account.data_account_type_receivable').id)]")
         self.aep.parse_expr("bal_700IN")  # deprecated
         self.aep.parse_expr("bals[700IN]")  # deprecated
         self.aep.done_parsing()
@@ -133,6 +140,12 @@ class TestAEP(common.TransactionCase):
         self.assertIs(self._eval('bali[700IN]'), AccountingNone)
         # check variation
         self.assertEquals(self._eval('balp[400AR]'), 100)
+        self.assertEquals(self._eval(
+            "balp[][('account_id.code', '=', '400AR')]"), 100)
+        self.assertEquals(self._eval(
+            "balp[]"
+            "[('account_id.user_type_id', '=', "
+            "  ref('account.data_account_type_receivable').id)]"), 100)
         self.assertEquals(self._eval('balp[700IN]'), -100)
         # check ending balance
         self.assertEquals(self._eval('bale[400AR]'), 100)

--- a/mis_builder/views/mis_report.xml
+++ b/mis_builder/views/mis_report.xml
@@ -143,6 +143,7 @@
                                         <li><b>bale[1%%]</b>: balance of accounts starting with 1 at end of period.</li>
                                         <li><b>crdp[40%]</b>: sum of all credits on accounts starting with 40 during the period.</li>
                                         <li><b>debp[55%][('journal_id.code', '=', 'BNK1')]</b>: sum of all debits on accounts 55 and journal BNK1 during the period.</li>
+                                        <li><b>balp[][('account_id.user_type_id', '=', ref('account.data_account_type_receivable').id)]</b>: variation of the balance of all receivable accounts over the period (this is a slow method).</li>
                                     </ul>
                                 </div>
                             </group>


### PR DESCRIPTION
Provide ref, datetime, dateutil, time, user in the evaluation
context of move line domains; among other things, this allows using
references to xml ids (such as account types or tax tags) when
querying move lines.

fixes #26 