### PR TITLE
[9.0][FIX] Fill some defaults in migration script

### DIFF
--- a/mis_builder/migrations/8.0.2.0.0/post-migration.py
+++ b/mis_builder/migrations/8.0.2.0.0/post-migration.py
@@ -2,6 +2,27 @@
 # © 2017 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
+from openerp import api, SUPERUSER_ID
+
+
+def fill_defaults(env):
+    cr = env.cr
+
+    default_specs = {
+        'mis.report.instance.period': ['report_instance_id'],
+        'mis.report.kpi': ['report_id'],
+        'mis.report.query': ['report_id'],
+        'mis.report.instance': ['company_id'],
+    }
+
+    for model in default_specs.keys():
+        obj = env[model]
+        for field in default_specs[model]:
+            value = obj.default_get([field])
+            if value:
+                cr.execute("UPDATE %s SET %s = %s WHERE %s is NULL" % (
+                    obj._table, field, value, field))
+
 
 def migrate(cr, version):
     cr.execute("""
@@ -22,3 +43,6 @@ def migrate(cr, version):
         UPDATE mis_report_instance_period
         SET mode='relative'
     """)
+    # set defaults in now required fields
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    fill_defaults(env)


### PR DESCRIPTION
From v8 to v9, some fields has become required (see commits https://github.com/OCA/mis-builder/commit/7e20ff90646fbee20707aeabf294cba77bb239f0 and https://github.com/OCA/mis-builder/commit/db7e6eece53e4a15274582d7f5c83a74c16fc05a). Thus, in case some of them were not filled, they should be filled in the migration.