### PR TITLE
[FIX] a few multi company fixes

### DIFF
--- a/mis_builder/CHANGES.rst
+++ b/mis_builder/CHANGES.rst
@@ -24,6 +24,10 @@ New features:
   querying move lines 
   (`#26 <https://github.com/OCA/mis-builder/issues/26>`_).
 
+Upgrading from 3.0 (breaking changes):
+
+* Alternative move line data sources must have a company_id field.
+
 10.0.3.0.4 (2017-10-14)
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -141,7 +141,7 @@ class MisReportInstancePeriod(models.Model):
                      '|',
                      ('company_id', '=', False),
                      ('company_id', 'in',
-                      record.report_instance_id.company_ids.ids)])
+                      record.report_instance_id._query_companies().ids)])
                 if current_periods:
                     # TODO we take the first date range we found as current
                     #      this may be surprising if several companies
@@ -235,9 +235,10 @@ class MisReportInstancePeriod(models.Model):
         domain=[('field_id.name', '=', 'debit'),
                 ('field_id.name', '=', 'credit'),
                 ('field_id.name', '=', 'account_id'),
-                ('field_id.name', '=', 'date')],
+                ('field_id.name', '=', 'date'),
+                ('field_id.name', '=', 'company_id')],
         help="A 'move line like' model, ie having at least debit, credit, "
-             "date and account_id fields.",
+             "date, account_id and company_id fields.",
     )
     source_sumcol_ids = fields.One2many(
         comodel_name='mis.report.instance.period.sum',
@@ -397,7 +398,7 @@ class MisReportInstance(models.Model):
         required=True,
     )
     multi_company = fields.Boolean(
-        string='Multiple',
+        string='Multiple companies',
         help="Check if you wish to specify "
              "children companies to be searched for data.",
         default=False,
@@ -406,7 +407,6 @@ class MisReportInstance(models.Model):
         comodel_name='res.company',
         string='Companies',
         help="Select companies for which data will be searched.",
-        required=True,
     )
     currency_id = fields.Many2one(
         comodel_name='res.currency',
@@ -433,7 +433,14 @@ class MisReportInstance(models.Model):
                 ('id', 'child_of', self.company_id.id),
             ])
         else:
-            self.company_ids = self.company_id
+            self.company_ids = False
+
+    def _query_companies(self):
+        """ Return companies to query """
+        if self.multi_company:
+            return self.company_ids or self.company_id
+        else:
+            return self.company_id
 
     @api.multi
     def save_report(self):
@@ -643,7 +650,7 @@ class MisReportInstance(models.Model):
         """
         self.ensure_one()
         aep = self.report_id._prepare_aep(
-            self.company_ids or self.company_id, self.currency_id)
+            self._query_companies(), self.currency_id)
         kpi_matrix = self.report_id.prepare_kpi_matrix()
         for period in self.period_ids:
             description = None
@@ -674,7 +681,7 @@ class MisReportInstance(models.Model):
         account_id = arg.get('account_id')
         if period_id and expr and AEP.has_account_var(expr):
             period = self.env['mis.report.instance.period'].browse(period_id)
-            aep = AEP(self.company_ids or self.company_id, self.currency_id)
+            aep = AEP(self._query_companies(), self.currency_id)
             aep.parse_expr(expr)
             aep.done_parsing()
             domain = aep.get_aml_domain_for_expr(

--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -435,8 +435,10 @@ class MisReportInstance(models.Model):
         else:
             self.company_ids = False
 
+    @api.multi
     def _get_query_companies(self):
         """ Return companies to query """
+        self.ensure_one()
         if self.multi_company:
             return self.company_ids or self.company_id
         else:

--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -141,7 +141,7 @@ class MisReportInstancePeriod(models.Model):
                      '|',
                      ('company_id', '=', False),
                      ('company_id', 'in',
-                      record.report_instance_id._query_companies().ids)])
+                      record.report_instance_id._get_query_companies().ids)])
                 if current_periods:
                     # TODO we take the first date range we found as current
                     #      this may be surprising if several companies
@@ -435,7 +435,7 @@ class MisReportInstance(models.Model):
         else:
             self.company_ids = False
 
-    def _query_companies(self):
+    def _get_query_companies(self):
         """ Return companies to query """
         if self.multi_company:
             return self.company_ids or self.company_id
@@ -650,7 +650,7 @@ class MisReportInstance(models.Model):
         """
         self.ensure_one()
         aep = self.report_id._prepare_aep(
-            self._query_companies(), self.currency_id)
+            self._get_query_companies(), self.currency_id)
         kpi_matrix = self.report_id.prepare_kpi_matrix()
         for period in self.period_ids:
             description = None
