### PR TITLE
[11.0] Add subkpis_filter on mis.report.instance

### DIFF
--- a/mis_builder/tests/test_mis_report_instance.py
+++ b/mis_builder/tests/test_mis_report_instance.py
@@ -318,3 +318,20 @@ class TestMisReportInstance(common.HttpCase):
                 self.assertEquals(vals, [AccountingNone, AccountingNone, None])
             elif row.kpi.name == 'k4':
                 self.assertEquals(vals, [AccountingNone, AccountingNone, 1.0])
+
+    def test_mis_report_subkpi_filter(self):
+        self.assertTrue(self.report_instance.report_subkpis)
+        self.report_instance.subkpis_filter_active = True
+        self.report_instance._onchange_subkpis_filter_active()
+        self.assertEqual(self.report.subkpi_ids,
+                         self.report_instance.filter_subkpi_ids)
+        for period in self.report_instance.period_ids:
+            self.assertEqual(period.subkpi_ids, self.report.subkpi_ids)
+        first_subkpi = self.report.subkpi_ids[0]
+        second_subkpi = self.report.subkpi_ids[1]
+        self.report_instance.write({
+            'filter_subkpi_ids': [(6, 0, [first_subkpi.id])],
+        })
+        for period in self.report_instance.period_ids:
+            self.assertEqual(first_subkpi, period.subkpi_ids)
+            self.assertNotIn(second_subkpi, period.subkpi_ids)

--- a/mis_builder/views/mis_report_instance.xml
+++ b/mis_builder/views/mis_report_instance.xml
@@ -108,6 +108,9 @@
                                 <field name="company_ids" groups="base.group_multi_company" widget="many2many_tags"
                                         domain="[('id', 'child_of', company_id)]"
                                         attrs="{'invisible': [('multi_company', '=', False)]}"/>
+                                <field name="report_subkpis" invisible="1" />
+                                <field name="subkpis_filter_active" attrs="{'invisible': [('report_subkpis', '=', False)]}" />
+                                <field name="filter_subkpi_ids" widget="many2many_tags" domain="[('report_id', '=', report_id)]" attrs="{'invisible': [('subkpis_filter_active', '=', False)]}" options="{'no_create_edit': True, 'no_open': True}"/>
                                 <field name="analytic_account_id" groups="analytic.group_analytic_accounting"/>
                             </group>
                         </page>
@@ -189,7 +192,10 @@
                         <field name="subkpi_ids"
                                domain="[('report_id', '=', parent.report_id)]"
                                widget="many2many_tags"
-                               options="{'no_create': True}"/>
+                               options="{'no_create': True}"
+                               attrs="{'readonly': [('subkpis_filter_active', '=', True)]}" />
+                        <field name="subkpis_filter_active" invisible="1" />
+                        <span attrs="{'invisible': [('subkpis_filter_active', '=', False)]}"><i>Sub KPI Filter is automatically computed according to Sub KPI filter at instance level.</i></span>
                         <field name="valid" invisible="1"/>
                         <field name="report_instance_id" invisible="1" attrs="{'required': [('id', '!=', False)]}"/>
                         <field name="report_id" invisible="1"/>


### PR DESCRIPTION
On reports linked to templates having subkpis defined, the possibility to filter subkpis
is now available at the instance level, so that filtering on each period is no more
required.

Extracted from https://github.com/OCA/mis-builder/pull/168#discussion_r268597389