### PR TITLE
[FIX] mis_builder_budget: properly handle NameDataError

### DIFF
--- a/mis_builder_budget/CHANGES.rst
+++ b/mis_builder_budget/CHANGES.rst
@@ -6,6 +6,13 @@ Changelog for mis_builder_budget
 ..
 .. *
 
+10.0.3.1.x (unreleased)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+- [FIX] #NAME error in out-of-order computation of non
+  budgetable items in budget columns
+  (`#68 <https://github.com/OCA/mis-builder/pull/69>`_)
+
 10.0.3.1.0 (2017-11-14)
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/mis_builder_budget/models/mis_report_instance.py
+++ b/mis_builder_budget/models/mis_report_instance.py
@@ -7,6 +7,7 @@ from odoo.osv import expression
 
 from odoo.addons.mis_builder.models.accounting_none import AccountingNone
 from odoo.addons.mis_builder.models.mis_safe_eval import mis_safe_eval
+from odoo.addons.mis_builder.models.data_error import NameDataError
 from .mis_report_instance_period import SRC_MIS_BUDGET
 
 
@@ -44,6 +45,8 @@ class MisReportInstance(models.Model):
                         }
                     elif expr.name:
                         val = mis_safe_eval(expr.name, locals_dict)
+                        if isinstance(val, NameDataError):
+                            name_error = True
                 vals.append(val)
                 drilldown_args.append(drilldown_arg)
             return vals, drilldown_args, name_error

--- a/mis_builder_budget/tests/test_mis_budget.py
+++ b/mis_builder_budget/tests/test_mis_budget.py
@@ -24,13 +24,16 @@ class TestMisBudget(TransactionCase):
             expression='10',
             budgetable=True,
         ))
+        self.kpi1_index = 1
         self.expr1 = self.kpi1.expression_ids[0]
         self.kpi2 = self.env['mis.report.kpi'].create(dict(
             report_id=self.report.id,
             name='k2',
             description='kpi 2',
             expression='k1 + 1',
+            sequence=0,  # kpi2 before kpi1 to test out of order evaluation
         ))
+        self.kpi2_index = 0
         # budget
         self.budget = self.env['mis.budget'].create(dict(
             name='the budget',
@@ -91,8 +94,8 @@ class TestMisBudget(TransactionCase):
         matrix = self.instance._compute_matrix()
         assert_matrix(matrix, [
             # jan, bud jan, feb (3w), bud feb (3w),
-            [10, 10, 10, 15],  # k1
             [11, 11, 11, 16],  # k2 = k1 + 1
+            [10, 10, 10, 15],  # k1
         ])
 
     def test_drilldown(self):
@@ -123,7 +126,7 @@ class TestMisBudget(TransactionCase):
 
     def test_name_search(self):
         report2 = self.report.copy()
-        report2.kpi_ids[0].name = 'k1_1'
+        report2.kpi_ids[self.kpi1_index].name = 'k1_1'
         budget2 = self.budget.copy()
         budget2.report_id = report2.id
         # search restricted to the context of budget2


### PR DESCRIPTION
Similar to what is done [here](https://github.com/OCA/mis-builder/blob/23a0f11fcf6b1321ed79ffea355292a8c95a9f59/mis_builder/models/mis_report.py#L782-L784).