### PR TITLE
[8.0][FIX] call of api-7 function in api-8 function get_pdf()

### DIFF
--- a/mis_builder/report/report_mis_report_instance.py
+++ b/mis_builder/report/report_mis_report_instance.py
@@ -52,5 +52,5 @@ class Report(models.Model):
     @api.v8
     def get_pdf(self, docids, report_name, html=None, data=None):
         return self._model.get_pdf(self._cr, self._uid,
-                                   docids, report_name,
+                                   docids.ids, report_name,
                                    html=html, data=data, context=self._context)


### PR DESCRIPTION
Fixed a bug where calling `get_pdf()` results in a `QWebException` while rendering the template.

Description:
In #61 a wrapper function `get_pdf()` with `api.v8` was added. Unfortunatly not all function parameters where handled well, so a recodset is passed through instead of a list of ids, leading to problems when interpreting the qweb template.

Solution:
Pass ids of the recordset to next function instead of the recordset itself.