### PR TITLE
[13.0][FIX] mis_builder_budget: incorrect budget by account multi company rules.

### DIFF
--- a/mis_builder_budget/readme/newsfragments/347.bugfix
+++ b/mis_builder_budget/readme/newsfragments/347.bugfix
@@ -1,0 +1,1 @@
+Fix incorrect budget by account multi company security rules.

--- a/mis_builder_budget/security/mis_budget_by_account.xml
+++ b/mis_builder_budget/security/mis_budget_by_account.xml
@@ -24,7 +24,7 @@
         <field name="name">mis.budget.by.account multi company</field>
         <field name="model_id" ref="model_mis_budget_by_account" />
         <field name="domain_force">
-            ['|',('company_id','=',False),('company_id','child_of',[user.company_id.id])]
+            ['|',('company_id','=',False),('company_id', 'in', company_ids)]
         </field>
     </record>
 </odoo>

--- a/mis_builder_budget/security/mis_budget_by_account_item.xml
+++ b/mis_builder_budget/security/mis_budget_by_account_item.xml
@@ -24,7 +24,7 @@
         <field name="name">mis.budget.by.account.item multi company</field>
         <field name="model_id" ref="model_mis_budget_by_account_item" />
         <field name="domain_force">
-            ['|',('budget_id.company_id','=',False),('budget_id.company_id','child_of',[user.company_id.id])]
+            ['|',('budget_id.company_id','=',False),('budget_id.company_id','in',company_ids)]
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Probably missed during migration.

@ForgeFlow