@@ -681,7 +681,7 @@ class MisReportInstance(models.Model):
         account_id = arg.get('account_id')
         if period_id and expr and AEP.has_account_var(expr):
             period = self.env['mis.report.instance.period'].browse(period_id)
-            aep = AEP(self._query_companies(), self.currency_id)
+            aep = AEP(self._get_query_companies(), self.currency_id)
             aep.parse_expr(expr)
             aep.done_parsing()
             domain = aep.get_aml_domain_for_expr(

--- a/mis_builder/tests/test_mis_report_instance.py
+++ b/mis_builder/tests/test_mis_report_instance.py
@@ -127,7 +127,6 @@ class TestMisReportInstance(common.TransactionCase):
             name='test instance',
             report_id=self.report.id,
             company_id=self.env.ref('base.main_company').id,
-            company_ids=[(6, 0, [self.env.ref('base.main_company').id])],
             period_ids=[(0, 0, dict(
                 name='p1',
                 mode='relative',
@@ -192,3 +191,27 @@ class TestMisReportInstance(common.TransactionCase):
         )
         r = self.env['mis.report.kpi.expression'].name_search('k4')
         self.assertEqual([i[1] for i in r], ['kpi 4 (k4)'])
+
+    def test_multi_company_onchange(self):
+        # not multi company
+        self.assertTrue(self.report_instance.company_id)
+        self.assertFalse(self.report_instance.multi_company)
+        self.assertFalse(self.report_instance.company_ids)
+        self.assertEqual(
+            self.report_instance._get_query_companies()[0],
+            self.report_instance.company_id)
+        # create a child company
+        self.env['res.company'].create(dict(
+            name='company 2',
+            parent_id=self.report_instance.company_id.id,
+        ))
+        self.report_instance.multi_company = True
+        # multi company, company_ids not set
+        self.assertEqual(
+            self.report_instance._get_query_companies()[0],
+            self.report_instance.company_id)
+        # set company_ids
+        self.report_instance._onchange_company()
+        self.assertTrue(self.report_instance.multi_company)
+        self.assertTrue(len(self.report_instance.company_ids) == 2)
+        self.assertTrue(len(self.report_instance._get_query_companies()) == 2)

--- a/mis_builder/views/mis_report_instance.xml
+++ b/mis_builder/views/mis_report_instance.xml
@@ -68,7 +68,7 @@
                             <field name="company_id" groups="base.group_multi_company"/>
                             <field name="multi_company" groups="base.group_multi_company"/>
                             <field name="company_ids" groups="base.group_multi_company" widget="many2many_tags"
-                                    domain="['|', ('id', '=', company_id), ('parent_id', 'child_of', company_id)]"
+                                    domain="[('id', 'child_of', company_id)]"
                                     attrs="{'invisible': [('multi_company', '=', False)]}"/>
                             <field name="currency_id" groups="base.group_multi_currency"/>
                             <field name="target_move" widget="radio"/>


### PR DESCRIPTION
* alt move lines view must have company_id field
* make company_ids optional to facilitate migration and be more
  robust in case the onchange multi_company has not be triggered
  (use company_id if company_ids is empty)

Refs #7 