### PR TITLE
[FIX] Non-existing security group linked to "Settings" button in MIS Widget

### DIFF
--- a/mis_builder/readme/newsfragments/281.bugfix
+++ b/mis_builder/readme/newsfragments/281.bugfix
@@ -1,0 +1,1 @@
+The "Settings" button is now displayed for users with the "Show full accounting features" right when previewing a report.

--- a/mis_builder/static/src/js/mis_report_widget.js
+++ b/mis_builder/static/src/js/mis_report_widget.js
@@ -114,7 +114,7 @@ odoo.define("mis_builder.widget", function(require) {
                 });
 
             var def2 = session
-                .user_has_group("analytic.group_account_user")
+                .user_has_group("account.group_account_user")
                 .then(function(result) {
                     self.show_settings = result;
                 });


### PR DESCRIPTION
## Description

Super small change to enable the "Settings" button when previewing reports, which is displayed automatically if the user has the "Show full accounting features" right.

It seems like this is already fixed in the 10.0 branch as it already uses the account.group_account_user ref.