### PR TITLE
[11.0][mis_builder] define the comparison method in the mis.report.instance.period

### DIFF
--- a/mis_builder/models/kpimatrix.py
+++ b/mis_builder/models/kpimatrix.py
@@ -186,13 +186,13 @@ class KpiMatrix(object):
         return col
 
     def declare_comparison(self, cmpcol_key, col_key, base_col_key,
-                           label, description=None):
+                           label, description=None, compare_method=None):
         """ Declare a new comparison column.
 
         Invoke the declare_* methods in display order.
         """
         self._comparison_todo[cmpcol_key] = \
-            (col_key, base_col_key, label, description)
+            (col_key, base_col_key, label, description, compare_method)
         self._cols[cmpcol_key] = None  # reserve slot in insertion order
 
     def declare_sum(self, sumcol_key, col_to_sum_keys,
@@ -288,8 +288,8 @@ class KpiMatrix(object):
 
         Invoke this after setting all values.
         """
-        for cmpcol_key, (col_key, base_col_key, label, description) in \
-                self._comparison_todo.items():
+        for cmpcol_key, (col_key, base_col_key, label, description,
+                         compare_method) in self._comparison_todo.items():
             col = self._cols[col_key]
             base_col = self._cols[base_col_key]
             common_subkpis = self._common_subkpis([col, base_col])
@@ -327,10 +327,11 @@ class KpiMatrix(object):
                 for val, base_val, comparison_subcol in \
                         zip(vals, base_vals, comparison_col.iter_subcols()):
                     # TODO FIXME average factors
+                    compare_method = compare_method or row.kpi.compare_method
                     delta, delta_r, style_r = \
                         self._style_model.compare_and_render(
                             self.lang, row.style_props,
-                            row.kpi.type, row.kpi.compare_method,
+                            row.kpi.type, compare_method,
                             val, base_val, 1, 1)
                     comparison_cell_tuple.append(KpiMatrixCell(
                         row, comparison_subcol, delta, delta_r, None,

--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -10,6 +10,9 @@ from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError, UserError
 
 from .aep import AccountingExpressionProcessor as AEP
+from .mis_report_style import (
+    CMP_DIFF, CMP_PCT, CMP_NONE
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -259,7 +262,10 @@ class MisReportInstancePeriod(models.Model):
         comodel_name='mis.report.instance.period',
         string='Compare',
     )
-
+    compare_method = fields.Selection([(CMP_DIFF, _('Difference')),
+                                       (CMP_PCT, _('Percentage')),
+                                       (CMP_NONE, _('None'))],
+                                      string='Comparison Method')
     _order = 'sequence, id'
 
     _sql_constraints = [
@@ -706,7 +712,7 @@ class MisReportInstance(models.Model):
         kpi_matrix.declare_comparison(
             period.id,
             period.source_cmpcol_to_id.id, period.source_cmpcol_from_id.id,
-            label, description)
+            label, description, period.compare_method)
 
     def _add_column(self, aep, kpi_matrix, period, label, description):
         if period.source == SRC_ACTUALS:

--- a/mis_builder/views/mis_report_instance.xml
+++ b/mis_builder/views/mis_report_instance.xml
@@ -222,6 +222,8 @@
                                    attrs="{'invisible': [('source', '!=', 'cmpcol')], 'required': [('source', '=', 'cmpcol')]}"
                                    domain="[('report_instance_id', '=', report_instance_id), ('id', '!=', id)]"
                                    options="{'no_create': True, 'no_open': True}"/>
+                            <field name="compare_method"
+                                   attrs="{'invisible': [('source', '!=', 'cmpcol')]}"/>
                         </group>
                     </group>
                     <group string="Dates">


### PR DESCRIPTION
This PR adds a field `compare_method` in the `mis.report.instance.period`, allowing to define multiple types of comparison (by percentage and by difference) simultaneously for the same KPI.

![image](https://user-images.githubusercontent.com/7683926/52418087-995aef00-2aed-11e9-8ffe-b861fb7d3522.png)

![image](https://user-images.githubusercontent.com/7683926/52418110-a7107480-2aed-11e9-987e-1bb9cc027b25.png)
