### PR TITLE
[13.0] ignore moves in 'cancel' state

### DIFF
--- a/mis_builder/models/aep.py
+++ b/mis_builder/models/aep.py
@@ -26,7 +26,7 @@ _DOMAIN_START_RE = re.compile(r"\(|(['\"])[!&|]\1")
 
 
 def _is_domain(s):
-    """ Test if a string looks like an Odoo domain """
+    """Test if a string looks like an Odoo domain"""
     return _DOMAIN_START_RE.match(s)
 
 
@@ -193,7 +193,7 @@ class AccountingExpressionProcessor(object):
                 self._map_account_ids[key].add(acc_domain)
 
     def done_parsing(self):
-        """ Replace account domains by account ids in map """
+        """Replace account domains by account ids in map"""
         for key, acc_domains in self._map_account_ids.items():
             all_account_ids = set()
             for acc_domain in acc_domains:
@@ -221,9 +221,7 @@ class AccountingExpressionProcessor(object):
             account_ids.update(self._account_ids_by_acc_domain[acc_domain])
         return account_ids
 
-    def get_aml_domain_for_expr(
-        self, expr, date_from, date_to, target_move, account_id=None
-    ):
+    def get_aml_domain_for_expr(self, expr, date_from, date_to, account_id=None):
         """Get a domain on account.move.line for an expression.
 
         Prerequisite: done_parsing() must have been invoked.
@@ -252,14 +250,14 @@ class AccountingExpressionProcessor(object):
             aml_domains.append(expression.normalize_domain(aml_domain))
             if mode not in date_domain_by_mode:
                 date_domain_by_mode[mode] = self.get_aml_domain_for_dates(
-                    date_from, date_to, mode, target_move
+                    date_from, date_to, mode
                 )
         assert aml_domains
         # TODO we could do this for more precision:
         #      AND(OR(aml_domains[mode]), date_domain[mode]) for each mode
         return expression.OR(aml_domains) + expression.OR(date_domain_by_mode.values())
 
-    def get_aml_domain_for_dates(self, date_from, date_to, mode, target_move):
+    def get_aml_domain_for_dates(self, date_from, date_to, mode):
         if mode == self.MODE_VARIATION:
             domain = [("date", ">=", date_from), ("date", "<=", date_to)]
         elif mode in (self.MODE_INITIAL, self.MODE_END):
@@ -292,10 +290,6 @@ class AccountingExpressionProcessor(object):
                 ("date", "<", fields.Date.to_string(fy_date_from)),
                 ("account_id.user_type_id.include_initial_balance", "=", False),
             ]
-        if target_move == "posted":
-            domain.append(("move_id.state", "=", "posted"))
-        elif target_move == "all":
-            domain.append(("move_id.state", "in", ("posted", "draft")))
         return expression.normalize_domain(domain)
 
     def _get_company_rates(self, date):
@@ -314,7 +308,6 @@ class AccountingExpressionProcessor(object):
         self,
         date_from,
         date_to,
-        target_move="posted",
         additional_move_line_filter=None,
         aml_model=None,
     ):
@@ -341,7 +334,7 @@ class AccountingExpressionProcessor(object):
                 continue
             if mode not in domain_by_mode:
                 domain_by_mode[mode] = self.get_aml_domain_for_dates(
-                    date_from, date_to, mode, target_move
+                    date_from, date_to, mode
                 )
             domain = list(domain) + domain_by_mode[mode]
             domain.append(("account_id", "in", self._map_account_ids[key]))
@@ -478,7 +471,7 @@ class AccountingExpressionProcessor(object):
             yield account_id, [self._ACC_RE.sub(f, expr) for expr in exprs]
 
     @classmethod
-    def _get_balances(cls, mode, companies, date_from, date_to, target_move="posted"):
+    def _get_balances(cls, mode, companies, date_from, date_to):
         expr = "deb{mode}[], crd{mode}[]".format(mode=mode)
         aep = AccountingExpressionProcessor(companies)
         # disable smart_end to have the data at once, instead
@@ -486,11 +479,11 @@ class AccountingExpressionProcessor(object):
         aep.smart_end = False
         aep.parse_expr(expr)
         aep.done_parsing()
-        aep.do_queries(date_from, date_to, target_move)
+        aep.do_queries(date_from, date_to)
         return aep._data[((), mode)]
 
     @classmethod
-    def get_balances_initial(cls, companies, date, target_move="posted"):
+    def get_balances_initial(cls, companies, date):
         """A convenience method to obtain the initial balances of all accounts
         at a given date.
 
