### PR TITLE
Add pbal, nbal accounting expressions

### DIFF
--- a/mis_builder/CHANGES.rst
+++ b/mis_builder/CHANGES.rst
@@ -15,6 +15,10 @@ Changelog for mis_builder
   enabling the creation of detailed templates while deferring the decision
   of rendering the details or not to the report instance
   (`#74 <https://github.com/OCA/mis-builder/issues/74>`_)
+* [ADD] pbal and nbal accounting expressions, to sum positive
+  and negative balances respectively (ie ignoring accounts with negative,
+  resp positive balances)
+  (`#86 <https://github.com/OCA/mis-builder/issues/86>`_)
 
 10.0.3.1.1 (2017-11-14)
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/mis_builder/models/aep.py
+++ b/mis_builder/models/aep.py
@@ -80,7 +80,7 @@ class AccountingExpressionProcessor(object):
     MODE_UNALLOCATED = 'u'
 
     _ACC_RE = re.compile(
-        r"(?P<field>\bbal|\bcrd|\bdeb)"
+        r"(?P<field>\bbal|\bpbal|\bnbal|\bcrd|\bdeb)"
         r"(?P<mode>[piseu])?"
         r"\s*"
         r"(?P<account_sel>_[a-zA-Z0-9]+|\[.*?\])"
@@ -384,6 +384,10 @@ class AccountingExpressionProcessor(object):
                                          (AccountingNone, AccountingNone))
                 if field == 'bal':
                     v += debit - credit
+                elif field == 'pbal' and debit >= credit:
+                    v += debit - credit
+                elif field == 'nbal' and debit < credit:
+                    v += debit - credit
                 elif field == 'deb':
                     v += debit
                 elif field == 'crd':
@@ -421,6 +425,16 @@ class AccountingExpressionProcessor(object):
                                      (AccountingNone, AccountingNone))
             if field == 'bal':
                 v = debit - credit
+            elif field == 'pbal':
+                if debit >= credit:
+                    v = debit - credit
+                else:
+                    v = AccountingNone
+            elif field == 'nbal':
+                if debit < credit:
+                    v = debit - credit
+                else:
+                    v = AccountingNone
             elif field == 'deb':
                 v = debit
             elif field == 'crd':

--- a/mis_builder/models/aep.py
+++ b/mis_builder/models/aep.py
@@ -35,13 +35,15 @@ class AccountingExpressionProcessor(object):
 
     Expressions of the form <field><mode>[accounts][optional move line domain]
     are supported, where:
-        * field is bal, crd, deb
+        * field is bal, crd, deb, pbal (positive balances only),
+          nbal (negative balance only)
         * mode is i (initial balance), e (ending balance),
           p (moves over period)
         * there is also a special u mode (unallocated P&L) which computes
           the sum from the beginning until the beginning of the fiscal year
           of the period; it is only meaningful for P&L accounts
-        * accounts is a list of accounts, possibly containing % wildcards
+        * accounts is a list of accounts, possibly containing % wildcards,
+          or a domain expression on account.account
         * an optional domain on move lines allowing filters on eg analytic
           accounts or journal
 
@@ -68,9 +70,9 @@ class AccountingExpressionProcessor(object):
           strict minimum number of queries to the database (for each period,
           one query per domain and mode);
         * it queries using the orm read_group which reduces to a query with
-          sum on debit and credit and group by on account_id (note: it seems
-          the orm then does one query per account to fetch the account
-          name...);
+          sum on debit and credit and group by on account_id and company_id,
+          (note: it seems the orm then does one query per account to fetch
+          the account name...);
         * additionally, one query per view/consolidation account is done to
           discover the children accounts.
     """

--- a/mis_builder/tests/test_aep.py
+++ b/mis_builder/tests/test_aep.py
@@ -189,12 +189,24 @@ class TestAEP(common.TransactionCase):
         # initial balance is the ending balance fo January
         self.assertEquals(self._eval('bali[400AR]'), 400)
         self.assertEquals(self._eval('bali[700IN]'), -300)
+        self.assertEquals(self._eval('pbali[400AR]'), 400)
+        self.assertEquals(self._eval('nbali[400AR]'), 0)
+        self.assertEquals(self._eval('nbali[700IN]'), -300)
+        self.assertEquals(self._eval('pbali[700IN]'), 0)
         # check variation
         self.assertEquals(self._eval('balp[400AR]'), 500)
         self.assertEquals(self._eval('balp[700IN]'), -500)
+        self.assertEquals(self._eval('nbalp[400AR]'), 0)
+        self.assertEquals(self._eval('pbalp[400AR]'), 500)
+        self.assertEquals(self._eval('nbalp[700IN]'), -500)
+        self.assertEquals(self._eval('pbalp[700IN]'), 0)
         # check ending balance
         self.assertEquals(self._eval('bale[400AR]'), 900)
+        self.assertEquals(self._eval('nbale[400AR]'), 0)
+        self.assertEquals(self._eval('pbale[400AR]'), 900)
         self.assertEquals(self._eval('bale[700IN]'), -800)
+        self.assertEquals(self._eval('nbale[700IN]'), -800)
+        self.assertEquals(self._eval('pbale[700IN]'), 0)
         # check some variant expressions, for coverage
         self.assertEquals(self._eval('crdp[700I%]'), 500)
         self.assertEquals(self._eval('debp[400A%]'), 500)

--- a/mis_builder/views/mis_report.xml
+++ b/mis_builder/views/mis_report.xml
@@ -114,10 +114,10 @@
                                      <p>Expressions can be any valid python expressions.</p>
                                      <p>
                                          The following special elements are recognized in the expressions to compute accounting data: 
-                                         <code>{bal|crd|deb}{pieu}[account selecor][journal items domain]</code>.
+                                         <code>{bal|crd|deb|pbal|nbal}{pieu}[account selecor][journal items domain]</code>.
                                      </p>
                                      <ul>
-                                         <li><b>bal, crd, deb</b>: balance, debit, credit.</li>
+                                         <li><b>bal, crd, deb, pbal, nbal</b>: balance, debit, credit, positive balance, negative balance.</li>
                                          <li><b>p, i, e</b>: respectivelyl variation over the period, initial balance, ending balance</li>
                                          <li>The <b>account selector</b> is a like expression on the account code (eg 70%, etc).</li>
                                          <li>The <b>journal items domain</b> is an Odoo domain filter on journal items.</li>
@@ -145,6 +145,8 @@
                                         <li><b>debp[55%][('journal_id.code', '=', 'BNK1')]</b>: sum of all debits on accounts 55 and journal BNK1 during the period.</li>
                                         <li><b>balp[('user_type_id', '=', ref('account.data_account_type_receivable').id)][]</b>: variation of the balance of all receivable accounts over the period.</li>
                                         <li><b>balp[][('tax_line_id.tag_ids', '=', ref('l10n_be.tax_tag_56').id)]</b>: balance of move lines related to tax grid 56.</li>
+                                        <li><b>pbale[55%]</b>: sum of all ending balances of accounts starting with 55 whose
+                                          ending balance is positive.</li>
                                     </ul>
                                 </div>
                             </group>


### PR DESCRIPTION
Sum accounts with positive/negative balance only.

So, for example, `pbale[551%]` will show the sum of all 551 accounts with a positive ending balance.

TODO
- [x] check it covers the use case @pedrobaeza 
- [x] unit test
- [x] handle decimal precision => not necessary in this case
- [x] update legend

Closes #86 