### PR TITLE
[11.0][IMP] mis_builder: description of column disabled by default

### DIFF
--- a/mis_builder/__manifest__.py
+++ b/mis_builder/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'MIS Builder',
-    'version': '11.0.3.2.2',
+    'version': '11.0.3.3.0',
     'category': 'Reporting',
     'summary': """
         Build 'Management Information System' Reports and Dashboards

--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -424,6 +424,9 @@ class MisReportInstance(models.Model):
     no_auto_expand_accounts = fields.Boolean(
         string='Disable account details expansion',
     )
+    display_columns_description = fields.Boolean(
+        help="Display the date range details in the columns of the reports.",
+    )
     comparison_mode = fields.Boolean(
         compute="_compute_comparison_mode",
         inverse="_inverse_comparison_mode")
@@ -592,6 +595,10 @@ class MisReportInstance(models.Model):
             raise UserError(_("Column %s with actuals source "
                               "must have from/to dates.") %
                             (period.name,))
+
+        if not self.display_columns_description:
+            description = ''
+
         self.report_id.declare_and_compute_period(
             kpi_matrix,
             period.id,

--- a/mis_builder/views/mis_report_instance.xml
+++ b/mis_builder/views/mis_report_instance.xml
@@ -114,6 +114,7 @@
                             <group name="layout">
                                 <field name="landscape_pdf"/>
                                 <field name="no_auto_expand_accounts"/>
+                                <field name="display_columns_description"/>
                             </group>
                         </page>
                     </notebook>


### PR DESCRIPTION
Our customers seem to be a little annoyed by the description in the columns of the printed reports. The description is in facts most of the time redundant (the column name would be enough) and makes the look&feel of the report bloated.

With this PR, the description in the columns of the MIS reports will be not printed by default.
To re-enable it, set the flag *Display Columns Description* to true in the MIS report instance.