@@ -498,14 +491,13 @@ class AccountingExpressionProcessor(object):
 
         :param companies:
         :param date:
-        :param target_move: if 'posted', consider only posted moves
 
         Returns a dictionary: {account_id, (debit, credit)}
         """
-        return cls._get_balances(cls.MODE_INITIAL, companies, date, date, target_move)
+        return cls._get_balances(cls.MODE_INITIAL, companies, date, date)
 
     @classmethod
-    def get_balances_end(cls, companies, date, target_move="posted"):
+    def get_balances_end(cls, companies, date):
         """A convenience method to obtain the ending balances of all accounts
         at a given date.
 
@@ -513,43 +505,34 @@ class AccountingExpressionProcessor(object):
 
         :param companies:
         :param date:
-        :param target_move: if 'posted', consider only posted moves
 
         Returns a dictionary: {account_id, (debit, credit)}
         """
-        return cls._get_balances(cls.MODE_END, companies, date, date, target_move)
+        return cls._get_balances(cls.MODE_END, companies, date, date)
 
     @classmethod
-    def get_balances_variation(
-        cls, companies, date_from, date_to, target_move="posted"
-    ):
+    def get_balances_variation(cls, companies, date_from, date_to):
         """A convenience method to obtain the variation of the
         balances of all accounts over a period.
 
         :param companies:
         :param date:
-        :param target_move: if 'posted', consider only posted moves
 
         Returns a dictionary: {account_id, (debit, credit)}
         """
-        return cls._get_balances(
-            cls.MODE_VARIATION, companies, date_from, date_to, target_move
-        )
+        return cls._get_balances(cls.MODE_VARIATION, companies, date_from, date_to)
 
     @classmethod
-    def get_unallocated_pl(cls, companies, date, target_move="posted"):
+    def get_unallocated_pl(cls, companies, date):
         """A convenience method to obtain the unallocated profit/loss
         of the previous fiscal years at a given date.
 
         :param companies:
         :param date:
-        :param target_move: if 'posted', consider only posted moves
 
         Returns a tuple (debit, credit)
         """
         # TODO shoud we include here the accounts of type "unaffected"
         # or leave that to the caller?
-        bals = cls._get_balances(
-            cls.MODE_UNALLOCATED, companies, date, date, target_move
-        )
+        bals = cls._get_balances(cls.MODE_UNALLOCATED, companies, date, date)
         return tuple(map(sum, zip(*bals.values())))

--- a/mis_builder/models/aep.py
+++ b/mis_builder/models/aep.py
@@ -294,6 +294,8 @@ class AccountingExpressionProcessor(object):
             ]
         if target_move == "posted":
             domain.append(("move_id.state", "=", "posted"))
+        elif target_move == "all":
+            domain.append(("move_id.state", "in", ("posted", "draft")))
         return expression.normalize_domain(domain)
 
     def _get_company_rates(self, date):

--- a/mis_builder/models/expression_evaluator.py
+++ b/mis_builder/models/expression_evaluator.py
@@ -15,14 +15,12 @@ class ExpressionEvaluator(object):
         aep,
         date_from,
         date_to,
-        target_move=None,
         additional_move_line_filter=None,
         aml_model=None,
     ):
         self.aep = aep
         self.date_from = date_from
         self.date_to = date_to
-        self.target_move = target_move
         self.additional_move_line_filter = additional_move_line_filter
         self.aml_model = aml_model
         self._aep_queries_done = False
@@ -32,7 +30,6 @@ class ExpressionEvaluator(object):
             self.aep.do_queries(
                 self.date_from,
                 self.date_to,
-                self.target_move,
                 self.additional_move_line_filter,
                 self.aml_model,
             )

--- a/mis_builder/models/mis_report.py
+++ b/mis_builder/models/mis_report.py
@@ -911,6 +911,10 @@ class MisReport(models.Model):
         return res
 
     @api.model
+    def _supports_target_move_filter(self, aml_model_name):
+        return "parent_state" in self.env[aml_model_name]._fields
+
+    @api.model
     def _get_target_move_domain(self, target_move, aml_model_name):
         """
         Obtain a domain to apply on a move-line-like model, to get posted
