### PR TITLE
mis_builder: Add support for "Year to date" relative date type in periods

### DIFF
--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -79,7 +79,8 @@ class MisReportInstancePeriod(models.Model):
                  'report_instance_id.comparison_mode',
                  'date_range_type_id',
                  'type', 'offset', 'duration', 'mode',
-                 'manual_date_from', 'manual_date_to')
+                 'manual_date_from', 'manual_date_to',
+                 'is_ytd')
     def _compute_dates(self):
         for record in self:
             record.date_from = False
@@ -161,6 +162,9 @@ class MisReportInstancePeriod(models.Model):
                         record.date_from = periods[0].date_start
                         record.date_to = periods[-1].date_end
                         record.valid = True
+            if record.mode == MODE_REL and record.valid and record.is_ytd:
+                record.date_from = fields.Date.from_string(record.date_to)\
+                    .replace(day=1, month=1)
 
     _name = 'mis.report.instance.period'
     _description = 'MIS Report Instance Period'
@@ -181,6 +185,11 @@ class MisReportInstancePeriod(models.Model):
          ('y', _('Year')),
          ('date_range', _('Date Range'))],
         string='Period type'
+    )
+    is_ytd = fields.Boolean(
+        default=False,
+        string='Year to date',
+        help='Forces the start date to Jan 1st of the relevant year'
     )
     date_range_type_id = fields.Many2one(
         comodel_name='date.range.type',

--- a/mis_builder/readme/newsfragments/165.feature
+++ b/mis_builder/readme/newsfragments/165.feature
@@ -1,0 +1,1 @@
+New year-to-date mode for defining periods.

--- a/mis_builder/tests/test_period_dates.py
+++ b/mis_builder/tests/test_period_dates.py
@@ -85,6 +85,21 @@ class TestPeriodDates(common.TransactionCase):
         self.assertEqual(self.period.date_to, '2016-12-30')
         self.assertTrue(self.period.valid)
 
+    def test_rel_day_ytd(self):
+        self.instance.write(dict(
+            comparison_mode=True,
+            date='2019-05-03'
+        ))
+        self.period.write(dict(
+            mode=MODE_REL,
+            type='d',
+            offset='-2',
+            is_ytd=True,
+        ))
+        self.assertEqual(self.period.date_from, '2019-01-01')
+        self.assertEqual(self.period.date_to, '2019-05-01')
+        self.assertTrue(self.period.valid)
+
     def test_rel_week(self):
         self.instance.write(dict(
             comparison_mode=True,
@@ -101,6 +116,22 @@ class TestPeriodDates(common.TransactionCase):
         self.assertEqual(self.period.date_to, '2017-01-15')
         self.assertTrue(self.period.valid)
 
+    def test_rel_week_ytd(self):
+        self.instance.write(dict(
+            comparison_mode=True,
+            date='2019-05-27'
+        ))
+        self.period.write(dict(
+            mode=MODE_REL,
+            type='w',
+            offset='1',
+            duration=2,
+            is_ytd=True,
+        ))
+        self.assertEqual(self.period.date_from, '2019-01-01')
+        self.assertEqual(self.period.date_to, '2019-06-16')
+        self.assertTrue(self.period.valid)
+
     def test_rel_month(self):
         self.instance.write(dict(
             comparison_mode=True,
@@ -113,6 +144,21 @@ class TestPeriodDates(common.TransactionCase):
         ))
         self.assertEqual(self.period.date_from, '2017-02-01')
         self.assertEqual(self.period.date_to, '2017-02-28')
+        self.assertTrue(self.period.valid)
+
+    def test_rel_month_ytd(self):
+        self.instance.write(dict(
+            comparison_mode=True,
+            date='2019-05-15'
+        ))
+        self.period.write(dict(
+            mode=MODE_REL,
+            type='m',
+            offset='-1',
+            is_ytd=True,
+        ))
+        self.assertEqual(self.period.date_from, '2019-01-01')
+        self.assertEqual(self.period.date_to, '2019-04-30')
         self.assertTrue(self.period.valid)
 
     def test_rel_year(self):

--- a/mis_builder/views/mis_report_instance.xml
+++ b/mis_builder/views/mis_report_instance.xml
@@ -231,6 +231,7 @@
                         <group name="relative" attrs="{'invisible': [('mode', '!=', 'relative')]}" colspan="4">
                             <group>
                                 <field name="type" attrs="{'required': [('mode', '=', 'relative')]}"/>
+                                <field name="is_ytd"/>
                                 <field name="date_range_type_id"
                                        attrs="{'invisible': [('type', '!=', 'date_range')], 'required': [('type', '=', 'date_range'), ('mode', '=', 'relative')]}"/>
                                 <field name="offset"/>


### PR DESCRIPTION
This change seemed pretty straightforward and works without any issues so far on V11 so I backported to V10 directly.

Hopefully there isn't a side-effect or issue cause by this modification that I haven't been able to spot with my current usage/workflow with mis_builder :crossed_fingers: 