### PR TITLE
[13.0][FIX] run doctests

### DIFF
--- a/mis_builder/tests/common.py
+++ b/mis_builder/tests/common.py
@@ -1,6 +1,10 @@
 # Copyright 2017 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
+import doctest
+
+from odoo.tests import BaseCase, tagged
+
 
 def setup_test_model(env, model_cls):
     model_cls._build_model(env.registry, env.cr)
@@ -40,3 +44,37 @@ def assert_matrix(matrix, expected):
             ) == expected_val, "{} != {} in row {} col {}".format(
                 cell and cell.val, expected_val, i, j
             )
+
+
+@tagged("doctest")
+class OdooDocTestCase(BaseCase):
+    """
+    We need a custom DocTestCase class in order to:
+    - define test_tags to run as part of standard tests
+    - output a more meaningful test name than default "DocTestCase.runTest"
+    """
+
+    __qualname__ = "doctests for "
+
+    def __init__(self, test):
+        self.__test = test
+        self.__name = test._dt_test.name
+        super().__init__(self.__name)
+
+    def __getattr__(self, item):
+        if item == self.__name:
+            return self.__test
+
+
+def load_doctests(module):
+    """
+    Generates a tests loading method for the doctests of the given module
+    https://docs.python.org/3/library/unittest.html#load-tests-protocol
+    """
+
+    def load_tests(loader, tests, ignore):
+        for test in doctest.DocTestSuite(module):
+            tests.addTest(OdooDocTestCase(test))
+        return tests
+
+    return load_tests

--- a/mis_builder/tests/test_accounting_none.py
+++ b/mis_builder/tests/test_accounting_none.py
@@ -1,11 +1,8 @@
 # Copyright 2014 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-import doctest
 
 from ..models import accounting_none
+from .common import load_doctests
 
-
-def load_tests(loader, tests, ignore):
-    tests.addTests(doctest.DocTestSuite(accounting_none))
-    return tests
+load_tests = load_doctests(accounting_none)

--- a/mis_builder/tests/test_aggregate.py
+++ b/mis_builder/tests/test_aggregate.py
@@ -1,11 +1,7 @@
 # Copyright 2014 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-import doctest
-
 from ..models import aggregate
+from .common import load_doctests
 
-
-def load_tests(loader, tests, ignore):
-    tests.addTests(doctest.DocTestSuite(aggregate))
-    return tests
+load_tests = load_doctests(aggregate)

--- a/mis_builder/tests/test_simple_array.py
+++ b/mis_builder/tests/test_simple_array.py
@@ -1,11 +1,7 @@
 # Copyright 2014 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-import doctest
-
 from ..models import simple_array
+from .common import load_doctests
 
-
-def load_tests(loader, tests, ignore):
-    tests.addTests(doctest.DocTestSuite(simple_array))
-    return tests
+load_tests = load_doctests(simple_array)


### PR DESCRIPTION
Run doctests as part of standard tests.

From https://github.com/OCA/queue/pull/296, courtesy @nilshamerlinck.