### PR TITLE
 fix read_group fields arguments

### DIFF
--- a/mis_builder/models/prorata_read_group_mixin.py
+++ b/mis_builder/models/prorata_read_group_mixin.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import _, api, fields, models
+from odoo.fields import Date
 from odoo.exceptions import UserError
 
 from .mis_kpi_data import intersect_days
@@ -38,7 +39,7 @@ class ProRataReadGroupMixin(models.AbstractModel):
 
     @api.model
     def read_group(
-        self, domain, flds, groupby, offset=0, limit=None, orderby=False, lazy=True
+        self, domain, fields, groupby, offset=0, limit=None, orderby=False, lazy=True
     ):
         """Override read_group to perform pro-rata temporis adjustments.
 
@@ -64,13 +65,13 @@ class ProRataReadGroupMixin(models.AbstractModel):
         if (
             date_from is not None
             and date_to is not None
-            and not any(":" in f for f in flds)
+            and not any(":" in f for f in fields)
         ):
-            dt_from = fields.Date.from_string(date_from)
-            dt_to = fields.Date.from_string(date_to)
+            dt_from = Date.from_string(date_from)
+            dt_to = Date.from_string(date_to)
             res = {}
-            sum_fields = set(flds) - set(groupby)
-            read_fields = set(flds + ["date_from", "date_to"])
+            sum_fields = set(fields) - set(groupby)
+            read_fields = set(fields + ["date_from", "date_to"])
             for item in self.search(domain).read(read_fields):
                 key = tuple(item[k] for k in groupby)
                 if key not in res:
@@ -78,16 +79,16 @@ class ProRataReadGroupMixin(models.AbstractModel):
                     res[key].update({k: 0.0 for k in sum_fields})
                 res_item = res[key]
                 for sum_field in sum_fields:
-                    item_dt_from = fields.Date.from_string(item["date_from"])
-                    item_dt_to = fields.Date.from_string(item["date_to"])
-                    i_days, item_days = self._intersect_days(
+                    item_dt_from = Date.from_string(item["date_from"])
+                    item_dt_to = Date.from_string(item["date_to"])
+                    i_days, item_days = intersect_days(
                         item_dt_from, item_dt_to, dt_from, dt_to
                     )
                     res_item[sum_field] += item[sum_field] * i_days / item_days
             return res.values()
         return super(ProRataReadGroupMixin, self).read_group(
             domain,
-            flds,
+            fields,
             groupby,
             offset=offset,
             limit=limit,

--- a/mis_builder/readme/newsfragments/296.bugfix
+++ b/mis_builder/readme/newsfragments/296.bugfix
@@ -1,0 +1,1 @@
+Fix stack trace when grouping budget by account items in the web client.


### PR DESCRIPTION
renamed the variable "flds" in read_group arguments to allow the execution of the method as per standard grouping on tree view.
The renaming involved the use of an alias for the fields module to guarantee the functionality of the method in the prorata.read_group.mixin