### PR TITLE
[10.0][IMP] mis_builder: Show company of account detail in multicompany

### DIFF
--- a/mis_builder/models/kpimatrix.py
+++ b/mis_builder/models/kpimatrix.py
@@ -148,7 +148,7 @@ class KpiMatrixCell(object):
 
 class KpiMatrix(object):
 
-    def __init__(self, env):
+    def __init__(self, env, multi_company=False):
         # cache language id for faster rendering
         lang_model = env['res.lang']
         self.lang = lang_model._lang_get(env.user.lang)
@@ -167,6 +167,7 @@ class KpiMatrix(object):
         self._sum_todo = {}
         # { account_id: account_name }
         self._account_names = {}
+        self.multi_company = multi_company
 
     def declare_kpi(self, kpi):
         """ Declare a new kpi (row) in the matrix.
@@ -419,9 +420,15 @@ class KpiMatrix(object):
         accounts = self._account_model.\
             search([('id', 'in', list(account_ids))])
         self._account_names = {
-            a.id: u'{} {}'.format(a.code, a.name)
+            a.id: self._get_account_name(a)
             for a in accounts
         }
+
+    def _get_account_name(self, account):
+        result = u'{} {}'.format(account.code, account.name)
+        if self.multi_company:
+            result = u'{} [{}]'.format(result, account.company_id.name)
+        return result
 
     def get_account_name(self, account_id):
         if account_id not in self._account_names:

--- a/mis_builder/models/mis_report.py
+++ b/mis_builder/models/mis_report.py
@@ -535,9 +535,9 @@ class MisReport(models.Model):
     # TODO: kpi name cannot be start with query name
 
     @api.multi
-    def prepare_kpi_matrix(self):
+    def prepare_kpi_matrix(self, multi_company=False):
         self.ensure_one()
-        kpi_matrix = KpiMatrix(self.env)
+        kpi_matrix = KpiMatrix(self.env, multi_company)
         for kpi in self.kpi_ids:
             kpi_matrix.declare_kpi(kpi)
         return kpi_matrix

--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -765,7 +765,7 @@ class MisReportInstance(models.Model):
         self.ensure_one()
         aep = self.report_id._prepare_aep(
             self.query_company_ids, self.currency_id)
-        kpi_matrix = self.report_id.prepare_kpi_matrix()
+        kpi_matrix = self.report_id.prepare_kpi_matrix(self.multi_company)
         for period in self.period_ids:
             description = None
             if period.mode == MODE_NONE:

--- a/mis_builder/tests/test_mis_report_instance.py
+++ b/mis_builder/tests/test_mis_report_instance.py
@@ -282,6 +282,35 @@ class TestMisReportInstance(common.HttpCase):
                 # k7 references k3 via subkpi names
                 self.assertEquals(vals, [AccountingNone, AccountingNone, 1.0])
 
+    def test_multi_company_compute(self):
+        self.report_instance.write({
+            'multi_company': True,
+            'company_ids': [(6, 0, self.report_instance.company_id.ids)],
+        })
+        self.report_instance.report_id.kpi_ids.write({
+            'auto_expand_accounts': True
+        })
+        matrix = self.report_instance._compute_matrix()
+        for row in matrix.iter_rows():
+            if row.account_id:
+                account = self.env['account.account'].browse(row.account_id)
+                self.assertEqual(row.label, '%s %s [%s]' % (
+                    account.code,
+                    account.name,
+                    account.company_id.name,
+                ))
+        self.report_instance.write({
+            'multi_company': False,
+        })
+        matrix = self.report_instance._compute_matrix()
+        for row in matrix.iter_rows():
+            if row.account_id:
+                account = self.env['account.account'].browse(row.account_id)
+                self.assertEqual(row.label, '%s %s' % (
+                    account.code,
+                    account.name,
+                ))
+
     def test_evaluate(self):
         company = self.env.ref('base.main_company')
         aep = self.report._prepare_aep(company)


### PR DESCRIPTION
With this PR, we are able to see the company of the account on the label.
![image](https://user-images.githubusercontent.com/28590170/66748448-83c17480-ee87-11e9-9ed5-e535baf363fa.png)

This PR does not change the behavior when `multi_company` is not selected.
![image](https://user-images.githubusercontent.com/28590170/66748415-6b515a00-ee87-11e9-84d2-422195f85918.png)