### PR TITLE
[10.0][FIX] mis_builder: _default_company_id returns id

### DIFF
--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -365,7 +365,7 @@ class MisReportInstance(models.Model):
     @api.model
     def _default_company_id(self):
         default_company_id = self.env['res.company'].\
-            _company_default_get('mis.report.instance').id
+            _company_default_get('mis.report.instance')
         return default_company_id
 
     _name = 'mis.report.instance'


### PR DESCRIPTION
In mis.report.instance, _default_company_id must return recordset instead
of id