### PR TITLE
[FIX] For sub-kpi the expressions is a list

### DIFF
--- a/mis_builder_budget/models/mis_report_instance.py
+++ b/mis_builder_budget/models/mis_report_instance.py
@@ -22,9 +22,17 @@ class MisBudgetAwareExpressionEvaluator(ExpressionEvaluator):
         self.kpi_data = kpi_data
 
     def eval_expressions(self, expressions, locals_dict):
-        kpi_id = expressions.mapped("kpi_id")
-        assert len(kpi_id) == 1
-        if kpi_id.budgetable:
+        # find the kpi (expressions may be a list)
+        if expressions and expressions[0] is not None:
+            expressions_obj = expressions[0]
+            for expr in expressions:
+                expressions_obj |= expr
+            kpi_id = expressions_obj.kpi_id
+            assert len(kpi_id) == 1
+        else:
+            kpi_id = False
+
+        if kpi_id and kpi_id.budgetable:
             vals = []
             drilldown_args = []
             for expression in expressions:


### PR DESCRIPTION
There is a bug in 14.0 if you use budgets with sub-kpi's with the stacktrace below when rendering a report with sub-kpi's and budgets.
The function `eval_expressions()` tries to call `expressions.mapped` which is not always an Odoo model instance. The value of `expressions` comes from `mis_builder/models/mis_report.py: _get_expressions` which returns a python list (most of the time).

```
  File "/home/odoo/src/user/addons-community/mis_builder/models/mis_report_instance.py", line 868, in compute
    kpi_matrix = self._compute_matrix()
  File "/home/odoo/src/user/addons-community/mis_builder/models/mis_report_instance.py", line 861, in _compute_matrix
    self._add_column(aep, kpi_matrix, period, period.name, description)
  File "/home/odoo/src/user/addons-community/mis_builder_budget/models/mis_report_instance.py", line 73, in _add_column
    return self._add_column_mis_budget(
  File "/home/odoo/src/user/addons-community/mis_builder_budget/models/mis_report_instance.py", line 60, in _add_column_mis_budget
    return self.report_id._declare_and_compute_period(
  File "/home/odoo/src/user/addons-community/mis_builder/models/mis_report.py", line 885, in _declare_and_compute_period
    self._declare_and_compute_col(
  File "/home/odoo/src/user/addons-community/mis_builder/models/mis_report.py", line 691, in _declare_and_compute_col
    ) = expression_evaluator.eval_expressions(expressions, locals_dict)
  File "/home/odoo/src/user/addons-community/mis_builder_budget/models/mis_report_instance.py", line 25, in eval_expressions
    kpi_id = expressions.mapped("kpi_id")
Exception

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/odoo/src/odoo/odoo/http.py", line 641, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/home/odoo/src/odoo/odoo/http.py", line 317, in _handle_exception
    raise exception.with_traceback(None) from new_cause
AttributeError: 'list' object has no attribute 'mapped'
```
