### PR TITLE
[12.0][FIX] balu[] and budgets by account fails

### DIFF
--- a/mis_builder/models/aep.py
+++ b/mis_builder/models/aep.py
@@ -290,7 +290,7 @@ class AccountingExpressionProcessor(object):
             ]
             domain = [
                 ("date", "<", fields.Date.to_string(fy_date_from)),
-                ("user_type_id.include_initial_balance", "=", False),
+                ("account_id.user_type_id.include_initial_balance", "=", False),
             ]
         if target_move == "posted":
             domain.append(("move_id.state", "=", "posted"))

--- a/mis_builder/readme/newsfragments/364.bugfix
+++ b/mis_builder/readme/newsfragments/364.bugfix
@@ -1,0 +1,4 @@
+[FIX] balu[] and budgets by account
+
+The balu[] expression (MODE_UNALLOCATED) need a user_type_id One2many to
+account.account.type. We get it from account_id as in v14


### PR DESCRIPTION
The balu[] expression (MODE_UNALLOCATED) expects the move line source to
have a user_type_id One2many to account.account.type

On a report consisting of both P&L and BS accounts and with Budgets by Account items for the P&L accounts the balu[] expression fails with:

Odoo Server Error

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 656, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 314, in _handle_exception
    raise pycompat.reraise(type(exception), exception, sys.exc_info()[2])
  File "/opt/odoo/custom/src/odoo/odoo/tools/pycompat.py", line 87, in reraise
    raise value
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 698, in dispatch
    result = self._call_function(**self.params)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 346, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/service/model.py", line 98, in wrapper
    return f(dbname, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 339, in checked_call
    result = self.endpoint(*a, **kw)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 941, in __call__
    return self.method(*args, **kw)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 519, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/auto/addons/web/controllers/main.py", line 963, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/opt/odoo/auto/addons/web/controllers/main.py", line 955, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 759, in call_kw
    return _call_kw_multi(method, model, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 746, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/opt/odoo/auto/addons/mis_builder/models/mis_report_instance.py", line 847, in compute
    kpi_matrix = self._compute_matrix()
  File "/opt/odoo/auto/addons/mis_builder/models/mis_report_instance.py", line 840, in _compute_matrix
    self._add_column(aep, kpi_matrix, period, period.name, description)
  File "/opt/odoo/auto/addons/mis_builder_budget/models/mis_report_instance.py", line 81, in _add_column
    aep, kpi_matrix, period, label, description
  File "/opt/odoo/auto/addons/mis_builder/models/mis_report_instance.py", line 784, in _add_column_move_lines
    no_auto_expand_accounts=self.no_auto_expand_accounts,
  File "/opt/odoo/auto/addons/mis_builder/models/mis_report.py", line 889, in _declare_and_compute_period
    expression_evaluator.aep_do_queries()
  File "/opt/odoo/auto/addons/mis_builder/models/expression_evaluator.py", line 37, in aep_do_queries
    self.aml_model,
  File "/opt/odoo/auto/addons/mis_builder/models/aep.py", line 353, in do_queries
    lazy=False,
  File "/opt/odoo/auto/addons/mis_builder/models/prorata_read_group_mixin.py", line 95, in read_group
    lazy=lazy,
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 2107, in read_group
    result = self._read_group_raw(domain, fields, groupby, offset=offset, limit=limit, orderby=orderby, lazy=lazy)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 2130, in _read_group_raw
    query = self._where_calc(domain)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3939, in _where_calc
    e = expression.expression(domain, self)
  File "/opt/odoo/custom/src/odoo/odoo/osv/expression.py", line 676, in __init__
    # Leafs management
  File "/opt/odoo/custom/src/odoo/odoo/osv/expression.py", line 857, in parse
    # comments about inherits'd fields
ValueError: Invalid field 'user_type_id.include_initial_balance' in leaf "<osv.ExtendedLeaf: ('user_type_id.include_initial_balance', '=', False) on mis_budget_by_account_item (ctx: )>"

The roor cause is the MODE_UNALLOCATED adds the domain   ("user_type_id.include_initial_balance", "=", False) in https://github.com/OCA/mis-builder/blob/12.0/mis_builder/models/aep.py#L293

With this fix I add the user_type_id field to mis.budget.by.account.item.

Another solutions could be to change the domain to ("account_id.user_type_id.include_initial_balance", "=", False) as It had been done in v14

