### PR TITLE
[11.0] analytic filters in widget, take 5

### DIFF
--- a/mis_builder/static/src/css/custom.css
+++ b/mis_builder/static/src/css/custom.css
@@ -20,19 +20,10 @@
   text-decoration: underline;
 }
 
-.odoo .oe_mis_builder_buttons {
-  padding-bottom: 10px;
-  padding-top: 10px;
-}
-
 .oe_mis_builder_content {
   padding: 10px;
 }
 
 .oe_mis_builder_analytic_filter_box {
-  padding: 10px;
-}
-
-.oe_mis_builder_buttons {
-  margin: 0 !important;
+  padding-bottom: 10px;
 }

--- a/mis_builder/static/src/js/mis_report_widget.js
+++ b/mis_builder/static/src/js/mis_report_widget.js
@@ -1,21 +1,21 @@
-/* Copyright 2014-2018 ACSONE SA/NV (<http://acsone.eu>)
+/* Copyright 2014-2019 ACSONE SA/NV (<http://acsone.eu>)
    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html). */
 
 odoo.define('mis_builder.widget', function (require) {
 "use strict";
 
     var AbstractField = require('web.AbstractField');
+    var StandaloneFieldManagerMixin = require('web.StandaloneFieldManagerMixin');
     var field_registry = require('web.field_registry');
+    var relational_fields = require('web.relational_fields');
+    var BasicModel = require('web.BasicModel');
 
-    var MisReportWidget = AbstractField.extend({
+    var core = require('web.core');
+    var session = require('web.session');
 
-        /*
-         * The following attributes are set after willStart() and are available
-         * in the widget template:
-         * - mis_report_data: the result of mis.report.instance.compute()
-         * - show_settings: a flag that controls the visibility of the Settings
-         *   button
-         */
+    var _t = core._t;
+
+    var MisReportWidget = AbstractField.extend(StandaloneFieldManagerMixin, {
 
         template: "MisReportWidgetTemplate",
 
@@ -26,6 +26,49 @@ odoo.define('mis_builder.widget', function (require) {
             'click .oe_mis_builder_settings': 'display_settings',
             'click .oe_mis_builder_refresh': 'refresh',
         }),
+
+        init: function () {
+            var self = this;
+            self._super.apply(self, arguments);
+            StandaloneFieldManagerMixin.init.call(self);
+            self.model = new BasicModel(self);  // for FieldManagerMixin
+            self.analytic_account_id_domain = [];  // TODO unused for now
+            self.analytic_account_id_label = _t("Analytic Account Filter");
+            self.analytic_account_id_m2o = undefined;  // Field widget
+            self.analytic_tag_ids_domain = [];  // TODO unused for now
+            self.analytic_tag_ids_label = _t("Analytic Tags Filter");
+            self.analytic_tag_ids_m2m = undefined;  // Field widget
+            self.mis_report_data = undefined;
+            self.show_settings = false;
+            self.has_group_analytic_accounting = false;
+            self.has_group_analytic_tags = false;
+            self.hide_analytic_filters = false;
+        },
+
+        _get_filter_value: function(name) {
+            var filters = this.getParent().state.context['mis_report_filters'] || {};
+            var filter = filters[name] || {};
+            return filter.value;
+        },
+
+        _set_filter_value: function(name, value, operator) {
+            var context = this.getParent().state.context;
+            var filters;
+            if (context['mis_report_filters'] === undefined) {
+                filters = {}
+                context['mis_report_filters'] = filters;
+            } else {
+                filters =  context['mis_report_filters'];
+            }
+            if (value === undefined) {
+                filters[name] = {};
+                return
+            }
+            filters[name] = {
+                value: value,
+                operator: operator,
+            };
+        },
 
         /**
          * Return the id of the mis.report.instance to which the widget is
@@ -65,16 +108,185 @@ odoo.define('mis_builder.widget', function (require) {
                 self.mis_report_data = result;
             });
 
-            var def2 = self._rpc({
-                model: 'res.users',
-                method: 'has_group',
-                args: ['account.group_account_user'],
-                context: context,
-            }).then(function (result) {
+            var def2 = session.user_has_group(
+                'analytic.group_account_user'
+            ).then(function (result) {
                 self.show_settings = result;
             });
 
-            return $.when(this._super.apply(this, arguments), def1, def2);
+            var def3 = session.user_has_group(
+                'analytic.group_analytic_accounting'
+            ).then(function (result) {
+                self.has_group_analytic_accounting = result;
+            });
+
+            var def4 = session.user_has_group(
+                'analytic.group_analytic_accounting'  // TODO change in v12
+            ).then(function (result) {
+                self.has_group_analytic_tags = result;
+            });
+
+            var def5 = self._rpc({
+                model: 'mis.report.instance',
+                method: 'read',
+                args: [self._instance_id(), ['hide_analytic_filters']],
+                context: context,
+            }).then(function (result) {
+                self.hide_analytic_filters = result[0]['hide_analytic_filters'];
+            });
+
+            return $.when(this._super.apply(this, arguments), def1, def2, def3, def4, def5);
+        },
+
+        start: function () {
+            var self = this;
+            self._super.apply(self, arguments);
+            self._add_analytic_filters();
+        },
+
+        /**
+         * Create list of field descriptors to be provided
+         * to BasicModel.makeRecord.
+         */
+        _get_filter_fields: function() {
+            var self = this;
+            var fields = []
+            if (self.has_group_analytic_accounting) {
+                fields.push({
+                    relation: 'account.analytic.account',
+                    type: 'many2one',
+                    name: 'filter_analytic_account_id',
+                    value: self._get_filter_value('analytic_account_id'),
+                });
+            }
+            if (self.has_group_analytic_tags) {
+                fields.push({
+                    relation: 'account.analytic.tag',
+                    type: 'many2many',
+                    name: 'filter_analytic_tag_ids',
+                    value: self._get_filter_value('analytic_tag_ids'),
+                });
+            }
+            return fields;
+        },
+
+        /**
+         * Create fieldInfo structure to be provided
+         * to BasicModel.makeRecord.
+         */
+        _get_filter_fieldInfo: function() {
+            return {};
+        },
+
+        /**
+         * Create analytic filter widgets and add them in the filter box.
+         */
+        _make_filter_field_widgets: function(record) {
+            var self = this;
+            
+            if (self.has_group_analytic_accounting) {
+                self.analytic_account_id_m2o = new relational_fields.FieldMany2One(self,
+                    'filter_analytic_account_id',
+                    record,
+                    {
+                        mode: 'edit',
+                        attrs: {
+                            placeholder: self.analytic_account_id_label,
+                            options: {
+                                no_create: 'True',
+                                no_open: 'True',
+                            },
+                        },
+                    }
+                );
+                self._registerWidget(record.id, self.analytic_account_id_m2o.name, self.analytic_account_id_m2o);
+                self.analytic_account_id_m2o.appendTo(self.get_mis_builder_filter_box());
+            }
+
+            if (self.has_group_analytic_tags) {
+                self.analytic_tag_ids_m2m = new relational_fields.FieldMany2ManyTags(self,
+                    'filter_analytic_tag_ids',
+                    record,
+                    {
+                        mode: 'edit',
+                        attrs: {
+                            placeholder: self.analytic_tag_ids_label,  // Odoo 11 does not display it
+                            options: {
+                                no_create: 'True',
+                                no_open: 'True',
+                            },
+                        },
+                    }
+                );
+                self._registerWidget(record.id, self.analytic_tag_ids_m2m.name, self.analytic_tag_ids_m2m);
+                self.analytic_tag_ids_m2m.appendTo(self.get_mis_builder_filter_box());
+            }
+        },
+
+        /**
+         * Hack to work around Odoo not fetching display name for
+         * x2many used with makeRecord. 
+         * 
+         * Return a list of deferred
+         * to be awaited before creating the widgets.
+         */
+        _before_create_widgets: function(record) {
+            var self = this;
+            var defs = []
+
+            if (self.has_group_analytic_tags) {
+                var dataPoint = record.data.filter_analytic_tag_ids;
+                dataPoint.fieldsInfo.default["display_name"] = {};
+                defs.push(self.model.reload(dataPoint.id));
+            }
+
+            return defs;
+        },
+
+        /**
+         * Populate the analytic filters box. 
+         * This method is not meant to be overridden.
+         */
+        _add_analytic_filters: function () {
+            var self = this;
+            if (self.hide_analytic_filters) {
+                return;
+            }
+            self.model.makeRecord(
+                "dummy.model",
+                self._get_filter_fields(),
+                self._get_filter_fieldInfo(),
+            ).then(function (recordId) {
+                var record = self.model.get(recordId);
+                var defs = self._before_create_widgets(record);
+                $.when.apply($, defs).then(function () {
+                    record = self.model.get(record.id);
+                    self._make_filter_field_widgets(record);
+                });
+            });
+        },
+
+        _confirmChange: function (id, fields, event) {
+            var self = this;
+            var result = StandaloneFieldManagerMixin._confirmChange.apply(self, arguments);
+
+            if (self.analytic_account_id_m2o !== undefined) {
+                if (self.analytic_account_id_m2o.value) {
+                    self._set_filter_value('analytic_account_id', self.analytic_account_id_m2o.value.res_id, "=");
+                } else {
+                    self._set_filter_value('analytic_account_id', undefined);
+                }
+            }
+
+            if (self.analytic_tag_ids_m2m !== undefined) {
+                if (self.analytic_tag_ids_m2m.value && self.analytic_tag_ids_m2m.value.res_ids.length > 0) {
+                    self._set_filter_value('analytic_tag_ids', self.analytic_tag_ids_m2m.value.res_ids, "all");
+                } else {
+                    self._set_filter_value('analytic_tag_ids', undefined);
+                }
+            }
+
+            return result;
         },
 
         refresh: function () {
@@ -132,6 +344,11 @@ odoo.define('mis_builder.widget', function (require) {
             }).then(function (result) {
                 self.do_action(result);
             });
+        },
+
+        get_mis_builder_filter_box: function () {
+            var self = this;
+            return self.$(".oe_mis_builder_analytic_filter_box");
         },
     });
 

--- a/mis_builder/static/src/js/mis_report_widget.js
+++ b/mis_builder/static/src/js/mis_report_widget.js
@@ -21,9 +21,9 @@ odoo.define('mis_builder.widget', function (require) {
 
         events: _.extend({}, AbstractField.prototype.events, {
             'click .mis_builder_drilldown': 'drilldown',
-            'click .oe_mis_builder_print': 'print_pdf',
-            'click .oe_mis_builder_export': 'export_xls',
-            'click .oe_mis_builder_settings': 'display_settings',
+            'click .oe_mis_builder_print': 'printPdf',
+            'click .oe_mis_builder_export': 'exportXls',
+            'click .oe_mis_builder_settings': 'displaySettings',
             'click .oe_mis_builder_refresh': 'refresh',
         }),
 
@@ -45,13 +45,13 @@ odoo.define('mis_builder.widget', function (require) {
             self.hide_analytic_filters = false;
         },
 
-        _get_filter_value: function(name) {
+        _getFilterValue: function(name) {
             var filters = this.getParent().state.context['mis_report_filters'] || {};
             var filter = filters[name] || {};
             return filter.value;
         },
 
-        _set_filter_value: function(name, value, operator) {
+        _setFilterValue: function(name, value, operator) {
             var context = this.getParent().state.context;
             var filters;
             if (context['mis_report_filters'] === undefined) {
@@ -74,7 +74,7 @@ odoo.define('mis_builder.widget', function (require) {
          * Return the id of the mis.report.instance to which the widget is
          * bound.
          */
-        _instance_id: function () {
+        _instanceId: function () {
             if (this.value) {
                 return this.value;
             }
@@ -102,7 +102,7 @@ odoo.define('mis_builder.widget', function (require) {
             var def1 = self._rpc({
                 model: 'mis.report.instance',
                 method: 'compute',
-                args: [self._instance_id()],
+                args: [self._instanceId()],
                 context: context,
             }).then(function (result) {
                 self.mis_report_data = result;
@@ -129,7 +129,7 @@ odoo.define('mis_builder.widget', function (require) {
             var def5 = self._rpc({
                 model: 'mis.report.instance',
                 method: 'read',
-                args: [self._instance_id(), ['hide_analytic_filters']],
+                args: [self._instanceId(), ['hide_analytic_filters']],
                 context: context,
             }).then(function (result) {
                 self.hide_analytic_filters = result[0]['hide_analytic_filters'];
@@ -141,14 +141,14 @@ odoo.define('mis_builder.widget', function (require) {
         start: function () {
             var self = this;
             self._super.apply(self, arguments);
-            self._add_analytic_filters();
+            self._addAnalyticFilters();
         },
 
         /**
          * Create list of field descriptors to be provided
          * to BasicModel.makeRecord.
          */
-        _get_filter_fields: function() {
+        _getFilterFields: function() {
             var self = this;
             var fields = []
             if (self.has_group_analytic_accounting) {
@@ -156,7 +156,7 @@ odoo.define('mis_builder.widget', function (require) {
                     relation: 'account.analytic.account',
                     type: 'many2one',
                     name: 'filter_analytic_account_id',
-                    value: self._get_filter_value('analytic_account_id'),
+                    value: self._getFilterValue('analytic_account_id'),
                 });
             }
             if (self.has_group_analytic_tags) {
@@ -164,7 +164,7 @@ odoo.define('mis_builder.widget', function (require) {
                     relation: 'account.analytic.tag',
                     type: 'many2many',
                     name: 'filter_analytic_tag_ids',
-                    value: self._get_filter_value('analytic_tag_ids'),
+                    value: self._getFilterValue('analytic_tag_ids'),
                 });
             }
             return fields;
@@ -174,16 +174,16 @@ odoo.define('mis_builder.widget', function (require) {
          * Create fieldInfo structure to be provided
          * to BasicModel.makeRecord.
          */
-        _get_filter_fieldInfo: function() {
+        _getFilterFieldInfo: function() {
             return {};
         },
 
         /**
          * Create analytic filter widgets and add them in the filter box.
          */
-        _make_filter_field_widgets: function(record) {
+        _makeFilterFieldWidgets: function(record) {
             var self = this;
-            
+
             if (self.has_group_analytic_accounting) {
                 self.analytic_account_id_m2o = new relational_fields.FieldMany2One(self,
                     'filter_analytic_account_id',
@@ -200,7 +200,7 @@ odoo.define('mis_builder.widget', function (require) {
                     }
                 );
                 self._registerWidget(record.id, self.analytic_account_id_m2o.name, self.analytic_account_id_m2o);
-                self.analytic_account_id_m2o.appendTo(self.get_mis_builder_filter_box());
+                self.analytic_account_id_m2o.appendTo(self.getMisBuilderFilterBox());
             }
 
             if (self.has_group_analytic_tags) {
@@ -219,18 +219,18 @@ odoo.define('mis_builder.widget', function (require) {
                     }
                 );
                 self._registerWidget(record.id, self.analytic_tag_ids_m2m.name, self.analytic_tag_ids_m2m);
-                self.analytic_tag_ids_m2m.appendTo(self.get_mis_builder_filter_box());
+                self.analytic_tag_ids_m2m.appendTo(self.getMisBuilderFilterBox());
             }
         },
 
         /**
          * Hack to work around Odoo not fetching display name for
-         * x2many used with makeRecord. 
-         * 
+         * x2many used with makeRecord.
+         *
          * Return a list of deferred
          * to be awaited before creating the widgets.
          */
-        _before_create_widgets: function(record) {
+        _beforeCreateWidgets: function(record) {
             var self = this;
             var defs = []
 
@@ -244,24 +244,24 @@ odoo.define('mis_builder.widget', function (require) {
         },
 
         /**
-         * Populate the analytic filters box. 
+         * Populate the analytic filters box.
          * This method is not meant to be overridden.
          */
-        _add_analytic_filters: function () {
+        _addAnalyticFilters: function () {
             var self = this;
             if (self.hide_analytic_filters) {
                 return;
             }
             self.model.makeRecord(
                 "dummy.model",
-                self._get_filter_fields(),
-                self._get_filter_fieldInfo(),
+                self._getFilterFields(),
+                self._getFilterFieldInfo(),
             ).then(function (recordId) {
                 var record = self.model.get(recordId);
-                var defs = self._before_create_widgets(record);
+                var defs = self._beforeCreateWidgets(record);
                 $.when.apply($, defs).then(function () {
                     record = self.model.get(record.id);
-                    self._make_filter_field_widgets(record);
+                    self._makeFilterFieldWidgets(record);
                 });
             });
         },
@@ -272,17 +272,17 @@ odoo.define('mis_builder.widget', function (require) {
 
             if (self.analytic_account_id_m2o !== undefined) {
                 if (self.analytic_account_id_m2o.value) {
-                    self._set_filter_value('analytic_account_id', self.analytic_account_id_m2o.value.res_id, "=");
+                    self._setFilterValue('analytic_account_id', self.analytic_account_id_m2o.value.res_id, "=");
                 } else {
-                    self._set_filter_value('analytic_account_id', undefined);
+                    self._setFilterValue('analytic_account_id', undefined);
                 }
             }
 
             if (self.analytic_tag_ids_m2m !== undefined) {
                 if (self.analytic_tag_ids_m2m.value && self.analytic_tag_ids_m2m.value.res_ids.length > 0) {
-                    self._set_filter_value('analytic_tag_ids', self.analytic_tag_ids_m2m.value.res_ids, "all");
+                    self._setFilterValue('analytic_tag_ids', self.analytic_tag_ids_m2m.value.res_ids, "all");
                 } else {
-                    self._set_filter_value('analytic_tag_ids', undefined);
+                    self._setFilterValue('analytic_tag_ids', undefined);
                 }
             }
 
@@ -293,39 +293,39 @@ odoo.define('mis_builder.widget', function (require) {
             this.replace();
         },
 
-        print_pdf: function () {
+        printPdf: function () {
             var self = this;
             var context = self.getParent().state.context;
             this._rpc({
                 model: 'mis.report.instance',
                 method: 'print_pdf',
-                args: [this._instance_id()],
+                args: [this._instanceId()],
                 context: context,
             }).then(function (result) {
                 self.do_action(result);
             });
         },
 
-        export_xls: function () {
+        exportXls: function () {
             var self = this;
             var context = self.getParent().state.context;
             this._rpc({
                 model: 'mis.report.instance',
                 method: 'export_xls',
-                args: [this._instance_id()],
+                args: [this._instanceId()],
                 context: context,
             }).then(function (result) {
                 self.do_action(result);
             });
         },
 
-        display_settings: function () {
+        displaySettings: function () {
             var self = this;
             var context = self.getParent().state.context;
             this._rpc({
                 model: 'mis.report.instance',
                 method: 'display_settings',
-                args: [this._instance_id()],
+                args: [this._instanceId()],
                 context: context,
             }).then(function (result) {
                 self.do_action(result);
@@ -339,14 +339,14 @@ odoo.define('mis_builder.widget', function (require) {
             this._rpc({
                 model: 'mis.report.instance',
                 method: 'drilldown',
-                args: [this._instance_id(), drilldown],
+                args: [this._instanceId(), drilldown],
                 context: context,
             }).then(function (result) {
                 self.do_action(result);
             });
         },
 
-        get_mis_builder_filter_box: function () {
+        getMisBuilderFilterBox: function () {
             var self = this;
             return self.$(".oe_mis_builder_analytic_filter_box");
         },

--- a/mis_builder/static/src/xml/mis_report_widget.xml
+++ b/mis_builder/static/src/xml/mis_report_widget.xml
@@ -3,7 +3,7 @@
     <t t-name="MisReportWidgetTemplate">
         <div class="oe_mis_builder_content">
             <t t-if="widget.mis_report_data">
-                <h2><t t-esc="widget.mis_report_data.report_name" /></h2>
+                <h2 t-if="widget.mis_report_data.report_name"><t t-esc="widget.mis_report_data.report_name" /></h2>
                 <div>
                     <div class="oe_mis_builder_analytic_filter_box oe_left o_form_view o_form_editable" style="position: relative; display: inline-block;"/>
                     <div class="oe_mis_builder_buttons oe_right oe_button_box">

--- a/mis_builder/static/src/xml/mis_report_widget.xml
+++ b/mis_builder/static/src/xml/mis_report_widget.xml
@@ -5,7 +5,7 @@
             <t t-if="widget.mis_report_data">
                 <h2><t t-esc="widget.mis_report_data.report_name" /></h2>
                 <div>
-                    <div class="oe_mis_builder_analytic_filter_box oe_left" style="position: relative; display: inline-block;"/>
+                    <div class="oe_mis_builder_analytic_filter_box oe_left o_form_view o_form_editable" style="position: relative; display: inline-block;"/>
                     <div class="oe_mis_builder_buttons oe_right oe_button_box">
                         <button class="oe_mis_builder_refresh btn btn-sm oe_button"><span class="fa fa-refresh"/> Refresh</button>
                         <button class="oe_mis_builder_print btn btn-sm oe_button"><span class="fa fa-print"/> Print</button>


### PR DESCRIPTION
This is the last and final attempt to have a working and clean implementation of the analytic filters in the widget.

Building on previous tries and inspiration provided in #133, #143, #144, #201 and #229.

The main trick here is to combine the use of `BasicModel.makeRecord` (proposed by @apineux in #229) with the `StandaloneFieldManagerMixin` to handle events and manage the field widgets.

This PR also preserves the same data stucture for the `mis_report_filters` context key, so there are no backend code changes.

It works as in on 12.