### PR TITLE
adding date field choise on instance and instance periods (draft, proposal)

### DIFF
--- a/mis_builder/models/mis_report.py
+++ b/mis_builder/models/mis_report.py
@@ -727,7 +727,8 @@ class MisReport(models.Model):
                                    get_additional_query_filter=None,
                                    locals_dict=None,
                                    aml_model=None,
-                                   no_auto_expand_accounts=False):
+                                   no_auto_expand_accounts=False,
+                                   date_field='date'):
         """ Evaluate a report for a given period, populating a KpiMatrix.
 
         :param kpi_matrix: the KpiMatrix object to be populated created
@@ -769,7 +770,7 @@ class MisReport(models.Model):
         aep.do_queries(date_from, date_to,
                        target_move,
                        additional_move_line_filter,
-                       aml_model)
+                       aml_model, date_field)
 
         def eval_expressions(expressions, locals_dict):
             expressions = [e and e.name or 'AccountingNone'

--- a/mis_builder/views/mis_report_instance.xml
+++ b/mis_builder/views/mis_report_instance.xml
@@ -77,6 +77,14 @@
                             </group>
                         </group>
                     </group>
+                <group>
+                    <group>
+                        <field name="date_field"/>
+                    </group>
+                    <group>
+                        <button type="object" name="apply_date" string="Apply" class="oe_inline"/>
+                    </group>
+                </group>
                     <notebook>
                         <page string="Columns" attrs="{'invisible': [('comparison_mode', '=', False)]}">
                             <group>
@@ -92,6 +100,7 @@
                                         <field name="source"/>
                                         <field name="date_from"/>
                                         <field name="date_to"/>
+                                        <field name="date_field"/>
                                         <field name="valid" invisible="1"/>
                                     </tree>
                                 </field>
@@ -184,6 +193,7 @@
                                domain="[('report_id', '=', parent.report_id)]"
                                widget="many2many_tags"
                                options="{'no_create': True}"/>
+                        <field name="date_field"/>
                         <field name="valid" invisible="1"/>
                         <field name="report_instance_id" invisible="1" attrs="{'required': [('id', '!=', False)]}"/>
                         <field name="report_id" invisible="1"/>


### PR DESCRIPTION
The goal is to have a report based on different date field on the move line.
The date field in on instance periods, in order to enable comparison between accounting/cash flow date in different columns.

The date field is also available on the report instance with "apply" button, in order to apply the date directly to all periods.

![image](https://user-images.githubusercontent.com/13367824/43824021-2df645c0-9af1-11e8-958e-54833cc753f9.png)

Improvements/open points:
- rename new field (e.g. date_field_name)?
- what if the date field is empty in destination model? Set a "undefined" line/field or warning?
- remove date field selction from non-"actuals" columns
- update automatic tests
- test flow adding new object to the MIS builder (other than account.move.line)  