### PR TITLE
[13.0][FIX] mis_builder: copying reports with comparison columns.

### DIFF
--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -459,6 +459,17 @@ class MisReportInstancePeriod(models.Model):
                         % rec.name
                     )
 
+    def copy_data(self, default=None):
+        if self.source == SRC_CMPCOL:
+            # While duplicating a MIS report instance, comparison columns are
+            # ignored because they would raise an error, as they keep the old
+            # `source_cmpcol_from_id` and `source_cmpcol_to_id` from the
+            # original record.
+            return [
+                False,
+            ]
+        return super().copy_data(default=default)
+
 
 class MisReportInstance(models.Model):
     """The MIS report instance combines everything to compute

--- a/mis_builder/readme/newsfragments/343.bugfix
+++ b/mis_builder/readme/newsfragments/343.bugfix
@@ -1,0 +1,3 @@
+While duplicating a MIS report instance, comparison columns are ignored because
+they would raise an error otherwise, as they keep the old source_cmpcol_from_id
+and source_cmpcol_to_id from the original record.


### PR DESCRIPTION
While duplicating a MIS report instance, comparison columns are
ignored because they would raise an error, as they keep the old
`source_cmpcol_from_id` and `source_cmpcol_to_id` from the
original record.

Error that raises without this fix is the following:
![image](https://user-images.githubusercontent.com/23449160/104617667-025d2100-568c-11eb-9134-cb89e1fd5061.png)

@ForgeFlow


