### PR TITLE
[mis_builder] generalize auto expands

### DIFF
--- a/mis_builder/migrations/8.0.2.0.0/pre-migration.py
+++ b/mis_builder/migrations/8.0.2.0.0/pre-migration.py
@@ -1,20 +1,38 @@
-# Copyright 2017 ACSONE SA/NV (<http://acsone.eu>)
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+# Copyright 2021 Ecosoft Co., Ltd. (http://ecosoft.co.th)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
 
 
-def migrate(cr, version):
-    cr.execute(
-        """
-        ALTER TABLE mis_report_kpi
-        RENAME COLUMN expression TO old_expression
-    """
-    )
-    # this migration to date_range type is partial,
-    # actual date ranges needs to be created manually
-    cr.execute(
-        """
-        UPDATE mis_report_instance_period
-        SET type='date_range'
-        WHERE type='fp'
-    """
-    )
+@openupgrade.migrate()
+def migrate(env, version):
+    old_column = "auto_expand_accounts"
+    new_column = "auto_expand"
+
+    if not openupgrade.column_exists(env.cr, "mis_report", new_column):
+        openupgrade.rename_fields(
+            env,
+            [
+                (
+                    "mis.report",
+                    "mis_report",
+                    old_column,
+                    new_column,
+                ),
+            ],
+        )
+    
+    old_column = "auto_expand_accounts_style_id"
+    new_column = "auto_expand_style_id"
+
+    if not openupgrade.column_exists(env.cr, "mis_report", new_column):
+        openupgrade.rename_fields(
+            env,
+            [
+                (
+                    "mis.report",
+                    "mis_report",
+                    old_column,
+                    new_column,
+                ),
+            ],
+        )

--- a/mis_builder/models/aep.py
+++ b/mis_builder/models/aep.py
@@ -431,66 +431,6 @@ class AccountingExpressionProcessor(object):
 
         return self._ACC_RE.sub(f, expr)
 
