### PR TITLE
[IMP] mis_builder: child_ of for analytic account group filtering

### DIFF
--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -421,7 +421,7 @@ class MisReportInstancePeriod(models.Model):
             domain.append(("analytic_account_id", "=", self.analytic_account_id.id))
         if self.analytic_group_id:
             domain.append(
-                ("analytic_account_id.group_id", "=", self.analytic_group_id.id)
+                ("analytic_account_id.group_id", "child_of", self.analytic_group_id.id)
             )
         for tag in self.analytic_tag_ids:
             domain.append(("analytic_tag_ids", "=", tag.id))
@@ -720,7 +720,7 @@ class MisReportInstance(models.Model):
         if self.analytic_group_id:
             context["mis_report_filters"]["analytic_account_id.group_id"] = {
                 "value": self.analytic_group_id.id,
-                "operator": "=",
+                "operator": "child_of",
             }
         if self.analytic_tag_ids:
             context["mis_report_filters"]["analytic_tag_ids"] = {

--- a/mis_builder/static/src/js/mis_report_widget.js
+++ b/mis_builder/static/src/js/mis_report_widget.js
@@ -356,7 +356,7 @@ odoo.define("mis_builder.widget", function (require) {
                     self._setFilterValue(
                         self.analytic_group_filter_name,
                         self.analytic_group_id_m2o.value.res_id,
-                        "="
+                        "child_of"
                     );
                 } else {
                     self._setFilterValue(self.analytic_group_filter_name, undefined);

--- a/mis_builder/tests/test_analytic_filters.py
+++ b/mis_builder/tests/test_analytic_filters.py
@@ -19,7 +19,10 @@ class TestAnalyticFilters(TransactionCase):
         mri.analytic_group_id = self.aag
         assert mri._context_with_filters().get("mis_report_filters") == {
             "analytic_account_id": {"value": aaa.id, "operator": "="},
-            "analytic_account_id.group_id": {"value": self.aag.id, "operator": "="},
+            "analytic_account_id.group_id": {
+                "value": self.aag.id,
+                "operator": "child_of",
+            },
         }
         # test _context_with_filters does nothing is a filter is already
         # in the context
@@ -112,4 +115,4 @@ class TestAnalyticFilters(TransactionCase):
             }
         )
         domain = instance_period._get_additional_move_line_filter()
-        assert domain == [("analytic_account_id.group_id", "=", self.aag.id)]
+        assert domain == [("analytic_account_id.group_id", "child_of", self.aag.id)]


### PR DESCRIPTION
With this commit, the filter on analytic group also include lines with analytic account in childs group of the targeted group