### PR TITLE
[10.0][IMP] Add analytic tags as filter for mis_builder

### DIFF
--- a/mis_builder/static/src/js/mis_report_widget.js
+++ b/mis_builder/static/src/js/mis_report_widget.js
@@ -153,9 +153,13 @@ odoo.define('mis_builder.widget', function (require) {
 
         set_filter_value: function(field_object, attr_name) {
             var self = this;
+            var value = field_object.get_value() || undefined;
+            if(value === undefined) {
+                self.filter_values[attr_name] = undefined;
+                return
+            }
             self.init_filter(attr_name);
-            self.filter_values[attr_name]['value'] =
-                field_object.get_value() || undefined;
+            self.filter_values[attr_name]['value'] = value;
             self.filter_values[attr_name]['operator'] = 'all';
         },
 

--- a/mis_builder/static/src/js/mis_report_widget.js
+++ b/mis_builder/static/src/js/mis_report_widget.js
@@ -13,6 +13,7 @@ odoo.define('mis_builder.widget', function (require) {
     var session = require('web.session');
 
     var FieldMany2One = core.form_widget_registry.get('many2one');
+    var FieldMany2ManyTags = core.form_widget_registry.get('many2many_tags');
     var _t = core._t;
 
     var MisReportWidget = AbstractField.extend({
@@ -47,10 +48,10 @@ odoo.define('mis_builder.widget', function (require) {
             self.analytic_account_id_domain = [];
             self.analytic_account_id_label = _t("Analytic Account");
             self.analytic_account_id_m2o = undefined;
-            self.analytic_tag_id = undefined;
-            self.analytic_tag_id_domain = [];
-            self.analytic_tag_id_label = _t("Analytic Tag");
-            self.analytic_tag_id_m2o = undefined;
+            self.analytic_tag_ids = undefined;
+            self.analytic_tag_ids_domain = [];
+            self.analytic_tag_ids_label = _t("Analytic Tags");
+            self.analytic_tag_ids_m2m = undefined;
             self.has_group_analytic_accounting = false;
             self.hide_analytic_filters = false;
             self.filter_values = {};
@@ -221,9 +222,10 @@ odoo.define('mis_builder.widget', function (require) {
             if (!self.has_group_analytic_accounting) {
                 return;
             }
-            if (self.analytic_tag_id_m2o) {
+            if (self.analytic_tag_ids_m2m) {
                 // Prevent errors with autocomplete
-                self.analytic_tag_id_m2o.destroy();
+                self.analytic_tag_ids_m2m.destroy_content();
+                self.analytic_tag_ids_m2m.destroy();
             }
             var field_name = 'analytic_tag_ids';
             var dfm_object = {};
@@ -231,24 +233,24 @@ odoo.define('mis_builder.widget', function (require) {
                 relation: 'account.analytic.tag',
             };
             self.dfm.extend_field_desc(dfm_object);
-            var analytic_tag_id_m2o = new FieldMany2One(self.dfm, {
+            var analytic_tag_ids_m2m = new FieldMany2ManyTags(self.dfm, {
                 attrs: {
-                    placeholder: self.analytic_tag_id_label,
+                    placeholder: self.analytic_tag_ids_label,
                     name: field_name,
-                    type: 'many2one',
-                    domain: self.analytic_tag_id_domain,
+                    type: 'many2many',
+                    domain: self.analytic_tag_ids_domain,
                     context: {},
                     modifiers: '{}',
                     options: '{"no_create": true}',
+                    help: _t('This filter returns the account move lines that have all the selected tags.'),
                 },
             });
-            self.init_filter_value(analytic_tag_id_m2o, field_name);
-            analytic_tag_id_m2o.prependTo(self.get_mis_builder_filter_box());
-            analytic_tag_id_m2o.$input.focusout(function () {
-                self.set_filter_value(analytic_tag_id_m2o, field_name);
+            self.init_filter_value(analytic_tag_ids_m2m, field_name);
+            analytic_tag_ids_m2m.prependTo(self.get_mis_builder_filter_box());
+            analytic_tag_ids_m2m.on("change:value", this, function () {
+                self.set_filter_value(analytic_tag_ids_m2m, field_name);
             });
-            analytic_tag_id_m2o.$follow_button.toggle();
-            self.analytic_tag_id_m2o = analytic_tag_id_m2o;
+            self.analytic_tag_ids_m2m = analytic_tag_ids_m2m;
         },
 
         refresh: function () {

--- a/mis_builder/static/src/js/mis_report_widget.js
+++ b/mis_builder/static/src/js/mis_report_widget.js
@@ -185,6 +185,7 @@ odoo.define('mis_builder.widget', function (require) {
             }
             self.add_analytic_account_filter();
             self.add_analytic_tag_filter();
+            $('.o_form_view').addClass('o_form_editable');
         },
 
         add_analytic_account_filter: function () {

--- a/mis_builder/static/src/js/mis_report_widget.js
+++ b/mis_builder/static/src/js/mis_report_widget.js
@@ -47,6 +47,10 @@ odoo.define('mis_builder.widget', function (require) {
             self.analytic_account_id_domain = [];
             self.analytic_account_id_label = _t("Analytic Account");
             self.analytic_account_id_m2o = undefined;
+            self.analytic_tag_id = undefined;
+            self.analytic_tag_id_domain = [];
+            self.analytic_tag_id_label = _t("Analytic Tag");
+            self.analytic_tag_id_m2o = undefined;
             self.has_group_analytic_accounting = false;
             self.hide_analytic_filters = false;
             self.filter_values = {};
@@ -174,6 +178,7 @@ odoo.define('mis_builder.widget', function (require) {
                 return;
             }
             self.add_analytic_account_filter();
+            self.add_analytic_tag_filter();
         },
 
         add_analytic_account_filter: function () {
@@ -209,6 +214,41 @@ odoo.define('mis_builder.widget', function (require) {
             });
             analytic_account_id_m2o.$follow_button.toggle();
             self.analytic_account_id_m2o = analytic_account_id_m2o;
+        },
+
+        add_analytic_tag_filter: function () {
+            var self = this;
+            if (!self.has_group_analytic_accounting) {
+                return;
+            }
+            if (self.analytic_tag_id_m2o) {
+                // Prevent errors with autocomplete
+                self.analytic_tag_id_m2o.destroy();
+            }
+            var field_name = 'analytic_tag_ids';
+            var dfm_object = {};
+            dfm_object[field_name] = {
+                relation: 'account.analytic.tag',
+            };
+            self.dfm.extend_field_desc(dfm_object);
+            var analytic_tag_id_m2o = new FieldMany2One(self.dfm, {
+                attrs: {
+                    placeholder: self.analytic_tag_id_label,
+                    name: field_name,
+                    type: 'many2one',
+                    domain: self.analytic_tag_id_domain,
+                    context: {},
+                    modifiers: '{}',
+                    options: '{"no_create": true}',
+                },
+            });
+            self.init_filter_value(analytic_tag_id_m2o, field_name);
+            analytic_tag_id_m2o.prependTo(self.get_mis_builder_filter_box());
+            analytic_tag_id_m2o.$input.focusout(function () {
+                self.set_filter_value(analytic_tag_id_m2o, field_name);
+            });
+            analytic_tag_id_m2o.$follow_button.toggle();
+            self.analytic_tag_id_m2o = analytic_tag_id_m2o;
         },
 
         refresh: function () {

--- a/mis_builder/static/src/js/mis_report_widget.js
+++ b/mis_builder/static/src/js/mis_report_widget.js
@@ -156,6 +156,7 @@ odoo.define('mis_builder.widget', function (require) {
             self.init_filter(attr_name);
             self.filter_values[attr_name]['value'] =
                 field_object.get_value() || undefined;
+            self.filter_values[attr_name]['operator'] = 'all';
         },
 
         set_filter_operator: function(operator, attr_name) {
@@ -209,7 +210,7 @@ odoo.define('mis_builder.widget', function (require) {
                 },
             });
             self.init_filter_value(analytic_account_id_m2o, field_name);
-            analytic_account_id_m2o.prependTo(self.get_mis_builder_filter_box());
+            analytic_account_id_m2o.appendTo(self.$("#analytic_account"));
             analytic_account_id_m2o.$input.focusout(function () {
                 self.set_filter_value(analytic_account_id_m2o, field_name);
             });
@@ -246,7 +247,7 @@ odoo.define('mis_builder.widget', function (require) {
                 },
             });
             self.init_filter_value(analytic_tag_ids_m2m, field_name);
-            analytic_tag_ids_m2m.prependTo(self.get_mis_builder_filter_box());
+            analytic_tag_ids_m2m.appendTo(self.$("#analytic_tags"));
             analytic_tag_ids_m2m.on("change:value", this, function () {
                 self.set_filter_value(analytic_tag_ids_m2m, field_name);
             });

--- a/mis_builder/static/src/xml/mis_report_widget.xml
+++ b/mis_builder/static/src/xml/mis_report_widget.xml
@@ -5,7 +5,10 @@
             <t t-if="widget.mis_report_data">
                 <h2><t t-esc="widget.mis_report_data.report_name" /></h2>
                 <div>
-                    <div class="oe_mis_builder_analytic_filter_box oe_left" style="position: relative; display: inline-block;"/>
+                    <div class="oe_mis_builder_analytic_filter_box oe_left" style="position: relative; display: inline-block;">
+                        <div id="analytic_account"/>
+                        <div id="analytic_tags"/>
+                    </div>
                     <div class="oe_mis_builder_buttons oe_right oe_button_box">
                         <button class="oe_mis_builder_refresh btn btn-sm oe_button"><span class="fa fa-refresh"/> Refresh</button>
                         <button class="oe_mis_builder_print btn btn-sm oe_button"><span class="fa fa-print"/> Print</button>

--- a/mis_builder/tests/test_analytic_filters.py
+++ b/mis_builder/tests/test_analytic_filters.py
@@ -13,7 +13,7 @@ class TestAnalyticFilters(TransactionCase):
         assert mri._context_with_filters().get("mis_report_filters") == {}
         mri.analytic_account_id = aaa
         assert mri._context_with_filters().get("mis_report_filters") == {
-            "analytic_account_id": {"value": aaa.id}
+            "analytic_account_id": {"value": aaa.id, "operator": '='}
         }
         # test _context_with_filters does nothing is a filter is already
         # in the context
@@ -54,4 +54,14 @@ class TestAnalyticFilters(TransactionCase):
         self._check_get_filter_domain_from_context(
             {"analytic_account_id": {"value": False}},
             [("analytic_account_id", "=", False)],
+        )
+        # Filter from analytic account filter widget
+        self._check_get_filter_domain_from_context(
+            {"analytic_account_id": {"value": 1, "operator": "all"}},
+            [('analytic_account_id', 'in', [1])],
+        )
+        # Filter from analytic tags filter widget
+        self._check_get_filter_domain_from_context(
+            {"analytic_tag_ids": {"value": [1, 2], "operator": "all"}},
+            [('analytic_tag_ids', 'in', [1]), ('analytic_tag_ids', 'in', [2])],
         )

--- a/mis_builder/views/mis_report_instance.xml
+++ b/mis_builder/views/mis_report_instance.xml
@@ -109,7 +109,7 @@
                                         domain="[('id', 'child_of', company_id)]"
                                         attrs="{'invisible': [('multi_company', '=', False)]}"/>
                                 <field name="analytic_account_id" groups="analytic.group_analytic_accounting"/>
-                                <field name="analytic_tag_id" groups="analytic.group_analytic_accounting"/>
+                                <field name="analytic_tag_ids" groups="analytic.group_analytic_accounting" widget="many2many_tags"/>
                             </group>
                         </page>
                         <page string="Layout">

--- a/mis_builder/views/mis_report_instance.xml
+++ b/mis_builder/views/mis_report_instance.xml
@@ -109,6 +109,7 @@
                                         domain="[('id', 'child_of', company_id)]"
                                         attrs="{'invisible': [('multi_company', '=', False)]}"/>
                                 <field name="analytic_account_id" groups="analytic.group_analytic_accounting"/>
+                                <field name="analytic_tag_id" groups="analytic.group_analytic_accounting"/>
                             </group>
                         </page>
                         <page string="Layout">


### PR DESCRIPTION
The improvement adds a new filter (on account.analytic.tag) in the mis builder preview.
![Capture d’écran de 2019-09-03 14-59-45](https://user-images.githubusercontent.com/7569349/64175466-a3628780-ce5b-11e9-8b8c-4741d8d5d8db.png)
