### PR TITLE
[IMP] improve report instance view form

### DIFF
--- a/mis_builder/CHANGES.rst
+++ b/mis_builder/CHANGES.rst
@@ -27,6 +27,10 @@ New features:
   any domain on account.account, not only account codes
   ``balp[('user_type_id', '=', ref('account.data_account_type_receivable').id)]``
   (`#4 <https://github.com/OCA/mis-builder/issues/4>`_).
+* [IMP] in the report instance configuration form, the filters are
+  now grouped in a notebook page, this improves readability and
+  extensibility
+  (`#39 <https://github.com/OCA/mis-builder/issues/39>`_).
 
 Upgrading from 3.0 (breaking changes):
 

--- a/mis_builder/views/mis_report_instance.xml
+++ b/mis_builder/views/mis_report_instance.xml
@@ -65,13 +65,7 @@
                     <group>
                         <group>
                             <field name="report_id" string="Template"/>
-                            <field name="company_id" groups="base.group_multi_company"/>
-                            <field name="multi_company" groups="base.group_multi_company"/>
-                            <field name="company_ids" groups="base.group_multi_company" widget="many2many_tags"
-                                    domain="[('id', 'child_of', company_id)]"
-                                    attrs="{'invisible': [('multi_company', '=', False)]}"/>
                             <field name="currency_id" groups="base.group_multi_currency"/>
-                            <field name="target_move" widget="radio"/>
                             <field name="landscape_pdf"/>
                             <field name="comparison_mode"/>
                         </group>
@@ -84,20 +78,33 @@
                             </group>
                         </group>
                     </group>
-                    <group name="comparison_mode" string="Columns"
-                           attrs="{'invisible': [('comparison_mode', '=', False)]}" colspan="4">
-                        <field name="period_ids" colspan="4" nolabel="1" attrs="{'required': [('comparison_mode', '=', True)]}" context="{'default_report_instance_id': id}">
-                            <tree colors="red:valid==False">
-                                <field name="sequence" widget="handle"/>
-                                <field name="name"/>
-                                <field name="source"/>
-                                <field name="date_from"/>
-                                <field name="date_to"/>
-                                <field name="valid" invisible="1"/>
-                            </tree>
-                        </field>
-                        <field name="date"/>
-                    </group>
+                    <notebook>
+                        <page string="Columns" attrs="{'invisible': [('comparison_mode', '=', False)]}">
+                            <group>
+                                <field name="period_ids" colspan="4" nolabel="1" attrs="{'required': [('comparison_mode', '=', True)]}" context="{'default_report_instance_id': id}">
+                                    <tree colors="red:valid==False">
+                                        <field name="sequence" widget="handle"/>
+                                        <field name="name"/>
+                                        <field name="source"/>
+                                        <field name="date_from"/>
+                                        <field name="date_to"/>
+                                        <field name="valid" invisible="1"/>
+                                    </tree>
+                                </field>
+                                <field name="date"/>
+                            </group>
+                        </page>
+                        <page string="Filters">
+                            <group name="filters">
+                                <field name="target_move" widget="radio"/>
+                                <field name="company_id" groups="base.group_multi_company"/>
+                                <field name="multi_company" groups="base.group_multi_company"/>
+                                <field name="company_ids" groups="base.group_multi_company" widget="many2many_tags"
+                                        domain="[('id', 'child_of', company_id)]"
+                                        attrs="{'invisible': [('multi_company', '=', False)]}"/>
+                            </group>
+                        </page>
+                    </notebook>
                 </sheet>
                 </form>
             </field>


### PR DESCRIPTION
In the report instance configuration form, the filters are
now grouped in a notebook page. This improves readability and
extensibility

fixes #39 

Example in comparison mode:

![image](https://user-images.githubusercontent.com/692075/32371535-8aa920de-c091-11e7-9203-7a59710150cf.png)

Example in simple mode:

![image](https://user-images.githubusercontent.com/692075/32371558-a05a4d68-c091-11e7-930a-58d024014a55.png)
