### PR TITLE
[12.0][FIX] mis_builder: arrays in domain

### DIFF
--- a/mis_builder/models/aep.py
+++ b/mis_builder/models/aep.py
@@ -1,4 +1,5 @@
 # Copyright 2014 ACSONE SA/NV (<http://acsone.eu>)
+# Copyright 2020 CorporateHub (https://corporatehub.eu)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 import datetime
@@ -88,7 +89,7 @@ class AccountingExpressionProcessor(object):
         r"\s*"
         r"(?P<account_sel>_[a-zA-Z0-9]+|\[.*?\])"
         r"\s*"
-        r"(?P<ml_domain>\[.*?\])?"
+        r"(?P<ml_domain>\[.*\])?"
     )
 
     def __init__(self, companies, currency=None, account_model="account.account"):
@@ -169,7 +170,14 @@ class AccountingExpressionProcessor(object):
         # move line domain
         if ml_domain:
             assert ml_domain[0] == "[" and ml_domain[-1] == "]"
-            ml_domain = tuple(safe_eval(ml_domain, domain_eval_context))
+            components = safe_eval(ml_domain, domain_eval_context)
+            ml_domain = []
+            for component in components:
+                left, op, right = component
+                if isinstance(right, list):
+                    right = tuple(right)
+                ml_domain.append((left, op, right))
+            ml_domain = tuple(ml_domain)
         else:
             ml_domain = tuple()
         return field, mode, acc_domain, ml_domain

--- a/mis_builder/readme/CONTRIBUTORS.rst
+++ b/mis_builder/readme/CONTRIBUTORS.rst
@@ -21,3 +21,6 @@
 * Arnaud Pineux <arnaud.pineux@acsone.eu>
 * Ernesto Tejeda <ernesto.tejeda@tecnativa.com>
 * Pedro M. Baeza <pedro.baeza@tecnativa.com>
+* `CorporateHub <https://corporatehub.eu/>`__
+
+  * Alexey Pelykh <alexey.pelykh@corphub.eu>

--- a/mis_builder/tests/test_aep.py
+++ b/mis_builder/tests/test_aep.py
@@ -1,4 +1,5 @@
 # Copyright 2014 ACSONE SA/NV (<http://acsone.eu>)
+# Copyright 2020 CorporateHub (https://corporatehub.eu)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 import datetime
@@ -90,7 +91,8 @@ class TestAEP(common.TransactionCase):
         self.aep.parse_expr("crdp[700I%]")
         self.aep.parse_expr("bali[400%]")
         self.aep.parse_expr("bale[700%]")
-        self.aep.parse_expr("balp[]" "[('account_id.code', '=', '400AR')]")
+        self.aep.parse_expr("balp[][('account_id.code', '=', '400AR')]")
+        self.aep.parse_expr("balp[][('account_id.code', 'in', ['400AR'])]")
         self.aep.parse_expr(
             "balp[]"
             "[('account_id.user_type_id', '=', "
@@ -162,6 +164,9 @@ class TestAEP(common.TransactionCase):
         # check variation
         self.assertEquals(self._eval("balp[400AR]"), 100)
         self.assertEquals(self._eval("balp[][('account_id.code', '=', '400AR')]"), 100)
+        self.assertEquals(
+            self._eval("balp[][('account_id.code', 'in', ['400AR'])]"), 100
+        )
         self.assertEquals(
             self._eval(
                 "balp[]"


### PR DESCRIPTION
To support expressions like `balp[][('something', 'in', ['a', 'b'])]`

cc @pedrobaeza @sbidoul 