### PR TITLE
[8.0][FIX] Added a wrpping method for get_pdf() to make it compatible to n…

### DIFF
--- a/mis_builder/report/report_mis_report_instance.py
+++ b/mis_builder/report/report_mis_report_instance.py
@@ -50,7 +50,7 @@ class Report(models.Model):
                                            context=context)
 
     @api.v8
-    def get_pdf(self, records, report_name, html=None, data=None):
-        return Report.get_pdf(self._model, self._cr, self._uid, records.ids,
-                              report_name, html=html, data=data,
-                              context=self._context)
+    def get_pdf(self, docids, report_name, html=None, data=None):
+        return self._model.get_pdf(self._cr, self._uid,
+                                   docids, report_name,
+                                   html=html, data=data, context=self._context)

--- a/mis_builder/report/report_mis_report_instance.py
+++ b/mis_builder/report/report_mis_report_instance.py
@@ -48,3 +48,9 @@ class Report(models.Model):
         return super(Report, self).get_pdf(cr, uid, ids, report_name,
                                            html=html, data=data,
                                            context=context)
+
+    @api.v8
+    def get_pdf(self, records, report_name, html=None, data=None):
+        return Report.get_pdf(self._model, self._cr, self._uid, records.ids,
+                              report_name, html=html, data=data,
+                              context=self._context)


### PR DESCRIPTION
Fixed a bug where calling get_pdf() with new API result in errors.

Description:

When the MIS Builder is installed and the get_pdf() method is called it gives an error. It can be seen when debugging the call into the api wrapper that the function pointer new_api() is assigned to "None".


Solution:

Adding a method definition with decorator for "api.v8" does the trick.