### PR TITLE
[IMP] Better error message when expressions are not tuples in presence of SubKPIs

### DIFF
--- a/mis_builder/models/mis_report.py
+++ b/mis_builder/models/mis_report.py
@@ -36,6 +36,14 @@ from .mis_kpi_data import (
 _logger = logging.getLogger(__name__)
 
 
+class SubKPITupleLengthError(UserError):
+    pass
+
+
+class SubKPIUnknownTypeError(UserError):
+    pass
+
+
 class AutoStruct(object):
 
     def __init__(self, **kwargs):
@@ -690,15 +698,29 @@ class MisReport(models.Model):
                     # a sum or other operation on multi-valued kpis)
                     if isinstance(vals[0], tuple):
                         vals = vals[0]
-                        assert len(vals) == col.colspan
+                        if len(vals) != col.colspan:
+                            raise SubKPITupleLengthError(
+                                _("KPI \"{}\" is valued as a tuple of "
+                                  "length {} while a tuple of length {} "
+                                  "is expected.")
+                                .format(kpi.description,
+                                        len(vals),
+                                        col.colspan)
+                            )
                     elif isinstance(vals[0], DataError):
                         vals = (vals[0],) * col.colspan
                     else:
-                        raise UserError(_("Probably not your fault... but I'm "
-                                          "really curious to know how you "
-                                          "managed to raise this error so "
-                                          "I can handle one more corner "
-                                          "case!"))
+                        raise SubKPIUnknownTypeError(
+                            _("KPI \"{}\" has type {} while a tuple was "
+                              "expected.\n\nThis can be fixed by either:\n\t- "
+                              "Changing the KPI value to a tuple of length "
+                              "{}\nor\n\t- Changing the "
+                              "KPI to `multi` mode and giving an explicit "
+                              "value for each sub-KPI.")
+                            .format(kpi.description,
+                                    type(vals[0]),
+                                    col.colspan)
+                            )
                 if len(drilldown_args) != col.colspan:
                     drilldown_args = [None] * col.colspan
 

--- a/mis_builder/readme/CONTRIBUTORS.rst
+++ b/mis_builder/readme/CONTRIBUTORS.rst
@@ -17,3 +17,4 @@
 * Richard deMeester <richard@willowit.com.au>
 * Eric Caudal <eric.caudal@elico-corp.com>
 * Andrea Stirpe <a.stirpe@onestein.nl>
+* Maxence Groine <mgroine@fiefmanage.ch>

--- a/mis_builder/tests/test_mis_report_instance.py
+++ b/mis_builder/tests/test_mis_report_instance.py
@@ -10,7 +10,8 @@ import odoo.tests.common as common
 from odoo.tools import test_reports
 from odoo import tools
 
-from ..models.mis_report import TYPE_STR
+from ..models.mis_report import \
+    TYPE_STR, SubKPITupleLengthError, SubKPIUnknownTypeError
 from ..models.accounting_none import AccountingNone
 
 
@@ -60,6 +61,32 @@ class TestMisReportInstance(common.HttpCase):
                 date_field=partner_create_date_field_id,
                 aggregate='sum',
             ))],
+        ))
+        # create another report with 2 subkpis, no query
+        self.report_2 = self.env['mis.report'].create(dict(
+            name='another test report',
+            subkpi_ids=[(0, 0, dict(
+                name='subkpi1_report2',
+                description='subkpi 1, report 2',
+                sequence=1,
+            )), (0, 0, dict(
+                name='subkpi2_report2',
+                description='subkpi 2, report 2',
+                sequence=2,
+            ))]
+        ))
+        # Third report, 2 subkpis, no query
+        self.report_3 = self.env['mis.report'].create(dict(
+            name='test report 3',
+            subkpi_ids=[(0, 0, dict(
+                name='subkpi1_report3',
+                description='subkpi 1, report 3',
+                sequence=1,
+            )), (0, 0, dict(
+                name='subkpi2_report3',
+                description='subkpi 2, report 3',
+                sequence=2,
+            ))]
         ))
         # kpi with accounting formulas
         self.kpi1 = self.env['mis.report.kpi'].create(dict(
@@ -154,6 +181,49 @@ class TestMisReportInstance(common.HttpCase):
                 subkpi_id=self.report.subkpi_ids[1].id,
             ))],
         ))
