### PR TITLE
[15.0] remove u string prefixes

### DIFF
--- a/mis_builder/models/kpimatrix.py
+++ b/mis_builder/models/kpimatrix.py
@@ -244,13 +244,13 @@ class KpiMatrix(object):
                     self.lang, row.style_props, kpi.type, val
                 )
                 if row.kpi.multi and subcol.subkpi:
-                    val_comment = u"{}.{} = {}".format(
+                    val_comment = "{}.{} = {}".format(
                         row.kpi.name,
                         subcol.subkpi.name,
                         row.kpi._get_expression_str_for_subkpi(subcol.subkpi),
                     )
                 else:
-                    val_comment = u"{} = {}".format(row.kpi.name, row.kpi.expression)
+                    val_comment = "{} = {}".format(row.kpi.name, row.kpi.expression)
             cell_style_props = row.style_props
             if row.kpi.style_expression:
                 # evaluate style expression
@@ -313,7 +313,7 @@ class KpiMatrix(object):
                     )
                 )
             if not label:
-                label = u"{} vs {}".format(col.label, base_col.label)
+                label = "{} vs {}".format(col.label, base_col.label)
             comparison_col = KpiMatrixCol(
                 cmpcol_key,
                 label,
@@ -470,9 +470,9 @@ class KpiMatrix(object):
         self._account_names = {a.id: self._get_account_name(a) for a in accounts}
 
     def _get_account_name(self, account):
-        result = u"{} {}".format(account.code, account.name)
+        result = "{} {}".format(account.code, account.name)
         if self._multi_company:
-            result = u"{} [{}]".format(result, account.company_id.name)
+            result = "{} [{}]".format(result, account.company_id.name)
         return result
 
     def get_account_name(self, account_id):

--- a/mis_builder/models/mis_kpi_data.py
+++ b/mis_builder/models/mis_kpi_data.py
@@ -62,7 +62,7 @@ class MisKpiData(models.AbstractModel):
                 subkpi_name = "." + subkpi_name
             else:
                 subkpi_name = ""
-            rec.name = u"{}{}: {} - {}".format(
+            rec.name = "{}{}: {} - {}".format(
                 rec.kpi_expression_id.kpi_id.name,
                 subkpi_name,
                 rec.date_from,

--- a/mis_builder/models/mis_report.py
+++ b/mis_builder/models/mis_report.py
@@ -144,7 +144,7 @@ class MisReportKpi(models.Model):
     def name_get(self):
         res = []
         for rec in self:
-            name = u"{} ({})".format(rec.description, rec.name)
+            name = "{} ({})".format(rec.description, rec.name)
             res.append((rec.id, name))
         return res
 
@@ -171,7 +171,7 @@ class MisReportKpi(models.Model):
             for expression in kpi.expression_ids:
                 if expression.subkpi_id:
                     exprs.append(
-                        u"{}\xa0=\xa0{}".format(
+                        "{}\xa0=\xa0{}".format(
                             expression.subkpi_id.name, expression.name
                         )
                     )
@@ -308,7 +308,7 @@ class MisReportKpiExpression(models.Model):
             kpi = rec.kpi_id
             subkpi = rec.subkpi_id
             if subkpi:
-                name = u"{} / {} ({}.{})".format(
+                name = "{} / {} ({}.{})".format(
                     kpi.description, subkpi.description, kpi.name, subkpi.name
                 )
             else:

--- a/mis_builder/models/mis_report_style.py
+++ b/mis_builder/models/mis_report_style.py
@@ -177,14 +177,14 @@ class MisReportKpiStyle(models.Model):
     ):
         # format number following user language
         if value is None or value is AccountingNone:
-            return u""
+            return ""
         value = round(value / float(divider or 1), dp or 0) or 0
         r = lang.format("%%%s.%df" % (sign, dp or 0), value, grouping=True)
-        r = r.replace("-", u"\N{NON-BREAKING HYPHEN}")
+        r = r.replace("-", "\N{NON-BREAKING HYPHEN}")
         if prefix:
-            r = prefix + u"\N{NO-BREAK SPACE}" + r
+            r = prefix + "\N{NO-BREAK SPACE}" + r
         if suffix:
-            r = r + u"\N{NO-BREAK SPACE}" + suffix
+            r = r + "\N{NO-BREAK SPACE}" + suffix
         return r
 
     @api.model
@@ -194,7 +194,7 @@ class MisReportKpiStyle(models.Model):
     @api.model
     def render_str(self, lang, value):
         if value is None or value is AccountingNone:
-            return u""
+            return ""
         return unicode(value)
 
     @api.model
@@ -275,20 +275,20 @@ class MisReportKpiStyle(models.Model):
             ("bg_color", props.background_color),
         ]
         if type == TYPE_NUM:
-            num_format = u"#,##0"
+            num_format = "#,##0"
             if props.dp:
-                num_format += u"."
-                num_format += u"0" * props.dp
+                num_format += "."
+                num_format += "0" * props.dp
             if props.prefix:
-                num_format = u'"{} "{}'.format(props.prefix, num_format)
+                num_format = '"{} "{}'.format(props.prefix, num_format)
             if props.suffix:
-                num_format = u'{}" {}"'.format(num_format, props.suffix)
+                num_format = '{}" {}"'.format(num_format, props.suffix)
             xlsx_attributes.append(("num_format", num_format))
         elif type == TYPE_PCT:
-            num_format = u"0"
+            num_format = "0"
             if props.dp:
-                num_format += u"."
-                num_format += u"0" * props.dp
+                num_format += "."
+                num_format += "0" * props.dp
             num_format += "%"
             xlsx_attributes.append(("num_format", num_format))
         if props.indent_level is not None and not no_indent:

--- a/mis_builder/report/mis_report_instance_xlsx.py
+++ b/mis_builder/report/mis_report_instance_xlsx.py
@@ -33,8 +33,8 @@ class MisBuilderXlsx(models.AbstractModel):
         style_obj = self.env["mis.report.style"]
 
         # create worksheet
-        report_name = u"{} - {}".format(
-            objects[0].name, u", ".join([a.name for a in objects[0].query_company_ids])
+        report_name = "{} - {}".format(
+            objects[0].name, ", ".join([a.name for a in objects[0].query_company_ids])
         )
         sheet = workbook.add_worksheet(report_name[:31])
         row_pos = 0

--- a/mis_builder/tests/test_render.py
+++ b/mis_builder/tests/test_render.py
@@ -37,146 +37,144 @@ class TestRendering(common.TransactionCase):
             return r
 
     def test_render(self):
-        self.assertEqual(u"1", self._render(1))
-        self.assertEqual(u"1", self._render(1.1))
-        self.assertEqual(u"2", self._render(1.6))
+        self.assertEqual("1", self._render(1))
+        self.assertEqual("1", self._render(1.1))
+        self.assertEqual("2", self._render(1.6))
         self.style.dp_inherit = False
         self.style.dp = 2
-        self.assertEqual(u"1.00", self._render(1))
-        self.assertEqual(u"1.10", self._render(1.1))
-        self.assertEqual(u"1.60", self._render(1.6))
-        self.assertEqual(u"1.61", self._render(1.606))
-        self.assertEqual(u"12,345.67", self._render(12345.67))
+        self.assertEqual("1.00", self._render(1))
+        self.assertEqual("1.10", self._render(1.1))
+        self.assertEqual("1.60", self._render(1.6))
+        self.assertEqual("1.61", self._render(1.606))
+        self.assertEqual("12,345.67", self._render(12345.67))
 
     def test_render_negative(self):
         # non breaking hyphen
-        self.assertEqual(u"\u20111", self._render(-1))
+        self.assertEqual("\u20111", self._render(-1))
 
     def test_render_zero(self):
-        self.assertEqual(u"0", self._render(0))
-        self.assertEqual(u"", self._render(None))
-        self.assertEqual(u"", self._render(AccountingNone))
+        self.assertEqual("0", self._render(0))
+        self.assertEqual("", self._render(None))
+        self.assertEqual("", self._render(AccountingNone))
 
     def test_render_suffix(self):
         self.style.suffix_inherit = False
-        self.style.suffix = u"€"
-        self.assertEqual(u"1\xa0€", self._render(1))
-        self.style.suffix = u"k€"
+        self.style.suffix = "€"
+        self.assertEqual("1\xa0€", self._render(1))
+        self.style.suffix = "k€"
         self.style.divider_inherit = False
         self.style.divider = "1e3"
-        self.assertEqual(u"1\xa0k€", self._render(1000))
+        self.assertEqual("1\xa0k€", self._render(1000))
 
     def test_render_prefix(self):
         self.style.prefix_inherit = False
-        self.style.prefix = u"$"
-        self.assertEqual(u"$\xa01", self._render(1))
-        self.style.prefix = u"k$"
+        self.style.prefix = "$"
+        self.assertEqual("$\xa01", self._render(1))
+        self.style.prefix = "k$"
         self.style.divider_inherit = False
         self.style.divider = "1e3"
-        self.assertEqual(u"k$\xa01", self._render(1000))
+        self.assertEqual("k$\xa01", self._render(1000))
 
     def test_render_divider(self):
         self.style.divider_inherit = False
         self.style.divider = "1e3"
         self.style.dp_inherit = False
         self.style.dp = 0
-        self.assertEqual(u"1", self._render(1000))
+        self.assertEqual("1", self._render(1000))
         self.style.divider = "1e6"
         self.style.dp = 3
-        self.assertEqual(u"0.001", self._render(1000))
+        self.assertEqual("0.001", self._render(1000))
         self.style.divider = "1e-3"
         self.style.dp = 0
-        self.assertEqual(u"1,000", self._render(1))
+        self.assertEqual("1,000", self._render(1))
         self.style.divider = "1e-6"
         self.style.dp = 0
-        self.assertEqual(u"1,000,000", self._render(1))
+        self.assertEqual("1,000,000", self._render(1))
 
     def test_render_pct(self):
-        self.assertEqual(u"100\xa0%", self._render(1, TYPE_PCT))
-        self.assertEqual(u"50\xa0%", self._render(0.5, TYPE_PCT))
+        self.assertEqual("100\xa0%", self._render(1, TYPE_PCT))
+        self.assertEqual("50\xa0%", self._render(0.5, TYPE_PCT))
         self.style.dp_inherit = False
         self.style.dp = 2
-        self.assertEqual(u"51.23\xa0%", self._render(0.5123, TYPE_PCT))
+        self.assertEqual("51.23\xa0%", self._render(0.5123, TYPE_PCT))
 
     def test_render_string(self):
-        self.assertEqual(u"", self._render("", TYPE_STR))
-        self.assertEqual(u"", self._render(None, TYPE_STR))
-        self.assertEqual(u"abcdé", self._render(u"abcdé", TYPE_STR))
+        self.assertEqual("", self._render("", TYPE_STR))
+        self.assertEqual("", self._render(None, TYPE_STR))
+        self.assertEqual("abcdé", self._render("abcdé", TYPE_STR))
 
     def test_compare_num_pct(self):
-        self.assertEqual((1.0, u"+100.0\xa0%"), self._compare_and_render(100, 50))
-        self.assertEqual((0.5, u"+50.0\xa0%"), self._compare_and_render(75, 50))
-        self.assertEqual((0.5, u"+50.0\xa0%"), self._compare_and_render(-25, -50))
-        self.assertEqual((1.0, u"+100.0\xa0%"), self._compare_and_render(0, -50))
-        self.assertEqual((2.0, u"+200.0\xa0%"), self._compare_and_render(50, -50))
-        self.assertEqual((-0.5, u"\u201150.0\xa0%"), self._compare_and_render(25, 50))
-        self.assertEqual((-1.0, u"\u2011100.0\xa0%"), self._compare_and_render(0, 50))
-        self.assertEqual((-2.0, u"\u2011200.0\xa0%"), self._compare_and_render(-50, 50))
-        self.assertEqual((-0.5, u"\u201150.0\xa0%"), self._compare_and_render(-75, -50))
+        self.assertEqual((1.0, "+100.0\xa0%"), self._compare_and_render(100, 50))
+        self.assertEqual((0.5, "+50.0\xa0%"), self._compare_and_render(75, 50))
+        self.assertEqual((0.5, "+50.0\xa0%"), self._compare_and_render(-25, -50))
+        self.assertEqual((1.0, "+100.0\xa0%"), self._compare_and_render(0, -50))
+        self.assertEqual((2.0, "+200.0\xa0%"), self._compare_and_render(50, -50))
+        self.assertEqual((-0.5, "\u201150.0\xa0%"), self._compare_and_render(25, 50))
+        self.assertEqual((-1.0, "\u2011100.0\xa0%"), self._compare_and_render(0, 50))
+        self.assertEqual((-2.0, "\u2011200.0\xa0%"), self._compare_and_render(-50, 50))
+        self.assertEqual((-0.5, "\u201150.0\xa0%"), self._compare_and_render(-75, -50))
         self.assertEqual(
-            (AccountingNone, u""), self._compare_and_render(50, AccountingNone)
+            (AccountingNone, ""), self._compare_and_render(50, AccountingNone)
         )
-        self.assertEqual((AccountingNone, u""), self._compare_and_render(50, None))
-        self.assertEqual((AccountingNone, u""), self._compare_and_render(50, 50))
-        self.assertEqual((0.002, u"+0.2\xa0%"), self._compare_and_render(50.1, 50))
-        self.assertEqual((AccountingNone, u""), self._compare_and_render(50.01, 50))
+        self.assertEqual((AccountingNone, ""), self._compare_and_render(50, None))
+        self.assertEqual((AccountingNone, ""), self._compare_and_render(50, 50))
+        self.assertEqual((0.002, "+0.2\xa0%"), self._compare_and_render(50.1, 50))
+        self.assertEqual((AccountingNone, ""), self._compare_and_render(50.01, 50))
         self.assertEqual(
-            (-1.0, u"\u2011100.0\xa0%"), self._compare_and_render(AccountingNone, 50)
+            (-1.0, "\u2011100.0\xa0%"), self._compare_and_render(AccountingNone, 50)
         )
+        self.assertEqual((-1.0, "\u2011100.0\xa0%"), self._compare_and_render(None, 50))
         self.assertEqual(
-            (-1.0, u"\u2011100.0\xa0%"), self._compare_and_render(None, 50)
-        )
-        self.assertEqual(
-            (AccountingNone, u""), self._compare_and_render(DataError("#ERR", "."), 1)
+            (AccountingNone, ""), self._compare_and_render(DataError("#ERR", "."), 1)
         )
         self.assertEqual(
-            (AccountingNone, u""), self._compare_and_render(1, DataError("#ERR", "."))
+            (AccountingNone, ""), self._compare_and_render(1, DataError("#ERR", "."))
         )
 
     def test_compare_num_diff(self):
         self.assertEqual(
-            (25, u"+25"), self._compare_and_render(75, 50, TYPE_NUM, CMP_DIFF)
+            (25, "+25"), self._compare_and_render(75, 50, TYPE_NUM, CMP_DIFF)
         )
         self.assertEqual(
-            (-25, u"\u201125"), self._compare_and_render(25, 50, TYPE_NUM, CMP_DIFF)
+            (-25, "\u201125"), self._compare_and_render(25, 50, TYPE_NUM, CMP_DIFF)
         )
         self.style.suffix_inherit = False
-        self.style.suffix = u"€"
+        self.style.suffix = "€"
         self.assertEqual(
-            (-25, u"\u201125\xa0€"),
+            (-25, "\u201125\xa0€"),
             self._compare_and_render(25, 50, TYPE_NUM, CMP_DIFF),
         )
-        self.style.suffix = u""
+        self.style.suffix = ""
         self.assertEqual(
-            (50.0, u"+50"),
+            (50.0, "+50"),
             self._compare_and_render(50, AccountingNone, TYPE_NUM, CMP_DIFF),
         )
         self.assertEqual(
-            (50.0, u"+50"), self._compare_and_render(50, None, TYPE_NUM, CMP_DIFF)
+            (50.0, "+50"), self._compare_and_render(50, None, TYPE_NUM, CMP_DIFF)
         )
         self.assertEqual(
-            (-50.0, u"\u201150"),
+            (-50.0, "\u201150"),
             self._compare_and_render(AccountingNone, 50, TYPE_NUM, CMP_DIFF),
         )
         self.assertEqual(
-            (-50.0, u"\u201150"), self._compare_and_render(None, 50, TYPE_NUM, CMP_DIFF)
+            (-50.0, "\u201150"), self._compare_and_render(None, 50, TYPE_NUM, CMP_DIFF)
         )
         self.style.dp_inherit = False
         self.style.dp = 2
         self.assertEqual(
-            (0.1, u"+0.10"), self._compare_and_render(1.1, 1.0, TYPE_NUM, CMP_DIFF)
+            (0.1, "+0.10"), self._compare_and_render(1.1, 1.0, TYPE_NUM, CMP_DIFF)
         )
         self.assertEqual(
-            (AccountingNone, u""),
+            (AccountingNone, ""),
             self._compare_and_render(1.001, 1.0, TYPE_NUM, CMP_DIFF),
         )
 
     def test_compare_pct(self):
         self.assertEqual(
-            (0.25, u"+25\xa0pp"), self._compare_and_render(0.75, 0.50, TYPE_PCT)
+            (0.25, "+25\xa0pp"), self._compare_and_render(0.75, 0.50, TYPE_PCT)
         )
         self.assertEqual(
-            (AccountingNone, u""), self._compare_and_render(0.751, 0.750, TYPE_PCT)
+            (AccountingNone, ""), self._compare_and_render(0.751, 0.750, TYPE_PCT)
         )
 
     def test_compare_pct_result_type(self):
@@ -271,9 +269,9 @@ class TestRendering(common.TransactionCase):
                 "italic": True,
                 "bold": True,
                 "size": 9,
-                "font_color": u"#FF0000",
-                "bg_color": u"#0000FF",
-                "num_format": u'"p "#,##0.00" s"',
+                "font_color": "#FF0000",
+                "bg_color": "#0000FF",
+                "num_format": '"p "#,##0.00" s"',
                 "indent": 2,
             },
         )
@@ -284,9 +282,9 @@ class TestRendering(common.TransactionCase):
                 "italic": True,
                 "bold": True,
                 "size": 9,
-                "font_color": u"#FF0000",
-                "bg_color": u"#0000FF",
-                "num_format": u'"p "#,##0.00" s"',
+                "font_color": "#FF0000",
+                "bg_color": "#0000FF",
+                "num_format": '"p "#,##0.00" s"',
             },
         )
         # percent type ignore prefix and suffix
@@ -297,9 +295,9 @@ class TestRendering(common.TransactionCase):
                 "italic": True,
                 "bold": True,
                 "size": 9,
-                "font_color": u"#FF0000",
-                "bg_color": u"#0000FF",
-                "num_format": u"0.00%",
+                "font_color": "#FF0000",
+                "bg_color": "#0000FF",
+                "num_format": "0.00%",
             },
         )
 
@@ -311,7 +309,7 @@ class TestRendering(common.TransactionCase):
                 "italic": True,
                 "bold": True,
                 "size": 9,
-                "font_color": u"#FF0000",
-                "bg_color": u"#0000FF",
+                "font_color": "#FF0000",
+                "bg_color": "#0000FF",
             },
         )


### PR DESCRIPTION
Remove a bunch of unicode string prefixes that are useless in python 3.