### PR TITLE
Fix drilldown action name

### DIFF
--- a/mis_builder/models/mis_report.py
+++ b/mis_builder/models/mis_report.py
@@ -697,6 +697,7 @@ class MisReport(models.Model):
                     if not drilldown_arg:
                         continue
                     drilldown_arg["period_id"] = col_key
+                    drilldown_arg["kpi_id"] = kpi.id
 
                 if name_error:
                     recompute_queue.append(kpi)
@@ -763,6 +764,7 @@ class MisReport(models.Model):
                         if not drilldown_arg:
                             continue
                         drilldown_arg["period_id"] = col_key
+                        drilldown_arg["kpi_id"] = kpi.id
                     kpi_matrix.set_values_detail_account(
                         kpi, col_key, account_id, vals, drilldown_args
                     )

--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -838,7 +838,7 @@ class MisReportInstance(models.Model):
             )
             domain.extend(period._get_additional_move_line_filter())
             return {
-                "name": u"{} - {}".format(expr, period.name),
+                "name": self._get_drilldown_action_name(arg),
                 "domain": domain,
                 "type": "ir.actions.act_window",
                 "res_model": period._get_aml_model_name(),
@@ -850,3 +850,23 @@ class MisReportInstance(models.Model):
             }
         else:
             return False
+
+    def _get_drilldown_action_name(self, arg):
+        kpi_id = arg.get("kpi_id")
+        kpi = self.env["mis.report.kpi"].browse(kpi_id)
+        period_id = arg.get("period_id")
+        period = self.env["mis.report.instance.period"].browse(period_id)
+        account_id = arg.get("account_id")
+
+        if account_id:
+            account = self.env["account.account"].browse(account_id)
+            return "{kpi} - {account} - {period}".format(
+                kpi=kpi.description,
+                account=account.display_name,
+                period=period.display_name,
+            )
+        else:
+            return "{kpi} - {period}".format(
+                kpi=kpi.description,
+                period=period.display_name,
+            )

--- a/mis_builder/readme/newsfragments/304.feature
+++ b/mis_builder/readme/newsfragments/304.feature
@@ -1,0 +1,3 @@
+The drilldown action name displayed on the breadcrumb has been revised.
+The kpi description and the account ``display_name`` are shown instead
+of the kpi's technical definition.

--- a/mis_builder/tests/test_mis_report_instance.py
+++ b/mis_builder/tests/test_mis_report_instance.py
@@ -417,6 +417,35 @@ class TestMisReportInstance(common.HttpCase):
         self.assertTrue(("account_id", "in", tuple(account_ids)) in action["domain"])
         self.assertEqual(action["res_model"], "account.move.line")
 
+    def test_drilldown_action_name_with_account(self):
+        period = self.report_instance.period_ids[0]
+        account = self.env["account.account"].search([], limit=1)
+        args = {
+            "period_id": period.id,
+            "kpi_id": self.kpi1.id,
+            "account_id": account.id,
+        }
+        action_name = self.report_instance._get_drilldown_action_name(args)
+        expected_name = "{kpi} - {account} - {period}".format(
+            kpi=self.kpi1.description,
+            account=account.display_name,
+            period=period.display_name,
+        )
+        assert action_name == expected_name
+
+    def test_drilldown_action_name_without_account(self):
+        period = self.report_instance.period_ids[0]
+        args = {
+            "period_id": period.id,
+            "kpi_id": self.kpi1.id,
+        }
+        action_name = self.report_instance._get_drilldown_action_name(args)
+        expected_name = "{kpi} - {period}".format(
+            kpi=self.kpi1.description,
+            period=period.display_name,
+        )
+        assert action_name == expected_name
+
     def test_qweb(self):
         self.report_instance.print_pdf()  # get action
         test_reports.try_report(


### PR DESCRIPTION
I click to drilldown on a report line.

![image](https://user-images.githubusercontent.com/27902736/86928791-061f5200-c103-11ea-81aa-57375861fa44.png)

The action title in the breadcrumb is the technical expression of the report line.

![image](https://user-images.githubusercontent.com/27902736/86928842-19cab880-c103-11ea-9ee0-796786531b98.png)

The problem is that this expression is not understandable for most users.
It is only understandable for technical users who parameterize the system.

After this PR, when possible, the name of the account is displayed instead of the technical expression.

![image](https://user-images.githubusercontent.com/27902736/86929290-ac6b5780-c103-11ea-8d7c-230074837a65.png)