-    def replace_exprs_by_account_id(self, exprs):
-        """This method is depreciated and replaced by replace_exprs_by_row_detail.
-
-        Replace accounting variables in a list of expression
-        by their amount, iterating by accounts involved in the expression.
-        yields account_id, replaced_expr
-        This method must be executed after do_queries().
-        """
-
-        def f(mo):
-            field, mode, acc_domain, ml_domain = self._parse_match_object(mo)
-            key = (ml_domain, mode)
-            # first check if account_id is involved in
-            # the current expression part
-            if account_id not in self._account_ids_by_acc_domain[acc_domain]:
-                return "(AccountingNone)"
-            # here we know account_id is involved in acc_domain
-            account_ids_data = self._data[key][UNCLASSIFIED_ROW_DETAIL]
-            debit, credit = account_ids_data.get(
-                account_id, (AccountingNone, AccountingNone)
-            )
-            if field == "bal":
-                v = debit - credit
-            elif field == "pbal":
-                if debit >= credit:
-                    v = debit - credit
-                else:
-                    v = AccountingNone
-            elif field == "nbal":
-                if debit < credit:
-                    v = debit - credit
-                else:
-                    v = AccountingNone
-            elif field == "deb":
-                v = debit
-            elif field == "crd":
-                v = credit
-            # in initial balance mode, assume 0 is None
-            # as it does not make sense to distinguish 0 from "no data"
-            if (
-                v is not AccountingNone
-                and mode in (self.MODE_INITIAL, self.MODE_UNALLOCATED)
-                and float_is_zero(v, precision_digits=self.dp)
-            ):
-                v = AccountingNone
-            return "(" + repr(v) + ")"
-
-        account_ids = set()
-        for expr in exprs:
-            for mo in self._ACC_RE.finditer(expr):
-                field, mode, acc_domain, ml_domain = self._parse_match_object(mo)
-                key = (ml_domain, mode)
-                account_ids_data = self._data[key][UNCLASSIFIED_ROW_DETAIL]
-                for account_id in self._account_ids_by_acc_domain[acc_domain]:
-                    if account_id in account_ids_data:
-                        account_ids.add(account_id)
-
-        for account_id in account_ids:
-            yield account_id, [self._ACC_RE.sub(f, expr) for expr in exprs]
-
     def replace_exprs_by_row_detail(self, exprs):
         """Replace accounting variables in a list of expression
         by their amount, iterating by accounts involved in the expression.

--- a/mis_builder/models/kpimatrix.py
+++ b/mis_builder/models/kpimatrix.py
@@ -471,9 +471,9 @@ class KpiMatrix(object):
         rdi_ids = list(rdi_ids)
         if UNCLASSIFIED_ROW_DETAIL in rdi_ids:
             rdi_ids.remove(UNCLASSIFIED_ROW_DETAIL)
-        rdis = self._rdi_model.search([("id", "in", rdi_ids)])
+        rdis = self._rdi_model.with_context(test_active=False).search([("id", "in", rdi_ids)])
         self._rdi_names = {rdi.id: self._get_rdi_name(rdi) for rdi in rdis}
-        self._rdi_names[UNCLASSIFIED_ROW_DETAIL] = _("Other")
+        self._rdi_names[UNCLASSIFIED_ROW_DETAIL] = _("(not set)")
 
     def _get_rdi_name(self, rdi):
         result = rdi.name_get()[0][1]

--- a/mis_builder/models/mis_report.py
+++ b/mis_builder/models/mis_report.py
@@ -92,9 +92,8 @@ class MisReportKpi(models.Model):
         string="Expressions",
     )
 
-    # TODO : this fields should be renamed to auto_expand_details or something like this
-    auto_expand_accounts = fields.Boolean(string="Display details")
-    auto_expand_accounts_style_id = fields.Many2one(
+    auto_expand = fields.Boolean(string="Display details")
+    auto_expand_style_id = fields.Many2one(
         string="Style for details rows", comodel_name="mis.report.style", required=False
     )
     style_id = fields.Many2one(
@@ -767,7 +766,7 @@ class MisReport(models.Model):
                     continue
 
                 rdis = expression_evaluator.eval_expressions_by_row_detail(
-                    expressions, locals_dict  # , self.auto_expand_col_name
+                    expressions, locals_dict
                 )
                 for (rdi, vals, drilldown_args, _name_error) in rdis:
                     for drilldown_arg in drilldown_args:

--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -887,6 +887,10 @@ class MisReportInstance(models.Model):
                 account_id,
             )
             domain.extend(period._get_additional_move_line_filter())
+            if arg.get("auto_expand_id") and arg.get("auto_expand_col_name"):
+                domain.extend(
+                    [(arg.get("auto_expand_col_name"), "=", arg.get("auto_expand_id"))]
+                )
             return {
                 "name": self._get_drilldown_action_name(arg),
                 "domain": domain,

--- a/mis_builder/tests/test_mis_report_instance.py
+++ b/mis_builder/tests/test_mis_report_instance.py
@@ -376,22 +376,22 @@ class TestMisReportInstance(common.HttpCase):
                 "company_ids": [(6, 0, self.report_instance.company_id.ids)],
             }
         )
+        self.report_instance.report_id.write({"auto_expand_col_name": "account_id"})
         self.report_instance.report_id.kpi_ids.write({"auto_expand_accounts": True})
         matrix = self.report_instance._compute_matrix()
         for row in matrix.iter_rows():
-            if row.account_id:
-                account = self.env["account.account"].browse(row.account_id)
+            if row.row_detail_identifier:
+                account = self.env["account.account"].browse(row.row_detail_identifier)
                 self.assertEqual(
                     row.label,
-                    "%s %s [%s]"
-                    % (account.code, account.name, account.company_id.name),
+                    "%s [%s]" % (account.name_get()[0][1], account.company_id.name),
                 )
         self.report_instance.write({"multi_company": False})
         matrix = self.report_instance._compute_matrix()
         for row in matrix.iter_rows():
-            if row.account_id:
-                account = self.env["account.account"].browse(row.account_id)
-                self.assertEqual(row.label, "{} {}".format(account.code, account.name))
+            if row.row_detail_identifier:
+                account = self.env["account.account"].browse(row.row_detail_identifier)
+                self.assertEqual(row.label, account.name_get()[0][1])
 
     def test_evaluate(self):
         company = self.env.ref("base.main_company")

--- a/mis_builder/tests/test_mis_report_instance.py
+++ b/mis_builder/tests/test_mis_report_instance.py
@@ -381,7 +381,7 @@ class TestMisReportInstance(common.HttpCase):
         matrix = self.report_instance._compute_matrix()
         for row in matrix.iter_rows():
             if row.row_detail_identifier:
-                account = self.env["account.account"].browse(row.row_detail_identifier)
+                account = self.env[row.row_detail_model].browse(row.row_detail_identifier)
                 self.assertEqual(
                     row.label,
                     "%s [%s]" % (account.name_get()[0][1], account.company_id.name),
@@ -390,7 +390,7 @@ class TestMisReportInstance(common.HttpCase):
         matrix = self.report_instance._compute_matrix()
         for row in matrix.iter_rows():
             if row.row_detail_identifier:
-                account = self.env["account.account"].browse(row.row_detail_identifier)
+                account = self.env[row.row_detail_model].browse(row.row_detail_identifier)
                 self.assertEqual(row.label, account.name_get()[0][1])
 
     def test_evaluate(self):

--- a/mis_builder/views/mis_report.xml
+++ b/mis_builder/views/mis_report.xml
@@ -20,6 +20,7 @@
                         <field name="name" />
                         <field name="description" />
                         <field name="style_id" />
+                        <field name="auto_expand_col_name" />
                         <field name="move_lines_source" options="{'no_open': true}" />
                     </group>
                     <notebook>


### PR DESCRIPTION
This is very far form mergability, 
it's purpose is to discuss an implementation of #115 (#392)

To do / to discuss : 

- how to choose which details lines to show (typicically for accounts, we need only the accounts included in the kpi expression)
We may have a domain field here : 
![image](https://user-images.githubusercontent.com/9885447/147001616-2635d189-d618-4267-b974-b2ca540b5c03.png)

 - fix the drilldown (should not be a problem)

- optimisation issues 
Now the PR multiply the query number by the number of details line, to solve this we would need to add a group_by clause here : https://github.com/OCA/mis-builder/blob/90702af67af96d305b00eb11c5bf0bab2a42d6fe/mis_builder/models/aep.py#L355
but that would mean a details kind could not provide a domain for each line but a field for all line
that would also automatically solve the problem of wich details line we display
(We could get back wich lines to show from aep here instead having them from the report model here : https://github.com/OCA/mis-builder/blob/90702af67af96d305b00eb11c5bf0bab2a42d6fe/mis_builder/models/mis_report.py#L771)

- !! TEST !!

- genericity of the details line model
in the PR, i make account_account and account_analytic_account extends RowDetailIdentifierInterface
it prevent it to be compatible with account_move_line compatible model (budget, actuals, ..)
the right approach would be to encapsulate the right aml fields in the RowDetailIdentifierInterface

- make it easy to extend : 
split the _get_row_detail_identifiers in many _get_row_detail_identifiers_for_{} 