### PR TITLE
[14.0][FIX] mis_builder: Be tolerant in tests with several installed companies

### DIFF
--- a/mis_builder/tests/test_mis_report_instance.py
+++ b/mis_builder/tests/test_mis_report_instance.py
@@ -409,7 +409,14 @@ class TestMisReportInstance(common.HttpCase):
             dict(expr="balp[200%]", period_id=self.report_instance.period_ids[0].id)
         )
         account_ids = (
-            self.env["account.account"].search([("code", "=like", "200%")]).ids
+            self.env["account.account"]
+            .search(
+                [
+                    ("code", "=like", "200%"),
+                    ("company_id", "=", self.env.ref("base.main_company").id),
+                ]
+            )
+            .ids
         )
         self.assertTrue(("account_id", "in", tuple(account_ids)) in action["domain"])
         self.assertEqual(action["res_model"], "account.move.line")
@@ -465,7 +472,14 @@ class TestMisReportInstance(common.HttpCase):
 
     def test_get_kpis_by_account_id(self):
         account_ids = (
-            self.env["account.account"].search([("code", "=like", "200%")]).mapped("id")
+            self.env["account.account"]
+            .search(
+                [
+                    ("code", "=like", "200%"),
+                    ("company_id", "=", self.env.ref("base.main_company").id),
+                ]
+            )
+            .ids
         )
         kpi200 = {self.kpi1, self.kpi2}
         res = self.report.get_kpis_by_account_id(self.env.ref("base.main_company"))
@@ -510,7 +524,7 @@ class TestMisReportInstance(common.HttpCase):
         self.report_instance.company_ids |= c1
         self.report_instance.company_ids |= c2
         assert len(self.report_instance.company_ids) == 2
-        assert self.report_instance.query_company_ids == self.env.companies
+        self.assertFalse(self.report_instance.query_company_ids - self.env.companies)
         # In a user context where there is only one company, ensure
         # query_company_ids only has one company too.
         assert (


### PR DESCRIPTION
If you are running tests in a integrated environment, you can have more than one company with the same account 200x, so we need to filter on the current active company.
    
We may have as well more companies as authorized ones, so let's assert the proper thing in `test_query_company_ids`.

@Tecnativa