### PR TITLE
[IMP] Description of column disabled by default

### DIFF
--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -425,6 +425,9 @@ class MisReportInstance(models.Model):
     no_auto_expand_accounts = fields.Boolean(
         string='Disable account details expansion',
     )
+    display_columns_description = fields.Boolean(
+        help="Display the date range details in the column headers.",
+    )
     comparison_mode = fields.Boolean(
         compute="_compute_comparison_mode",
         inverse="_inverse_comparison_mode")
@@ -670,6 +673,8 @@ class MisReportInstance(models.Model):
         for period in self.period_ids:
             description = None
             if period.mode == MODE_NONE:
+                pass
+            elif not self.display_columns_description:
                 pass
             elif period.date_from == period.date_to and period.date_from:
                 description = self._format_date(period.date_from)

--- a/mis_builder/readme/CONTRIBUTORS.rst
+++ b/mis_builder/readme/CONTRIBUTORS.rst
@@ -16,3 +16,4 @@
 * Juan Jose Scarafia <jjs@adhoc.com.ar>
 * Richard deMeester <richard@willowit.com.au>
 * Eric Caudal <eric.caudal@elico-corp.com>
+* Andrea Stirpe <a.stirpe@onestein.nl>

--- a/mis_builder/readme/newsfragments/118.feature
+++ b/mis_builder/readme/newsfragments/118.feature
@@ -1,0 +1,1 @@
+Description in the columns of the MIS reports not printed by default.

--- a/mis_builder/views/mis_report_instance.xml
+++ b/mis_builder/views/mis_report_instance.xml
@@ -111,6 +111,7 @@
                             <group name="layout">
                                 <field name="landscape_pdf"/>
                                 <field name="no_auto_expand_accounts"/>
+                                <field name="display_columns_description"/>
                             </group>
                         </page>
                     </notebook>


### PR DESCRIPTION
With this PR, the description in the columns of the MIS reports will be not printed by default.
To re-enable it, set the flag Display Columns Description to true in the MIS report instance.

Implements #73.
Supersedes https://github.com/OCA/mis-builder/pull/117.