@@ -920,17 +924,16 @@ class MisReport(models.Model):
         :param: aml_model_name: an optional move-line-like model name
                 (defaults to accaount.move.line)
         """
-        if "parent_state" in self.env[aml_model_name]._fields:
-            if target_move == "posted":
-                return [("parent_state", "=", "posted")]
-            elif target_move == "all":
-                # all (in Odoo 13+, there is also the cancel state that we must ignore)
-                return [("parent_state", "in", ("posted", "draft"))]
-            else:
-                raise UserError(
-                    _("Unexpected value %s for target_move.") % (target_move,)
-                )
-        return []
+        if not self._supports_target_move_filter(aml_model_name):
+            return []
+
+        if target_move == "posted":
+            return [("parent_state", "=", "posted")]
+        elif target_move == "all":
+            # all (in Odoo 13+, there is also the cancel state that we must ignore)
+            return [("parent_state", "in", ("posted", "draft"))]
+        else:
+            raise UserError(_("Unexpected value %s for target_move.") % (target_move,))
 
     def evaluate(
         self,
@@ -978,7 +981,9 @@ class MisReport(models.Model):
             additional_move_line_filter,
             aml_model,
         )
-        return self._evaluate(expression_evaluator, subkpis_filter)
+        return self._evaluate(
+            expression_evaluator, subkpis_filter, get_additional_query_filter
+        )
 
     def _evaluate(
         self,

--- a/mis_builder/models/mis_report.py
+++ b/mis_builder/models/mis_report.py
@@ -210,7 +210,7 @@ class MisReportKpi(models.Model):
 
     @api.onchange("description")
     def _onchange_description(self):
-        """ construct name from description """
+        """construct name from description"""
         if self.description and not self.name:
             self.name = _python_var(self.description)
 
@@ -273,7 +273,7 @@ class MisReportSubkpi(models.Model):
 
     @api.onchange("description")
     def _onchange_description(self):
-        """ construct name from description """
+        """construct name from description"""
         if self.description and not self.name:
             self.name = _python_var(self.description)
 
@@ -790,7 +790,6 @@ class MisReport(models.Model):
         aep,
         date_from,
         date_to,
-        target_move,
         subkpis_filter=None,
         get_additional_move_line_filter=None,
         get_additional_query_filter=None,
@@ -806,7 +805,6 @@ class MisReport(models.Model):
             aep,
             date_from,
             date_to,
-            target_move,
             get_additional_move_line_filter()
             if get_additional_move_line_filter
             else None,
@@ -900,7 +898,7 @@ class MisReport(models.Model):
         )
 
     def get_kpis_by_account_id(self, company):
-        """ Return { account_id: set(kpi) } """
+        """Return { account_id: set(kpi) }"""
         aep = self._prepare_aep(company)
         res = defaultdict(set)
         for kpi in self.kpi_ids:
@@ -911,6 +909,28 @@ class MisReport(models.Model):
                 for account_id in account_ids:
                     res[account_id].add(kpi)
         return res
+
+    @api.model
+    def _get_target_move_domain(self, target_move, aml_model_name):
+        """
+        Obtain a domain to apply on a move-line-like model, to get posted
+        entries or return all of them (always excluding cancelled entries).
+
+        :param: target_move: all|posted
+        :param: aml_model_name: an optional move-line-like model name
+                (defaults to accaount.move.line)
+        """
+        if "parent_state" in self.env[aml_model_name]._fields:
+            if target_move == "posted":
+                return [("parent_state", "=", "posted")]
+            elif target_move == "all":
+                # all (in Odoo 13+, there is also the cancel state that we must ignore)
+                return [("parent_state", "in", ("posted", "draft"))]
+            else:
+                raise UserError(
+                    _("Unexpected value %s for target_move.") % (target_move,)
+                )
+        return []
 
     def evaluate(
         self,
@@ -930,7 +950,7 @@ class MisReport(models.Model):
         :param date_from, date_to: the starting and ending date
         :param target_move: all|posted
         :param aml_model: the name of a model that is compatible with
-                          account.move.line
+                          account.move.line (default: account.move.line)
         :param subkpis_filter: a list of subkpis to include in the evaluation
                                (if empty, use all subkpis)
         :param get_additional_move_line_filter: a bound method that takes
@@ -946,14 +966,16 @@ class MisReport(models.Model):
                  these should be ignored as they might be removed in
                  the future.
         """
