### PR TITLE
[12.0][IMP] Add domain generated for query to locals_dict to be reused...

### DIFF
--- a/mis_builder/models/mis_report.py
+++ b/mis_builder/models/mis_report.py
@@ -645,6 +645,7 @@ class MisReport(models.Model):
                 for field_name in field_names:
                     setattr(s, field_name, agg([d[field_name] for d in data]))
                 res[query.name] = s
+            res.update({query: {"domain": domain}})
         return res
 
     def _declare_and_compute_col(  # noqa: C901 (TODO simplify this fnction)


### PR DESCRIPTION
...for filtering drilldown This PR is a requisite for this piece https://github.com/sergiocorato/mis-builder-contrib/blob/12.0-add-mis_builder_query_drilldown/mis_builder_query_drilldown/models/mis_report.py#L28..L29 of PR https://github.com/OCA/mis-builder-contrib/pull/13
