### PR TITLE
[10.0] Switch order of computes to allow comparisons of sum columns

### DIFF
--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -791,8 +791,8 @@ class MisReportInstance(models.Model):
                 date_to = self._format_date(period.date_to)
                 description = _("from %s to %s") % (date_from, date_to)
             self._add_column(aep, kpi_matrix, period, period.name, description)
-        kpi_matrix.compute_comparisons()
         kpi_matrix.compute_sums()
+        kpi_matrix.compute_comparisons()
         return kpi_matrix
 
     def compute(self):


### PR DESCRIPTION
This is my use case. 

A user is using a particular budget for 6 month of the year, and another budget for the other 6 months. We have a column for each in the report, and a column to tally them up and have a full-year budget. Then we compare this total column to the realized of the year.

Right now, the sum column cannot be used as part of a comparison. It errors out on the following line of the kpimatrix.py:

 `    def compute_comparisons(self):
        """ Compute comparisons.

        Invoke this after setting all values.
        """
        for (
            cmpcol_key,
            (col_key, base_col_key, label, description),
        ) in self._comparison_todo.items():
            col = self._cols[col_key]
            base_col = self._cols[base_col_key]
            common_subkpis = self._common_subkpis([col, base_col])`

because base_col  is None at this point.

However, with the proposed fix, sum columns are prepared before the compute_comparison method runs and it works fine.

