### PR TITLE
[14.0][FIX] mis_builder: compute comparison domain correctly

### DIFF
--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -274,6 +274,9 @@ class MisReportInstancePeriod(models.Model):
     source_cmpcol_to_id = fields.Many2one(
         comodel_name="mis.report.instance.period", string="Compare"
     )
+    allowed_cmpcol_ids = fields.Many2many(
+        comodel_name="mis.report.instance.period", compute="_compute_allowed_cmpcol_ids"
+    )
     # filters
     analytic_account_id = fields.Many2one(
         comodel_name="account.analytic.account",
@@ -318,6 +321,12 @@ class MisReportInstancePeriod(models.Model):
             "Period name should be unique by report",
         ),
     ]
+
+    @api.depends("report_instance_id")
+    def _compute_allowed_cmpcol_ids(self):
+        """Compute actual records while in NewId context"""
+        for record in self:
+            record.allowed_cmpcol_ids = record.report_instance_id.period_ids - record
 
     @api.constrains("source_aml_model_id")
     def _check_source_aml_model_id(self):

--- a/mis_builder/readme/newsfragments/361.bugfix
+++ b/mis_builder/readme/newsfragments/361.bugfix
@@ -1,0 +1,3 @@
+When on a MIS Report Instance, if you wanted to generate a new line of type comparison, you couldn't currently select any existing period to compare.
+This happened because the field domain was searching in a NewId context, thus not finding a correct period.
+Changing the domain and making it use a computed field with a search for the _origin record solves the problem.

--- a/mis_builder/views/mis_report_instance.xml
+++ b/mis_builder/views/mis_report_instance.xml
@@ -335,16 +335,17 @@
                             name="source_sumcol_accdet"
                             attrs="{'invisible': [('source', '!=', 'sumcol')]}"
                         />
+                        <field name="allowed_cmpcol_ids" invisible="1" />
                         <field
                             name="source_cmpcol_to_id"
                             attrs="{'invisible': [('source', '!=', 'cmpcol')], 'required': [('source', '=', 'cmpcol')]}"
-                            domain="[('report_instance_id', '=', report_instance_id), ('id', '!=', id)]"
+                            domain="[('id', 'in', allowed_cmpcol_ids)]"
                             options="{'no_create': True, 'no_open': True}"
                         />
                         <field
                             name="source_cmpcol_from_id"
                             attrs="{'invisible': [('source', '!=', 'cmpcol')], 'required': [('source', '=', 'cmpcol')]}"
-                            domain="[('report_instance_id', '=', report_instance_id), ('id', '!=', id)]"
+                            domain="[('id', 'in', allowed_cmpcol_ids)]"
                             options="{'no_create': True, 'no_open': True}"
                         />
                     </group>


### PR DESCRIPTION
When on a MIS Report Instance, if you wanted to generate a new line of type comparison, you couldn't currently select any existing period to compare

This happened because the field domain was searching in a `NewId` context, thus not finding a correct period.

Changing the domain and making it use a computed field with a search for the `_origin` record solves the problem

@Tecnativa
TT29316

ping @pedrobaeza @victoralmau 
