### PR TITLE
[13.0][FIX] mis_builder: always ignore cancel entries.

### DIFF
--- a/mis_builder/models/aep.py
+++ b/mis_builder/models/aep.py
@@ -294,6 +294,8 @@ class AccountingExpressionProcessor(object):
             ]
         if target_move == "posted":
             domain.append(("move_id.state", "=", "posted"))
+        else:
+            domain.append(("move_id.state", "in", ("posted", "draft")))
         return expression.normalize_domain(domain)
 
     def _get_company_rates(self, date):

--- a/mis_builder/models/aep.py
+++ b/mis_builder/models/aep.py
@@ -294,7 +294,7 @@ class AccountingExpressionProcessor(object):
             ]
         if target_move == "posted":
             domain.append(("move_id.state", "=", "posted"))
-        else:
+        elif target_move == "all":
             domain.append(("move_id.state", "in", ("posted", "draft")))
         return expression.normalize_domain(domain)
 

--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -401,6 +401,8 @@ class MisReportInstancePeriod(models.Model):
             and self.report_instance_id.target_move == "posted"
         ):
             domain.extend([("move_id.state", "=", "posted")])
+        elif self._get_aml_model_name() == "account.move.line":
+            domain.extend([("move_id.state", "in", ("posted", "draft"))])
         if self.analytic_account_id:
             domain.append(("analytic_account_id", "=", self.analytic_account_id.id))
         for tag in self.analytic_tag_ids:

--- a/mis_builder/tests/test_aep.py
+++ b/mis_builder/tests/test_aep.py
@@ -367,12 +367,15 @@ class TestAEP(common.TransactionCase):
                 ("account_id", "in", (self.account_ar.id,)),
                 ("credit", "<>", 0.0),
                 "&",
+                "&",
                 # for P&L accounts, only after fy start
                 "|",
                 ("date", ">=", "2017-01-01"),
                 ("account_id.user_type_id.include_initial_balance", "=", True),
                 # everything must be before from_date for initial balance
                 ("date", "<", "2017-02-01"),
+                # Cancel entries should be always ignored.
+                ("move_id.state", "in", ("posted", "draft")),
             ],
         )
 


### PR DESCRIPTION
When you select all entries in "Target Moves", the expected is
that the report considers both posted and draft entries.

In v13 and due to the merge of invoice in `account.move` model,
a new state `cancel` has been introduced. This forces to always
filter entries in this state to keep the behavior of previous
versions (and expected).

@ForgeFlow