+        # Report 2 : kpi with AccountingNone value
+        self.env['mis.report.kpi'].create(dict(
+            report_id=self.report_2.id,
+            description='AccountingNone kpi',
+            name='AccountingNoneKPI',
+            multi=False,
+        ))
+        # Report 2 : 'classic' kpi with values for each sub-KPI
+        self.env['mis.report.kpi'].create(dict(
+            report_id=self.report_2.id,
+            description='Classic kpi',
+            name='classic_kpi_r2',
+            multi=True,
+            expression_ids=[(0, 0, dict(
+                name='bale[200%]',
+                subkpi_id=self.report_2.subkpi_ids[0].id,
+            )), (0, 0, dict(
+                name='balp[200%]',
+                subkpi_id=self.report_2.subkpi_ids[1].id,
+            ))]
+        ))
+        # Report 3 : kpi with wrong tuple length
+        self.env['mis.report.kpi'].create(dict(
+            report_id=self.report_3.id,
+            description='Wrong tuple length kpi',
+            name='wrongTupleLen',
+            multi=False,
+            expression="('hello', 'does', 'this', 'work')"
+        ))
+        # Report 3 : 'classic' kpi
+        self.env['mis.report.kpi'].create(dict(
+            report_id=self.report_3.id,
+            description='Classic kpi',
+            name='classic_kpi_r2',
+            multi=True,
+            expression_ids=[(0, 0, dict(
+                name='bale[200%]',
+                subkpi_id=self.report_3.subkpi_ids[0].id,
+            )), (0, 0, dict(
+                name='balp[200%]',
+                subkpi_id=self.report_3.subkpi_ids[1].id,
+            ))]
+        ))
         # create a report instance
         self.report_instance = self.env['mis.report.instance'].create(dict(
             name='test instance',
@@ -173,6 +243,30 @@ class TestMisReportInstance(common.HttpCase):
         ))
         self.report_instance.period_ids[1].comparison_column_ids = \
             [(4, self.report_instance.period_ids[0].id, None)]
+        # same for report 2
+        self.report_instance_2 = self.env['mis.report.instance'].create(dict(
+            name='test instance 2',
+            report_id=self.report_2.id,
+            company_id=self.env.ref('base.main_company').id,
+            period_ids=[(0, 0, dict(
+                name='p3',
+                mode='fix',
+                manual_date_from='2019-01-01',
+                manual_date_to='2019-12-31',
+            ))],
+        ))
+        # and for report 3
+        self.report_instance_3 = self.env['mis.report.instance'].create(dict(
+            name='test instance 3',
+            report_id=self.report_3.id,
+            company_id=self.env.ref('base.main_company').id,
+            period_ids=[(0, 0, dict(
+                name='p4',
+                mode='fix',
+                manual_date_from='2019-01-01',
+                manual_date_to='2019-12-31',
+            ))]
+        ))
 
     def test_compute(self):
         matrix = self.report_instance._compute_matrix()
@@ -319,3 +413,11 @@ class TestMisReportInstance(common.HttpCase):
                 self.assertEquals(vals, [AccountingNone, AccountingNone, None])
             elif row.kpi.name == 'k4':
                 self.assertEquals(vals, [AccountingNone, AccountingNone, 1.0])
+
+    def test_raise_when_unknown_kpi_value_type(self):
+        with self.assertRaises(SubKPIUnknownTypeError):
+            self.report_instance_2.compute()
+
+    def test_raise_when_wrong_tuple_length_with_subkpis(self):
+        with self.assertRaises(SubKPITupleLengthError):
+            self.report_instance_3.compute()


### PR DESCRIPTION
Maybe related to #125

I got the "_Probably not your fault... but I'm really curious to know how you managed to raise this error so I can handle one more corner case!_" error message by using a "title row" KPI with _AccountingNone_ (or empty) value while having another KPI using subKPIs in the same report.

During report computation, the _AccountingNone_ KPI throws an error:

(mis_builder/models/mis_report.py, L686)
```python
if subkpis and not kpi.multi:
    if isinstance(vals[0], tuple):
        vals = vals[0]
        assert len(vals) == col.colspan
    elif isinstance(vals[0], DataError):
        vals = (vals[0],) * col.colspan
    else:
        raise UserError(_("Probably not your fault... but I'm "
                          "really curious to know how you "
                          "managed to raise this error so "
                          "I can handle one more corner "
                          "case!"))
```

We arrive with vals[0] equal to _AccountingNone_ so we neither enter the _tuple_ nor the _DataError_ condition, and the error is thrown.
I fixed it by adding an explicit check on _AccountingNone_ below the DataError check.