### PR TITLE
[10.0] mis_builder python3 compatibility

### DIFF
--- a/mis_builder/models/aep.py
+++ b/mis_builder/models/aep.py
@@ -5,7 +5,11 @@
 import datetime
 import re
 from collections import defaultdict
-from itertools import izip
+try:
+    import itertools.izip as zip
+except ImportError:
+    pass
+
 import time
 
 import dateutil
@@ -519,4 +523,4 @@ class AccountingExpressionProcessor(object):
         # or leave that to the caller?
         bals = cls._get_balances(cls.MODE_UNALLOCATED, companies,
                                  date, date, target_move)
-        return tuple(map(sum, izip(*bals.values())))
+        return tuple(map(sum, zip(*bals.values())))

--- a/mis_builder/models/kpimatrix.py
+++ b/mis_builder/models/kpimatrix.py
@@ -3,7 +3,11 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from collections import defaultdict, OrderedDict
-from itertools import izip
+try:
+    import itertools.izip as zip
+except ImportError:
+    pass
+
 import logging
 
 from odoo import _
@@ -233,7 +237,7 @@ class KpiMatrix(object):
         assert len(vals) == col.colspan
         assert len(drilldown_args) == col.colspan
         for val, drilldown_arg, subcol in \
-                izip(vals, drilldown_args, col.iter_subcols()):
+                zip(vals, drilldown_args, col.iter_subcols()):
             if isinstance(val, DataError):
                 val_rendered = val.name
                 val_comment = val.msg
@@ -323,9 +327,9 @@ class KpiMatrix(object):
                                  cell.subcol.subkpi in common_subkpis]
                 comparison_cell_tuple = []
                 for val, base_val, comparison_subcol in \
-                        izip(vals,
-                             base_vals,
-                             comparison_col.iter_subcols()):
+                        zip(vals,
+                            base_vals,
+                            comparison_col.iter_subcols()):
                     # TODO FIXME average factors
                     delta, delta_r, style_r = \
                         self._style_model.compare_and_render(

--- a/mis_builder/models/mis_report.py
+++ b/mis_builder/models/mis_report.py
@@ -4,7 +4,10 @@
 
 from collections import defaultdict
 import datetime
-from itertools import izip
+try:
+    import itertools.izip as zip
+except ImportError:
+    pass
 import logging
 import re
 import time
@@ -799,7 +802,7 @@ class MisReport(models.Model):
                 drilldown_args = []
                 name_error = False
                 for expression, replaced_expr in \
-                        izip(expressions, replaced_exprs):
+                        zip(expressions, replaced_exprs):
                     vals.append(mis_safe_eval(replaced_expr, locals_dict))
                     if replaced_expr != expression:
                         drilldown_args.append({

--- a/mis_builder/models/mis_report_style.py
+++ b/mis_builder/models/mis_report_style.py
@@ -2,12 +2,15 @@
 # Copyright 2016 Therp BV (<http://therp.nl>)
 # Copyright 2016-2017 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
-
+import sys
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError
 
 from .accounting_none import AccountingNone
 from .data_error import DataError
+
+if sys.version_info.major >= 3:
+    unicode = str
 
 
 class PropertyDict(dict):


### PR DESCRIPTION
Adds compatibility with python 3. Now requires python package `future`