### PR TITLE
[WIP] Working with External Reports' KPIs

### DIFF
--- a/mis_builder/models/mis_builder.py
+++ b/mis_builder/models/mis_builder.py
@@ -769,9 +769,6 @@ class MisReportInstancePeriod(models.Model):
             ('report_id', 'in', sub_report_ids)
         ])
 
-        id_tree = self.env.ref('mis_builder.'
-                               'mis_report_instance_view_tree')
-
         id_form = self.env.ref('mis_builder.'
                                'mis_report_instance_result_view_form')
 
@@ -783,7 +780,7 @@ class MisReportInstancePeriod(models.Model):
                 'view_type': 'list',
                 'views': [(False, 'list'), (False, 'form')],
                 'view_id': False,
-                'domain': str([('id', 'in', sub_report_ids)]),
+                'domain': str([('id', 'in', report_ids.ids)]),
                 'target': 'new',
                 'context': context,
             }

--- a/mis_builder/models/mis_builder.py
+++ b/mis_builder/models/mis_builder.py
@@ -935,14 +935,14 @@ class MisReportInstance(models.Model):
 
         sub_report_ids = self.env.context.get('sub_report_ids')
 
+        report_id = self.report_id
+
         if sub_report_ids:
             for sub_report_id in sub_report_ids:
                 sub_report = self.search([('report_id', '=', sub_report_id)])
                 if self == sub_report:
                     report_id = self.env['mis.report'].browse(sub_report_id)
                     break
-        else:
-            report_id = self.report_id
 
         return self._compute(
             report_id=report_id,

--- a/mis_builder/models/mis_builder.py
+++ b/mis_builder/models/mis_builder.py
@@ -283,6 +283,13 @@ class MisReport(models.Model):
     kpi_ids = fields.One2many('mis.report.kpi', 'report_id',
                               string='KPI\'s',
                               copy=True)
+    code = fields.Char(size=32, string='Code', translate=True)
+
+    @api.onchange('name')
+    def _onchange_name_code(self):
+        """ Construct code from Name"""
+        if self.name and not self.code:
+            self.code = _python_var(self.name)
 
     @api.one
     def copy(self, default=None):

--- a/mis_builder/models/mis_builder.py
+++ b/mis_builder/models/mis_builder.py
@@ -781,7 +781,7 @@ class MisReportInstancePeriod(models.Model):
                 'views': [(False, 'list'), (False, 'form')],
                 'view_id': False,
                 'domain': str([('id', 'in', report_ids.ids)]),
-                'target': 'new',
+                'target': 'current',
                 'context': context,
             }
         else:
@@ -936,7 +936,11 @@ class MisReportInstance(models.Model):
         sub_report_ids = self.env.context.get('sub_report_ids')
 
         if sub_report_ids:
-            report_id = self.env['mis.report'].browse(sub_report_ids)
+            for sub_report_id in sub_report_ids:
+                sub_report = self.search([('report_id', '=', sub_report_id)])
+                if self == sub_report:
+                    report_id = self.env['mis.report'].browse(sub_report_id)
+                    break
         else:
             report_id = self.report_id
 

--- a/mis_builder/models/mis_builder.py
+++ b/mis_builder/models/mis_builder.py
@@ -451,7 +451,7 @@ class MisReport(models.Model):
 
         compute_queue = self.kpi_ids
         recompute_inherit = {}
-        recompute_queue = []
+        recompute_queue = self.env['mis.report.kpi']
         while True:
             for kpi in compute_queue:
                 try:
@@ -479,7 +479,7 @@ class MisReport(models.Model):
                         recompute_inherit[inherit.report_id.id] = inherit.report_id
 
                     else:
-                        recompute_queue.append(kpi)
+                        recompute_queue += kpi
                     kpi_val = None
                     kpi_val_rendered = '#ERR'
                     kpi_val_comment += '\n\n%s' % (traceback.format_exc(),)
@@ -537,7 +537,7 @@ class MisReport(models.Model):
 
                 if kpi_inherit_val:
                     recomputed_dict[kpi.expression] = kpi_inherit_val
-                    recompute_queue.append(kpi)
+                    recompute_queue += kpi
                     compute_queue -= kpi
 
             recompute_inherit = {}

