### PR TITLE
[13.0][FIX] Compatibility with multicompany

### DIFF
--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -499,7 +499,7 @@ class MisReportInstance(models.Model):
         comodel_name="res.company",
         string="Company",
         default=lambda self: self.env.company,
-        required=True,
+        required=False,
     )
     multi_company = fields.Boolean(
         string="Multiple companies",
@@ -511,6 +511,7 @@ class MisReportInstance(models.Model):
         comodel_name="res.company",
         string="Companies",
         help="Select companies for which data will be searched.",
+        domain=lambda self: [("id", "in", self.env.companies.ids)],
     )
     query_company_ids = fields.Many2many(
         comodel_name="res.company",
@@ -544,12 +545,10 @@ class MisReportInstance(models.Model):
     )
     hide_analytic_filters = fields.Boolean(default=True)
 
-    @api.onchange("company_id", "multi_company")
+    @api.onchange("multi_company")
     def _onchange_company(self):
-        if self.company_id and self.multi_company:
-            self.company_ids = self.env["res.company"].search(
-                [("id", "child_of", self.company_id.id)]
-            )
+        if self.multi_company:
+            self.company_id = False
         else:
             self.company_ids = False
 

--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -504,7 +504,7 @@ class MisReportInstance(models.Model):
     multi_company = fields.Boolean(
         string="Multiple companies",
         help="Check if you wish to specify "
-        "children companies to be searched for data.",
+        "several companies to be searched for data.",
         default=False,
     )
     company_ids = fields.Many2many(
@@ -548,15 +548,28 @@ class MisReportInstance(models.Model):
     @api.onchange("multi_company")
     def _onchange_company(self):
         if self.multi_company:
+            self.company_ids |= self.company_id
             self.company_id = False
         else:
+            prev = self.company_ids.ids
+            company = False
+            if self.env.company.id in prev:
+                company = self.env.company
+            else:
+                for c_id in prev:
+                    if c_id in self.env.companies.ids:
+                        company = self.env["res.company"].browse(c_id)
+                        break
+
+            self.company_id = company
             self.company_ids = False
 
     @api.depends("multi_company", "company_id", "company_ids")
     def _compute_query_company_ids(self):
         for rec in self:
             if rec.multi_company:
-                rec.query_company_ids = rec.company_ids or rec.company_id
+                # If no companies defined use active companies.
+                rec.query_company_ids = rec.company_ids or self.env.companies
             else:
                 rec.query_company_ids = rec.company_id
 

--- a/mis_builder/readme/newsfragments/327.bugfix
+++ b/mis_builder/readme/newsfragments/327.bugfix
@@ -1,0 +1,2 @@
+The mis.report.instance should allow to define as many companies as the user is allowed to operate on when logged.
+The company is only a required field if the flag 'multi_company' is not set.

--- a/mis_builder/security/mis_builder_security.xml
+++ b/mis_builder/security/mis_builder_security.xml
@@ -4,7 +4,8 @@
         <field name="name">Mis Report Instance multi company</field>
         <field name="model_id" ref="model_mis_report_instance" />
         <field name="domain_force">
-            ['|',('company_id','=',False),('company_id','in',company_ids)]
+            ['|',('company_id','=',False),('company_id','in',company_ids), '|',
+            ('company_ids', '=', False), ('company_ids', 'in', company_ids)]
         </field>
     </record>
 </odoo>

--- a/mis_builder/tests/test_mis_report_instance.py
+++ b/mis_builder/tests/test_mis_report_instance.py
@@ -509,25 +509,22 @@ class TestMisReportInstance(common.HttpCase):
         self.env["res.company"].create(
             dict(name="company 2", parent_id=self.report_instance.company_id.id)
         )
-        companies = self.env["res.company"].search(
-            [("id", "child_of", self.report_instance.company_id.id)]
-        )
         self.report_instance.multi_company = True
         # multi company, company_ids not set
-        self.assertEqual(
-            self.report_instance.query_company_ids[0], self.report_instance.company_id
-        )
+        self.assertEqual(self.report_instance.query_company_ids, self.env.companies)
         # set company_ids
+        previous_company = self.report_instance.company_id
         self.report_instance._onchange_company()
+        self.assertFalse(self.report_instance.company_id)
         self.assertTrue(self.report_instance.multi_company)
-        self.assertEqual(self.report_instance.company_ids, companies)
-        self.assertEqual(self.report_instance.query_company_ids, companies)
+        self.assertEqual(self.report_instance.company_ids, previous_company)
+        self.assertEqual(self.report_instance.query_company_ids, previous_company)
         # reset single company mode
         self.report_instance.multi_company = False
+        self.report_instance._onchange_company()
         self.assertEqual(
             self.report_instance.query_company_ids[0], self.report_instance.company_id
         )
-        self.report_instance._onchange_company()
         self.assertFalse(self.report_instance.company_ids)
 
     def test_mis_report_analytic_filters(self):

--- a/mis_builder/views/mis_report_instance.xml
+++ b/mis_builder/views/mis_report_instance.xml
@@ -163,6 +163,7 @@
                                 <field
                                     name="company_id"
                                     groups="base.group_multi_company"
+                                    attrs="{'required': [('multi_company', '=', False)]}"
                                 />
                                 <field
                                     name="multi_company"
@@ -172,7 +173,6 @@
                                     name="company_ids"
                                     groups="base.group_multi_company"
                                     widget="many2many_tags"
-                                    domain="[('id', 'child_of', company_id)]"
                                     attrs="{'invisible': [('multi_company', '=', False)]}"
                                 />
                                 <field


### PR DESCRIPTION
- The mis.report.instance should allow to define as many
  companies as the user is allowed to operate on when logged.
- The company is only a required field if the flag 'multi_company' is not set.