+        additional_move_line_filter = self._get_target_move_domain(
+            target_move, aml_model or "account.move.line"
+        )
+        if get_additional_move_line_filter:
+            additional_move_line_filter.extend(get_additional_move_line_filter())
         expression_evaluator = ExpressionEvaluator(
             aep,
             date_from,
             date_to,
-            target_move,
-            get_additional_move_line_filter()
-            if get_additional_move_line_filter
-            else None,
+            additional_move_line_filter,
             aml_model,
         )
         return self._evaluate(expression_evaluator, subkpis_filter)

--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -405,13 +405,13 @@ class MisReportInstancePeriod(models.Model):
         compatible with account.move.line."""
         self.ensure_one()
         domain = self._get_filter_domain_from_context()
-        if (
-            self._get_aml_model_name() == "account.move.line"
-            and self.report_instance_id.target_move == "posted"
-        ):
-            domain.extend([("move_id.state", "=", "posted")])
-        elif self._get_aml_model_name() == "account.move.line":
-            domain.extend([("move_id.state", "in", ("posted", "draft"))])
+        aml_model_name = self._get_aml_model_name()
+        if aml_model_name:
+            domain.extend(
+                self.report_id._get_target_move_domain(
+                    self.report_instance_id.target_move, aml_model_name
+                )
+            )
         if self.analytic_account_id:
             domain.append(("analytic_account_id", "=", self.analytic_account_id.id))
         if self.analytic_group_id:
@@ -771,7 +771,6 @@ class MisReportInstance(models.Model):
             aep,
             period.date_from,
             period.date_to,
-            None,  # target_move now part of additional_move_line_filter
             period._get_additional_move_line_filter(),
             period._get_aml_model_name(),
         )
@@ -865,7 +864,6 @@ class MisReportInstance(models.Model):
                 expr,
                 period.date_from,
                 period.date_to,
-                None,  # target_move now part of additional_move_line_filter
                 account_id,
             )
             domain.extend(period._get_additional_move_line_filter())

--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -410,6 +410,8 @@ class MisReportInstancePeriod(models.Model):
             and self.report_instance_id.target_move == "posted"
         ):
             domain.extend([("move_id.state", "=", "posted")])
+        elif self._get_aml_model_name() == "account.move.line":
+            domain.extend([("move_id.state", "in", ("posted", "draft"))])
         if self.analytic_account_id:
             domain.append(("analytic_account_id", "=", self.analytic_account_id.id))
         if self.analytic_group_id:

--- a/mis_builder/tests/__init__.py
+++ b/mis_builder/tests/__init__.py
@@ -13,4 +13,5 @@ from . import test_mis_safe_eval
 from . import test_period_dates
 from . import test_render
 from . import test_simple_array
+from . import test_target_move
 from . import test_utc_midnight

--- a/mis_builder/tests/test_aep.py
+++ b/mis_builder/tests/test_aep.py
@@ -367,12 +367,15 @@ class TestAEP(common.TransactionCase):
                 ("account_id", "in", (self.account_ar.id,)),
                 ("credit", "<>", 0.0),
                 "&",
+                "&",
                 # for P&L accounts, only after fy start
                 "|",
                 ("date", ">=", "2017-01-01"),
                 ("account_id.user_type_id.include_initial_balance", "=", True),
                 # everything must be before from_date for initial balance
                 ("date", "<", "2017-02-01"),
+                # Cancel entries should be always ignored.
+                ("move_id.state", "in", ("posted", "draft")),
             ],
         )
 

--- a/mis_builder/tests/test_multi_company_aep.py
+++ b/mis_builder/tests/test_multi_company_aep.py
@@ -139,7 +139,6 @@ class TestMultiCompanyAEP(common.TransactionCase):
         aep.do_queries(
             date_from=fields.Date.to_string(date_from),
             date_to=fields.Date.to_string(date_to),
-            target_move="posted",
         )
         return aep
 

--- a/mis_builder/tests/test_target_move.py
+++ b/mis_builder/tests/test_target_move.py
@@ -1,0 +1,36 @@
+# Copyright 2016 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+import odoo.tests.common as common
+
+
+class TestMisReportInstance(common.TransactionCase):
+    def test_supports_target_move_filter(self):
+        self.assertTrue(
+            self.env["mis.report"]._supports_target_move_filter("account.move.line")
+        )
+
+    def test_supports_target_move_filter_no_parent_state(self):
+        self.assertFalse(
+            self.env["mis.report"]._supports_target_move_filter("account.move")
+        )
+
+    def test_target_move_domain_posted(self):
+        self.assertEqual(
+            self.env["mis.report"]._get_target_move_domain(
+                "posted", "account.move.line"
+            ),
+            [("parent_state", "=", "posted")],
+        )
+
+    def test_target_move_domain_all(self):
+        self.assertEqual(
+            self.env["mis.report"]._get_target_move_domain("all", "account.move.line"),
+            [("parent_state", "in", ("posted", "draft"))],
+        )
+
+    def test_target_move_domain_no_parent_state(self):
+        """Test get_target_move_domain on a model that has no parent_state."""
+        self.assertEqual(
+            self.env["mis.report"]._get_target_move_domain("all", "account.move"), []
+        )

--- a/mis_builder_budget/models/mis_report_instance.py
+++ b/mis_builder_budget/models/mis_report_instance.py
@@ -16,7 +16,6 @@ class MisBudgetAwareExpressionEvaluator(ExpressionEvaluator):
             aep=None,
             date_from=date_from,
             date_to=date_to,
-            target_move=None,
             additional_move_line_filter=additional_move_line_filter,
             aml_model=None,
         )

--- a/mis_builder_budget/models/mis_report_instance_period.py
+++ b/mis_builder_budget/models/mis_report_instance_period.py
@@ -50,7 +50,7 @@ class MisReportInstancePeriod(models.Model):
           [(field_name, {'value': value, 'operator': operator})]
 
         This default filter is the same as the one set by
-        _get_additional_move_line_filter on mis.report.instance, so
+        _get_additional_move_line_filter on mis.report.instance.period, so
         a budget.item is expected to have the same analytic fields as
         a move line.
 


### PR DESCRIPTION
supersedes #344 
closes #376

Use the `parent_state` field of `account.move.line` to filter entries in `posted` and `draft` state only. Before, when reporting in draft mode, all entries were used (i.e. there was no filter), and that started included the cancelled entries in Odoo 13.+.

This PR also contains a breaking change in the internal API. For quite a while the `target_move` argument of AEP and other methods was not used by MIS Builder itself and was kept for backward compatibility. To avoid rippling effects of the necessary change, we now remove this argument.

TODO
- [x] add a test for target_move=all