### PR TITLE
Render table in one or more columns

### DIFF
--- a/mis_builder/report/mis_builder_xls.py
+++ b/mis_builder/report/mis_builder_xls.py
@@ -100,7 +100,8 @@ class MisBuilderXls(report_xls):
 
             for line in data['content']:
                 col = tables.index(data) * (len(line['cols']) + 1)
-                ws.write(row_pos, col, line['kpi_name'], self.mis_rh_cell_style)
+                ws.write(row_pos, col, line['kpi_name'],
+                         self.mis_rh_cell_style)
                 for value in line['cols']:
                     col += 1
                     num_format_str = '#'
@@ -108,7 +109,8 @@ class MisBuilderXls(report_xls):
                         num_format_str += '.'
                         num_format_str += '0' * int(value['dp'])
                     if value.get('prefix'):
-                        num_format_str = '"%s"' % value['prefix'] + num_format_str
+                        num_format_str = '"%s"' % value['prefix'] + \
+                                         num_format_str
                     if value.get('suffix'):
                         num_format_str += ' "%s"' % value['suffix']
                     kpi_cell_style = xlwt.easyxf(

--- a/mis_builder/report/report_mis_report_instance.xml
+++ b/mis_builder/report/report_mis_report_instance.xml
@@ -9,42 +9,50 @@
             <div class="page">
               <h2 t-field="o.name"></h2>
               <table class="table table-condensed">
-                <thead>
-                  <tr>
-                    <t t-foreach="docs_computed[o.id]['header']" t-as="h">
-                      <th>
-                        <div>
-                          <t t-esc="h_value['kpi_name']"/>
-                        </div>
-                      </th>
-                      <th t-foreach="h_value['cols']" t-as="col" class="text-center">
-                        <div>
-                          <t t-esc="col['name']"/>
-                        </div>
-                        <div>
-                          <t t-esc="col['date']"/>
-                        </div>
-                      </th>
+                <tr>
+                    <t t-foreach="docs_computed[o.id]" t-as="doc">
+                        <td>
+                          <table class="table table-condensed">
+                            <thead>
+                              <tr>
+                                <t t-foreach="doc_value['header']" t-as="h">
+                                  <th>
+                                    <div>
+                                      <t t-esc="h_value['kpi_name']"/>
+                                    </div>
+                                  </th>
+                                  <th t-foreach="h_value['cols']" t-as="col" class="text-center">
+                                    <div>
+                                      <t t-esc="col['name']"/>
+                                    </div>
+                                    <div>
+                                      <t t-esc="col['date']"/>
+                                    </div>
+                                  </th>
+                                </t>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              <tr t-foreach="doc_value['content']" t-as="c">
+                                <td t-att-style="c_value['default_style']">
+                                  <div class="text-left">
+                                    <t t-esc="c_value['kpi_name']"/>
+                                  </div>
+                                </td>
+                                <t t-foreach="c_value['cols']" t-as="value">
+                                  <td t-att-style="c_value['default_style']">
+                                    <div t-att-style="value_value.get('style')" class="text-right">
+                                      <t t-esc="value_value['val_r']"/>
+                                    </div>
+                                  </td>
+                                </t>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </td>
                     </t>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr t-foreach="docs_computed[o.id]['content']" t-as="c">
-                    <td t-att-style="c_value['default_style']">
-                      <div class="text-left">
-                        <t t-esc="c_value['kpi_name']"/>
-                      </div>
-                    </td>
-                    <t t-foreach="c_value['cols']" t-as="value">
-                      <td t-att-style="c_value['default_style']">
-                        <div t-att-style="value_value.get('style')" class="text-right">
-                          <t t-esc="value_value['val_r']"/>
-                        </div>
-                      </td>
-                    </t>
-                  </tr>
-                </tbody>
-              </table>
+                </tr>
+            </table>
             </div>
           </t>
         </t>

--- a/mis_builder/static/src/xml/mis_widget.xml
+++ b/mis_builder/static/src/xml/mis_widget.xml
@@ -6,62 +6,63 @@
                 <button class="oe_mis_builder_export"><img src="/web/static/src/img/icons/gtk-go-down.png"/>Export</button>
                 <button style="display: none;" class="oe_mis_builder_settings"><img src="/web/static/src/img/icons/gtk-execute.png"/> Settings</button>
             </div>
+
             <table t-if="widget.mis_report_data" class="oe_list_content mis_builder">
-                <thead>
-                    <tr class="oe_list_header_columns">
-                        <t t-foreach="widget.mis_report_data.header" t-as="h">
-                            <th class="oe_list_header_char">
-                                <div>
-                                    <t t-esc="h_value.kpi_name"/>
-                                </div>
-                            </th>
-                            <th t-foreach="h_value.cols" t-as="col" class="oe_list_header_char mis_builder_ralign">
-                                <div>
-                                    <t t-esc="col.name"/>
-                                </div>
-                                <div>
-                                    <t t-esc="col.date"/>
-                                </div>
-                            </th>
-                        </t>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr t-foreach="widget.mis_report_data.content" t-as="c">
-                        <td t-att="{'style': c_value.default_style}">
-                            <div>
-                                <t t-esc="c_value.kpi_name"/>
-                            </div>
+                <tr>
+                    <t t-foreach="widget.mis_report_data" t-as="report">
+                        <td>
+                            <table class="oe_list_content mis_builder">
+                                <thead>
+                                    <tr class="oe_list_header_columns">
+                                        <t t-foreach="report_value.header" t-as="h">
+                                            <th class="oe_list_header_char">
+                                                <div>
+                                                    <t t-esc="h_value.kpi_name"/>
+                                                </div>
+                                            </th>
+                                            <th t-foreach="h_value.cols" t-as="col" class="oe_list_header_char mis_builder_ralign">
+                                                <div>
+                                                    <t t-esc="col.name"/>
+                                                </div>
+                                                <div>
+                                                    <t t-esc="col.date"/>
+                                                </div>
+                                            </th>
+                                        </t>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr t-foreach="report_value.content" t-as="c">
+                                        <td t-att="{'style': c_value.default_style}">
+                                            <div>
+                                                <t t-esc="c_value.kpi_name"/>
+                                            </div>
+                                        </td>
+                                        <t t-foreach="c_value.cols" t-as="value">
+                                            <td t-att="{'style': c_value.default_style}" class="mis_builder_ralign">
+                                                <div t-att="{'style': value_value.style, 'title': value_value.val_c}">
+                                                    <t t-if="value_value.drilldown">
+                                                        <a href="javascript:void(0)"
+                                                           class="mis_builder_drilldown"
+                                                           t-att-data-drilldown="JSON.stringify(value_value.drilldown)"
+                                                           t-att-data-period-id="JSON.stringify(value_value.period_id)"
+                                                           t-att-data-expr="JSON.stringify(value_value.expr)"
+                                                        >
+                                                            <t t-esc="value_value.val_r"/>
+                                                        </a>
+                                                    </t>
+                                                    <t t-if="!value_value.drilldown">
+                                                        <t t-esc="value_value.val_r"/>
+                                                    </t>
+                                                </div>
+                                            </td>
+                                        </t>
+                                    </tr>
+                                </tbody>
+                            </table>
                         </td>
-                        <t t-foreach="c_value.cols" t-as="value">
-                            <td t-att="{'style': c_value.default_style}" class="mis_builder_ralign">
-                                <div t-att="{'style': value_value.style, 'title': value_value.val_c}">
-                                    <t t-if="value_value.drilldown">
-                                        <a href="javascript:void(0)"
-                                           class="mis_builder_drilldown"
-                                           t-att-data-drilldown="JSON.stringify(value_value.drilldown)"
-                                           t-att-data-period-id="JSON.stringify(value_value.period_id)"
-                                           t-att-data-expr="JSON.stringify(value_value.expr)"
-                                        >
-                                            <t t-esc="value_value.val_r"/>
-                                        </a>
-                                    </t>
-                                    <t t-if="!value_value.drilldown">
-                                        <t t-esc="value_value.val_r"/>
-                                    </t>
-                                </div>
-                            </td>
-                        </t>
-                    </tr>
-                </tbody>
-                <tfoot>
-                    <tr>
-                        <td class="oe_list_footer" />
-                        <t t-foreach="widget.mis_report_data.header" t-as="f">
-                            <td t-foreach="f_value.cols" class="oe_list_footer" />
-                        </t>
-                    </tr>
-                </tfoot>
+                    </t>
+                </tr>
             </table>
         </div>
     </t>

--- a/mis_builder/tests/test_mis_builder.py
+++ b/mis_builder/tests/test_mis_builder.py
@@ -36,7 +36,7 @@ class TestMisBuilder(common.TransactionCase):
         # account.analytic.balance
         data = self.registry('mis.report.instance').compute(
             self.cr, self.uid,
-            self.ref('mis_builder.mis_report_instance_test'))
+            self.ref('mis_builder.mis_report_instance_test'))[0]
         self.assertDictContainsSubset(
             {'content':
                 [{'kpi_name': u'total test',

--- a/mis_builder/views/mis_builder.xml
+++ b/mis_builder/views/mis_builder.xml
@@ -49,6 +49,7 @@
                                 <field name="sequence" widget="handle"/>
                                 <field name="description"/>
                                 <field name="name"/>
+                                <field name="column"/>
                                 <field name="expression"/>
                                 <field name="type"/>
                                 <field name="dp" attrs="{'invisible': [('type', '=', 'str')]}"/>
@@ -90,6 +91,49 @@
                     </group>
                 </sheet>
                 </form>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="mis_report_kpi_form_view">
+            <field name="name">mis.report.kpi.form</field>
+            <field name="model">mis.report.kpi</field>
+            <field name="arch" type="xml">
+                <form name="MIS report KPI">
+                    <group>
+                        <field name="sequence" widget="handle"/>
+                        <field name="description"/>
+                        <field name="name"/>
+                        <field name="column"/>
+                        <field name="expression"/>
+                        <field name="type"/>
+                        <field name="dp"/>
+                        <field name="divider"/>
+                        <field name="prefix"/>
+                        <field name="suffix"/>
+                        <field name="compare_method"/>
+                        <field name="default_css_style"/>
+                        <field name="css_style"/>
+                    </group>
+                </form>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="mis_report_kpi_tree_view">
+            <field name="name">mis.report.kpi.tree</field>
+            <field name="model">mis.report.kpi</field>
+            <field name="arch" type="xml">
+                <tree>
+                    <field name="sequence" widget="handle"/>
+                    <field name="description"/>
+                    <field name="name"/>
+                    <field name="column"/>
+                    <field name="type"/>
+                    <field name="dp"/>
+                    <field name="divider"/>
+                    <field name="prefix"/>
+                    <field name="suffix"/>
+                    <field name="compare_method"/>
+                </tree>
             </field>
         </record>
 


### PR DESCRIPTION
Sometimes it's necessary to show two or more tables alongside one another. The original module mis_builder didn't have this feature by default, so I added it. It was necessary, though, to change what used to be returned from the method compute from the model mis_report_instance, which can cause trouble if you are overriding this method.