### PR TITLE
fix screenshot links in readme

### DIFF
--- a/mis_builder/README.rst
+++ b/mis_builder/README.rst
@@ -32,21 +32,20 @@ To configure this module, you need to:
   you can create report templates by defining KPI's. KPI's constitute the rows of your
   reports. Such report templates are time independent.
 
-.. figure:: static/description/ex_report_template.png
-   :scale: 80 %
+.. figure:: https://raw.githubusercontent.com/OCA/mis-builder/10.0/mis_builder/static/description/ex_report_template.png
    :alt: Sample report template
 
 * Then in Accounting > Reporting > MIS Reports you can create report instance by
   binding the templates to time period, hence defining the columns of your reports.
 
-.. figure:: static/description/ex_report.png
+.. figure:: https://raw.githubusercontent.com/OCA/mis-builder/10.0/mis_builder/static/description/ex_report_settings.png
    :alt: Sample report configuration
 
 * From the MIS Report view, you can preview the report, add it to and Odoo dashboard,
   and export it to PDF or Excel.
 
-.. figure:: static/description/ex_dashboard.png
-   :alt: Sample dashboard view
+.. figure:: https://raw.githubusercontent.com/OCA/mis-builder/10.0/mis_builder/static/description/ex_report_preview.png
+   :alt: Sample preview
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot

--- a/mis_builder/README.rst
+++ b/mis_builder/README.rst
@@ -28,24 +28,30 @@ Configuration and Usage
 
 To configure this module, you need to:
 
-* Go to Accounting > Configuration > Financial Reports > MIS Report Templates where
+* Go to Accounting > Configuration > MIS Reporting > MIS Report Templates where
   you can create report templates by defining KPI's. KPI's constitute the rows of your
   reports. Such report templates are time independent.
 
 .. figure:: https://raw.githubusercontent.com/OCA/mis-builder/10.0/mis_builder/static/description/ex_report_template.png
    :alt: Sample report template
+   :width: 95 %
+   :align: center
 
-* Then in Accounting > Reporting > MIS Reports you can create report instance by
-  binding the templates to time period, hence defining the columns of your reports.
+* Then in Accounting > Reports > MIS Reporting > MIS Reports you can create report instance by
+  binding the templates to time periods, hence defining the columns of your reports.
 
 .. figure:: https://raw.githubusercontent.com/OCA/mis-builder/10.0/mis_builder/static/description/ex_report_settings.png
    :alt: Sample report configuration
+   :width: 95 %
+   :align: center
 
-* From the MIS Report view, you can preview the report, add it to and Odoo dashboard,
+* From the MIS Reports view, you can preview the report, add it to and Odoo dashboard,
   and export it to PDF or Excel.
 
 .. figure:: https://raw.githubusercontent.com/OCA/mis-builder/10.0/mis_builder/static/description/ex_report_preview.png
    :alt: Sample preview
+   :width: 95 %
+   :align: center
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot


### PR DESCRIPTION
Fixes #76 

Putting a full link (admiteddly a little bit overusing github as a CDN) should fix the display in all media.