### PR TITLE
Set mis_builder version to 4.0

### DIFF
--- a/mis_builder/__manifest__.py
+++ b/mis_builder/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "MIS Builder",
-    "version": "15.0.1.0.1",
+    "version": "15.0.4.0.0",
     "category": "Reporting",
     "summary": """
         Build 'Management Information System' Reports and Dashboards


### PR DESCRIPTION
I like to keep minor and major version aligned across series, to communicate the feature level, as I try to forward and backport features.