### PR TITLE
Fix 'module' object is not iterable in ProRataReadGroupMixin

### DIFF
--- a/mis_builder/models/prorata_read_group_mixin.py
+++ b/mis_builder/models/prorata_read_group_mixin.py
@@ -82,7 +82,7 @@ class ProRataReadGroupMixin(models.AbstractModel):
             return res.values()
         return super(ProRataReadGroupMixin, self).read_group(
             domain,
-            fields,
+            flds,
             groupby,
             offset=offset,
             limit=limit,

--- a/mis_builder/readme/newsfragments/276.bugfix
+++ b/mis_builder/readme/newsfragments/276.bugfix
@@ -1,0 +1,2 @@
+Fix ``TypeError: 'module' object is not iterable`` when using
+budgets by account.


### PR DESCRIPTION
fixes #276 