--- a/mis_builder/models/mis_builder.py
+++ b/mis_builder/models/mis_builder.py
@@ -473,7 +473,7 @@ class MisReport(models.Model):
                     if '.' in kpi.expression:
                         report_descript, kpi_name = kpi.expression.split('.')
                         inherit = kpi.search(
-                            [('report_id.description', '=', report_descript),
+                            [('report_id.code', '=', report_descript),
                              ('name', '=', kpi_name)]
                         )
                         recompute_inherit[inherit.report_id.id] = inherit.report_id
@@ -525,7 +525,7 @@ class MisReport(models.Model):
                 report_descript, kpi_name = kpi.expression.split('.')
 
                 inherit = kpi.search(
-                    [('report_id.description', '=', report_descript),
+                    [('report_id.code', '=', report_descript),
                      ('name', '=', kpi_name)]
                 )
 
@@ -551,7 +551,6 @@ class MisReport(models.Model):
                 # so we stop trying
                 break
             # try again
-
             compute_queue = recompute_queue
             recompute_queue = []
 

--- a/mis_builder/static/src/js/mis_builder.js
+++ b/mis_builder/static/src/js/mis_builder.js
@@ -78,7 +78,13 @@ openerp.mis_builder = function(instance) {
         },
         generate_content: function() {
             var self = this
-            context = new instance.web.CompoundContext(self.build_context(), self.get_context()|| {}) 
+
+            old_context = self.field_manager.ViewManager.ActionManager.inner_action.context;
+            if (old_context.sub_report_ids)
+                context = old_context;
+            else
+                context = new instance.web.CompoundContext(self.build_context(), self.get_context()|| {});
+
             new instance.web.Model("mis.report.instance").call(
                 "compute", 
                 [self.mis_report_instance_id], 

--- a/mis_builder/static/src/js/mis_builder.js
+++ b/mis_builder/static/src/js/mis_builder.js
@@ -103,6 +103,7 @@ openerp.mis_builder = function(instance) {
         },
         events: {
             "click a.mis_builder_drilldown": "drilldown",
+            "click a.mis_builder_sub_report": "sub_report",
         },
 
         drilldown: function(event) {
@@ -115,6 +116,25 @@ openerp.mis_builder = function(instance) {
                 new instance.web.Model("mis.report.instance.period").call(
                     "drilldown",
                     [period_id, val_c],
+                    {'context': context}
+                ).then(function(result) {
+                    if (result) {
+                        self.do_action(result);
+                    }
+                });
+            }
+        },
+        sub_report: function(event) {
+            var self = this;
+            var sub_report = JSON.parse($(event.target).data("sub-report-id"));
+            if (sub_report) {
+                var period_id = JSON.parse($(event.target).data("period-id"));
+                var val_c = JSON.parse($(event.target).data("expr"));
+                var sub_report_id = JSON.parse($(event.target).data("sub-report-id"));
+                context = new instance.web.CompoundContext(self.build_context(), self.get_context()|| {})
+                new instance.web.Model("mis.report.instance.period").call(
+                    "sub_report",
+                    [period_id, val_c, sub_report_id],
                     {'context': context}
                 ).then(function(result) {
                     if (result) {

--- a/mis_builder/static/src/js/mis_builder.js
+++ b/mis_builder/static/src/js/mis_builder.js
@@ -37,7 +37,7 @@ openerp.mis_builder = function(instance) {
         
         get_context: function() {
             var self = this;
-            context = {}
+            context = self.field_manager.ViewManager.ActionManager.inner_action.context;
             if (this.mis_report_instance_id){
                 context['active_ids'] = [this.mis_report_instance_id];
             }
@@ -77,14 +77,8 @@ openerp.mis_builder = function(instance) {
             });
         },
         generate_content: function() {
-            var self = this
-
-            old_context = self.field_manager.ViewManager.ActionManager.inner_action.context;
-            if (old_context.sub_report_ids)
-                context = old_context;
-            else
-                context = new instance.web.CompoundContext(self.build_context(), self.get_context()|| {});
-
+            var self = this;
+            context = new instance.web.CompoundContext(self.build_context(), self.get_context()|| {});
             new instance.web.Model("mis.report.instance").call(
                 "compute", 
                 [self.mis_report_instance_id], 

--- a/mis_builder/static/src/js/mis_builder.js
+++ b/mis_builder/static/src/js/mis_builder.js
@@ -112,7 +112,7 @@ openerp.mis_builder = function(instance) {
             if (drilldown) {
                 var period_id = JSON.parse($(event.target).data("period-id"));
                 var val_c = JSON.parse($(event.target).data("expr"));
-                context = new instance.web.CompoundContext(self.build_context(), self.get_context()|| {}) 
+                context = new instance.web.CompoundContext(self.build_context(), self.get_context()|| {});
                 new instance.web.Model("mis.report.instance.period").call(
                     "drilldown",
                     [period_id, val_c],
@@ -126,15 +126,14 @@ openerp.mis_builder = function(instance) {
         },
         sub_report: function(event) {
             var self = this;
-            var sub_report = JSON.parse($(event.target).data("sub-report-id"));
-            if (sub_report) {
+            var sub_report_ids = $(event.target).data("sub-report-ids");
+            if (sub_report_ids) {
                 var period_id = JSON.parse($(event.target).data("period-id"));
                 var val_c = JSON.parse($(event.target).data("expr"));
-                var sub_report_id = JSON.parse($(event.target).data("sub-report-id"));
-                context = new instance.web.CompoundContext(self.build_context(), self.get_context()|| {})
+                context = new instance.web.CompoundContext(self.build_context(), self.get_context()|| {});
                 new instance.web.Model("mis.report.instance.period").call(
                     "sub_report",
-                    [period_id, val_c, sub_report_id],
+                    [period_id, val_c, sub_report_ids],
                     {'context': context}
                 ).then(function(result) {
                     if (result) {

--- a/mis_builder/static/src/xml/mis_widget.xml
+++ b/mis_builder/static/src/xml/mis_widget.xml
@@ -46,7 +46,17 @@
                                             <t t-esc="value_value.val_r"/>
                                         </a>
                                     </t>
-                                    <t t-if="!value_value.drilldown">
+                                    <t t-if="value_value.sub_report_id">
+                                        <a href="javascript:void(0)"
+                                           class="mis_builder_sub_report"
+                                           t-att-data-sub-report-id="JSON.stringify(value_value.sub_report_id)"
+                                           t-att-data-period-id="JSON.stringify(value_value.period_id)"
+                                           t-att-data-expr="JSON.stringify(value_value.expr)"
+                                        >
+                                            <t t-esc="value_value.val_r"/>
+                                        </a>
+                                    </t>
+                                    <t t-if="!value_value.drilldown &amp;&amp; !value_value.sub_report_id">
                                         <t t-esc="value_value.val_r"/>
                                     </t>
                                 </div>

--- a/mis_builder/static/src/xml/mis_widget.xml
+++ b/mis_builder/static/src/xml/mis_widget.xml
@@ -46,17 +46,17 @@
                                             <t t-esc="value_value.val_r"/>
                                         </a>
                                     </t>
-                                    <t t-if="value_value.sub_report_id">
+                                    <t t-if="value_value.sub_report_ids">
                                         <a href="javascript:void(0)"
                                            class="mis_builder_sub_report"
-                                           t-att-data-sub-report-id="JSON.stringify(value_value.sub_report_id)"
+                                           t-att-data-sub-report-ids="JSON.stringify(value_value.sub_report_ids)"
                                            t-att-data-period-id="JSON.stringify(value_value.period_id)"
                                            t-att-data-expr="JSON.stringify(value_value.expr)"
                                         >
                                             <t t-esc="value_value.val_r"/>
                                         </a>
                                     </t>
-                                    <t t-if="!value_value.drilldown &amp;&amp; !value_value.sub_report_id">
+                                    <t t-if="!value_value.drilldown &amp;&amp; !value_value.sub_report_ids">
                                         <t t-esc="value_value.val_r"/>
                                     </t>
                                 </div>

--- a/mis_builder/views/mis_builder.xml
+++ b/mis_builder/views/mis_builder.xml
@@ -15,6 +15,7 @@
             <field name="arch" type="xml">
                 <tree string="MIS Reports">
                     <field name="name"/>
+                    <field name="code"/>
                     <field name="description"/>
                 </tree>
             </field>
@@ -28,6 +29,7 @@
                 <sheet>
                     <group col="2">
                         <field name="name"/>
+                        <field name="code"/>
                         <field name="description"/>
                     </group>
                     <group string="Queries">


### PR DESCRIPTION
- **[ADD] MisReport Code Field Added**

Here was added a new field, **code**, which contains the report's name without any special characters and/or spaces.
The method called to do that was __python_var(var_str)_, as is done with the _name_ field from _kpi_ids_.

- **[IMP] MIS Reports working with external Report's KPIs**

This commit allows the user entering a 'dot notation' expression for a KPI. i.e, _report_01.receipt_05_.
Doing so, MIS Reports will compute the value held by the "receipt_05 KPI" from the "report_01 MisReport".