### PR TITLE
[FIX] mis_builder: Comparison percentages export format in XLSX

### DIFF
--- a/mis_builder/readme/newsfragments/300.bugfix
+++ b/mis_builder/readme/newsfragments/300.bugfix
@@ -1,0 +1,3 @@
+Having a "Compare columns" added on a KPI with an associated style using a
+Factor/Divider did lead to the said factor being applied on the percentages
+when exporting to XLSX.

--- a/mis_builder/report/mis_report_instance_xlsx.py
+++ b/mis_builder/report/mis_report_instance_xlsx.py
@@ -143,7 +143,11 @@ class MisBuilderXlsx(ReportXlsx):
                     val = ""
                 else:
                     divider = float(cell.style_props.get("divider", 1))
-                    if divider != 1 and isinstance(cell.val, numbers.Number):
+                    if (
+                        divider != 1
+                        and isinstance(cell.val, numbers.Number)
+                        and not cell.val_type == "pct"
+                    ):
                         val = cell.val / divider
                     else:
                         val = cell.val


### PR DESCRIPTION
When a divider/factor Style parameter is used on a KPI, it is also applied to the "Compare columns" when exporting to Excel, which leads to errors of magnitude for the percentages displayed in the resulting XLSX file.

Here is a simple report using a KPI with a style factor "1e3 - k" and with a compare column as it is displayed in Odoo :
![Screenshot from 2020-05-08 09-27-33](https://user-images.githubusercontent.com/5863446/81386062-b2998380-9114-11ea-9e9c-d8e144bbaae6.png)

And the resulting XLSX export:
![Screenshot from 2020-05-08 09-27-47](https://user-images.githubusercontent.com/5863446/81386274-086e2b80-9115-11ea-85a7-daaf1129b7e7.png)

Seen on 12.0 but it seems like 10.0 code is similar.