### PR TITLE
[11.0][IMP] add analytic account filter to mis_builder reports

### DIFF
--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -295,7 +295,7 @@ class MisReportInstancePeriod(models.Model):
         mis_report_filters = self.env.context.get('mis_report_filters', {})
         for filter_name, values in mis_report_filters.items():
             if values:
-                value = values.get('value')
+                value = values.get('value')[0]
                 operator = values.get('operator', '=')
                 filters.append((filter_name, operator, value))
         return filters
@@ -463,6 +463,9 @@ class MisReportInstance(models.Model):
     analytic_account_id = fields.Many2one(
         comodel_name='account.analytic.account', string='Analytic Account',
         oldname='account_analytic_id')
+    analytic_account_filter_id = fields.Many2one(
+        comodel_name='account.analytic.account',
+        string='Analytic Account Filter')
     hide_analytic_filters = fields.Boolean(default=True)
 
     @api.onchange('company_id', 'multi_company')
@@ -487,7 +490,7 @@ class MisReportInstance(models.Model):
     def get_filter_descriptions_from_context(self):
         filters = self.env.context.get('mis_report_filters', {})
         analytic_account = filters.get('analytic_account_id', {})
-        analytic_account_id = analytic_account.get('value')
+        analytic_account_id = analytic_account.get('value')[0]
         filter_descriptions = []
         if analytic_account_id:
             analytic_account = self.env['account.analytic.account'].browse(
@@ -578,7 +581,10 @@ class MisReportInstance(models.Model):
         self.ensure_one()
         if self.analytic_account_id:
             context['mis_report_filters']['analytic_account_id'] = {
-                'value': self.analytic_account_id.id,
+                'value': [
+                    self.analytic_account_id.id,
+                    self.analytic_account_id.display_name
+                ]
             }
 
     @api.multi

--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -490,7 +490,8 @@ class MisReportInstance(models.Model):
     def get_filter_descriptions_from_context(self):
         filters = self.env.context.get('mis_report_filters', {})
         analytic_account = filters.get('analytic_account_id', {})
-        analytic_account_id = analytic_account.get('value')[0]
+        analytic_account_id = analytic_account.get('value') and \
+            analytic_account.get('value')[0]
         filter_descriptions = []
         if analytic_account_id:
             analytic_account = self.env['account.analytic.account'].browse(

--- a/mis_builder/static/src/js/mis_report_widget.js
+++ b/mis_builder/static/src/js/mis_report_widget.js
@@ -18,7 +18,7 @@ odoo.define('mis_builder.widget', function (require) {
         template: "MisReportWidgetTemplate",
 
         custom_events: _.extend({}, AbstractField.prototype.custom_events, {
-            'field_changed': '_onFieldChanged',
+            'field_changed': 'on_field_changed',
         }),
         events: _.extend({}, AbstractField.prototype.events, {
             'click .mis_builder_drilldown': 'drilldown',
@@ -187,7 +187,7 @@ odoo.define('mis_builder.widget', function (require) {
             this.replace();
         },
 
-        _onFieldChanged: function (event) {
+        on_field_changed: function (event) {
             var self = this;
             if (event && event.data.changes) {
                 var changes = event.data.changes;

--- a/mis_builder/static/src/js/mis_report_widget.js
+++ b/mis_builder/static/src/js/mis_report_widget.js
@@ -6,8 +6,27 @@ odoo.define('mis_builder.widget', function (require) {
 
     var AbstractField = require('web.AbstractField');
     var field_registry = require('web.field_registry');
+    var relational_fields = require('web.relational_fields');
+
+    var core = require('web.core');
+    var session = require('web.session');
+
+    var _t = core._t;
 
     var MisReportWidget = AbstractField.extend({
+
+        template: "MisReportWidgetTemplate",
+
+        custom_events: _.extend({}, AbstractField.prototype.custom_events, {
+            'field_changed': '_onFieldChanged',
+        }),
+        events: _.extend({}, AbstractField.prototype.events, {
+            'click .mis_builder_drilldown': 'drilldown',
+            'click .oe_mis_builder_print': 'print_pdf',
+            'click .oe_mis_builder_export': 'export_xls',
+            'click .oe_mis_builder_settings': 'display_settings',
+            'click .oe_mis_builder_refresh': 'refresh',
+        }),
 
         /*
          * The following attributes are set after willStart() and are available
@@ -17,15 +36,23 @@ odoo.define('mis_builder.widget', function (require) {
          *   button
          */
 
-        template: "MisReportWidgetTemplate",
+        init: function () {
+            var self = this;
+            self._super.apply(self, arguments);
+            self.analytic_account_id_m2o = undefined;
+            self.analytic_account_id_domain = [];
+            self.analytic_account_id_label = _t("Analytic Account");
+            self.has_group_analytic_accounting = false;
+            self.hide_analytic_filters = false;
+            self.filter_values = {};
+            self.init_filter_from_context();
+        },
 
-        events: _.extend({}, AbstractField.prototype.events, {
-            'click .mis_builder_drilldown': 'drilldown',
-            'click .oe_mis_builder_print': 'print_pdf',
-            'click .oe_mis_builder_export': 'export_xls',
-            'click .oe_mis_builder_settings': 'display_settings',
-            'click .oe_mis_builder_refresh': 'refresh',
-        }),
+        init_filter_from_context: function() {
+            var self = this;
+            var filters = self.getParent().state.context['mis_report_filters'] || {};
+            self.filter_values = filters;
+        },
 
         /**
          * Return the id of the mis.report.instance to which the widget is
@@ -74,11 +101,102 @@ odoo.define('mis_builder.widget', function (require) {
                 self.show_settings = result;
             });
 
-            return $.when(this._super.apply(this, arguments), def1, def2);
+            var def3 = session.user_has_group(
+                'analytic.group_analytic_accounting'
+            ).then(function(result) {
+                self.has_group_analytic_accounting = result;
+            });
+
+            var def_hide_analytic_filters = self._rpc({
+                model: 'mis.report.instance',
+                method: 'read',
+                args: [self._instance_id(), ['hide_analytic_filters']],
+                context: context,
+            }).then(function (result) {
+                var record = result[0];
+                self.hide_analytic_filters = record['hide_analytic_filters'];
+            });
+
+            return $.when(this._super.apply(this, arguments), def1, def2, def3, def_hide_analytic_filters);
+        },
+
+        start: function () {
+            var self = this;
+            self._super.apply(self, arguments);
+            self.add_filters();
+        },
+
+        init_filter_value: function(field_object, attr_name) {
+            var self = this;
+            var filter = self.filter_values[attr_name];
+            if (filter !== undefined && filter['value'] !== undefined) {
+                field_object.value = filter['value'][0];
+                field_object.m2o_value = filter['value'][1];
+            }
+        },
+
+        init_filter: function(filter_name) {
+            var self = this;
+            if(self.filter_values[filter_name] === undefined) {
+                self.filter_values[filter_name] = {};
+            }
+        },
+
+        set_filter_value: function(field_object, attr_name, new_val) {
+            var self = this;
+            self.init_filter(attr_name);
+            self.filter_values[attr_name]['value'] =
+                [new_val.id, new_val.display_name] || undefined;
+        },
+
+        add_filters: function () {
+            var self = this;
+            if (self.hide_analytic_filters) {
+                return;
+            }
+            self.add_analytic_account_filter();
+        },
+
+        add_analytic_account_filter: function () {
+            var self = this;
+            if (!self.has_group_analytic_accounting) {
+                return;
+            }
+            if (self.analytic_account_id_m2o) {
+                // Prevent errors with autocomplete
+                self.analytic_account_id_m2o.destroy();
+            }
+            var field_name = 'analytic_account_id';
+            self.analytic_account_id_m2o = new relational_fields.FieldMany2One(self, "analytic_account_filter_id", self.record, {
+                mode: 'edit',
+                viewType: self.viewType,
+                attrs: {
+                    can_write: false,
+                    can_create: false,
+                },
+            });
+            self.init_filter_value(self.analytic_account_id_m2o, field_name);
+
+            // Add field to view
+            self.analytic_account_id_m2o.prependTo(self.get_mis_builder_filter_box());
+
+            self.analytic_account_id_m2o.$external_button.hide();
         },
 
         refresh: function () {
             this.replace();
+        },
+
+        _onFieldChanged: function (event) {
+            var self = this;
+            if (event && event.data.changes) {
+                var changes = event.data.changes;
+                if (changes['analytic_account_filter_id']) {
+                    var field_name = 'analytic_account_id';
+                    var new_val = changes['analytic_account_filter_id'];
+                    self.set_filter_value(self.analytic_account_id_m2o, field_name, new_val);
+                }
+            }
         },
 
         print_pdf: function () {
@@ -132,6 +250,11 @@ odoo.define('mis_builder.widget', function (require) {
             }).then(function (result) {
                 self.do_action(result);
             });
+        },
+
+        get_mis_builder_filter_box: function () {
+            var self = this;
+            return self.$(".oe_mis_builder_analytic_filter_box");
         },
     });
 

--- a/mis_builder/tests/test_mis_report_instance.py
+++ b/mis_builder/tests/test_mis_report_instance.py
@@ -305,7 +305,7 @@ class TestMisReportInstance(common.HttpCase):
         matrix = self.report_instance.with_context(
             mis_report_filters={
                 'analytic_account_id': {
-                    'value': 999,
+                    'value': [999, 'Fake Analytic Account'],
                 },
             }
         )._compute_matrix()


### PR DESCRIPTION
This PR is intended to migrate the analytic account filtering feature that was available in v10.

![image](https://user-images.githubusercontent.com/44768500/58473072-03a0a980-8148-11e9-8102-fcb70de58809.png)

cc ~ @Eficent @sbidoul 