### PR TITLE
[14.0][IMP] - add balance inverse

### DIFF
--- a/mis_builder_budget/models/mis_budget_by_account_item.py
+++ b/mis_builder_budget/models/mis_budget_by_account_item.py
@@ -15,7 +15,10 @@ class MisBudgetByAccountItem(models.Model):
     debit = fields.Monetary(default=0.0, currency_field="company_currency_id")
     credit = fields.Monetary(default=0.0, currency_field="company_currency_id")
     balance = fields.Monetary(
-        compute="_compute_balance", store=True, currency_field="company_currency_id"
+        compute="_compute_balance",
+        inverse="_inverse_balance",
+        store=True,
+        currency_field="company_currency_id",
     )
     company_id = fields.Many2one(
         "res.company",
@@ -75,3 +78,20 @@ class MisBudgetByAccountItem(models.Model):
     )
     def _check_dates(self):
         super(MisBudgetByAccountItem, self)._check_dates()
+
+    def _inverse_balance(self):
+        for rec in self:
+            if rec.balance < 0:
+                rec.update(
+                    {
+                        "credit": -rec.balance,
+                        "debit": 0,
+                    }
+                )
+            else:
+                rec.update(
+                    {
+                        "credit": 0,
+                        "debit": rec.balance,
+                    }
+                )

--- a/mis_builder_budget/tests/test_mis_budget_by_account.py
+++ b/mis_builder_budget/tests/test_mis_budget_by_account.py
@@ -126,3 +126,11 @@ class TestMisBudgetByAccount(SavepointCase):
         self.assertEqual(self.budget.state, "cancelled")
         self.budget.action_draft()
         self.assertEqual(self.budget.state, "draft")
+
+    def test_budget_item_balance(self):
+        item = self.budget.item_ids[0]
+        item.balance = 100
+        self.assertEqual(item.debit, 100)
+        item.balance = -100
+        self.assertEqual(item.debit, 0)
+        self.assertEqual(item.credit, 100)

--- a/mis_builder_budget/views/mis_budget_by_account_item.xml
+++ b/mis_builder_budget/views/mis_budget_by_account_item.xml
@@ -28,8 +28,9 @@
                 <field name="date_range_id" />
                 <field name="date_from" />
                 <field name="date_to" />
-                <field name="debit" />
-                <field name="credit" />
+                <field name="debit" invisible="1" />
+                <field name="credit" invisible="1" />
+                <field name="balance" />
                 <field
                     name="analytic_account_id"
                     groups="analytic.group_analytic_accounting"


### PR DESCRIPTION
This PR add an inverse method for balance field in `mis.budget.by.account.item` model to make its input more user friendly.