### PR TITLE
[fix] fix for storno accounting

### DIFF
--- a/mis_builder/models/aep.py
+++ b/mis_builder/models/aep.py
@@ -187,9 +187,9 @@ class AccountingExpressionProcessor(object):
                 account_ids.update(self._account_ids_by_code[account_code])
             aml_domain.append(('account_id', 'in', tuple(account_ids)))
             if field == 'crd':
-                aml_domain.append(('credit', '>', 0))
+                aml_domain.append(('credit', '<>', 0.0))
             elif field == 'deb':
-                aml_domain.append(('debit', '>', 0))
+                aml_domain.append(('debit', '<>', 0.0))
             aml_domains.append(expression.normalize_domain(aml_domain))
             if mode not in date_domain_by_mode:
                 date_domain_by_mode[mode] = \


### PR DESCRIPTION
In storno accounting negative ammounts on credit or debit side is normal thing, 
this fix will take all ammounts (positive or negative) with same logic ( different from zero ammount. 

Applicable in all countries where storno accounting is applied .
(check module: account storno) 
Curtesy of Decodio dev team