### PR TITLE
[12.0] FIX mis_builder when user does not have time zone set.

### DIFF
--- a/mis_builder/models/mis_report.py
+++ b/mis_builder/models/mis_report.py
@@ -601,10 +601,9 @@ class MisReport(models.Model):
                     ]
                 )
             else:
-                datetime_from = _utc_midnight(date_from, self._context.get("tz", "UTC"))
-                datetime_to = _utc_midnight(
-                    date_to, self._context.get("tz", "UTC"), add_day=1
-                )
+                tz = str(self.env["ir.fields.converter"]._input_tz())
+                datetime_from = _utc_midnight(date_from, tz)
+                datetime_to = _utc_midnight(date_to, tz, add_day=1)
                 domain.extend(
                     [
                         (query.date_field.name, ">=", datetime_from),


### PR DESCRIPTION
Steps:

 - Install mis_builder
 - Empty time zone field of your user, if present
 - Create a MIS report template, following for example https://oca-mis-builder.readthedocs.io/en/latest/usage.html#reporting-on-non-accounting-data-queries

Get
`AttributeError: 'bool' object has no attribute 'upper'`

