### PR TITLE
[14.0][FIX]mis_builder: do not pass bare module to safe_eval

### DIFF
--- a/mis_builder/models/mis_report.py
+++ b/mis_builder/models/mis_report.py
@@ -13,7 +13,12 @@ import pytz
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
 from odoo.models import expression as osv_expression
-from odoo.tools.safe_eval import safe_eval
+from odoo.tools.safe_eval import (
+    datetime as safe_datetime,
+    dateutil as safe_dateutil,
+    safe_eval,
+    time as safe_time,
+)
 
 from .accounting_none import AccountingNone
 from .aep import AccountingExpressionProcessor as AEP
@@ -583,9 +588,9 @@ class MisReport(models.Model):
             model = self.env[query.model_id.model]
             eval_context = {
                 "env": self.env,
-                "time": time,
-                "datetime": datetime,
-                "dateutil": dateutil,
+                "time": safe_time,
+                "datetime": safe_datetime,
+                "dateutil": safe_dateutil,
                 # deprecated
                 "uid": self.env.uid,
                 "context": self.env.context,


### PR DESCRIPTION
fixes #352 

When creating template with queries, it is impossible to render the report because of the following error:

`
File "/home/odoo-prod14/instance/venv-40.0.71/lib/python3.8/site-packages/odoo/addons/mis_builder/models/mis_report_instance.py", line 854, in compute
    kpi_matrix = self._compute_matrix()
  File "/home/odoo-prod14/instance/venv-40.0.71/lib/python3.8/site-packages/odoo/addons/mis_builder/models/mis_report_instance.py", line 847, in _compute_matrix
    self._add_column(aep, kpi_matrix, period, period.name, description)
  File "/home/odoo-prod14/instance/venv-40.0.71/lib/python3.8/site-packages/odoo/addons/mis_builder/models/mis_report_instance.py", line 814, in _add_column
    return self._add_column_move_lines(
  File "/home/odoo-prod14/instance/venv-40.0.71/lib/python3.8/site-packages/odoo/addons/mis_builder/models/mis_report_instance.py", line 783, in _add_column_move_lines
    self.report_id._declare_and_compute_period(
  File "/home/odoo-prod14/instance/venv-40.0.71/lib/python3.8/site-packages/odoo/addons/mis_builder/models/mis_report.py", line 882, in _declare_and_compute_period
    self._fetch_queries(
  File "/home/odoo-prod14/instance/venv-40.0.71/lib/python3.8/site-packages/odoo/addons/mis_builder/models/mis_report.py", line 593, in _fetch_queries
    domain = query.domain and safe_eval(query.domain, eval_context) or []
  File "/home/odoo-prod14/instance/venv-40.0.71/lib/python3.8/site-packages/odoo/tools/safe_eval.py", line 317, in safe_eval
    check_values(globals_dict)
  File "/home/odoo-prod14/instance/venv-40.0.71/lib/python3.8/site-packages/odoo/tools/safe_eval.py", line 371, in check_values
    raise TypeError(f"""Module {v} can not be used in evaluation contexts
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/odoo-prod14/instance/venv-40.0.71/lib/python3.8/site-packages/odoo/http.py", line 640, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/home/odoo-prod14/instance/venv-40.0.71/lib/python3.8/site-packages/odoo/http.py", line 316, in _handle_exception
    raise exception.with_traceback(None) from new_cause
TypeError: Module <module 'time' (built-in)> can not be used in evaluation contexts

Prefer providing only the items necessary for your intended use.

If a "module" is necessary for backwards compatibility, use
`odoo.tools.safe_eval.wrap_module` to generate a wrapper recursively
whitelisting allowed attributes.

Pre-wrapped modules are provided as attributes of `odoo.tools.safe_eval`.
`

This PR suggest a fix inspired by: https://github.com/odoo/odoo/commit/02e816877ec12471a1446ba894b5cfca309979da
