### PR TITLE
[14.0][FIX] mis_builder: bug unable to add SUM COL at once

### DIFF
--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -365,6 +365,9 @@ class MisReportInstancePeriod(models.Model):
     def _onchange_source(self):
         if self.source in (SRC_SUMCOL, SRC_CMPCOL):
             self.mode = MODE_NONE
+        # Dirty hack to solve bug https://github.com/OCA/mis-builder/issues/393
+        if self.source and not self.report_instance_id.id:
+            self.report_instance_id = self.report_instance_id._origin.id
 
     def _get_aml_model_name(self):
         self.ensure_one()
@@ -587,7 +590,7 @@ class MisReportInstance(models.Model):
         else:
             prev = self.company_ids.ids
             company = False
-            if self.env.company.id in prev:
+            if self.env.company.id in prev or not prev:
                 company = self.env.company
             else:
                 for c_id in prev:


### PR DESCRIPTION
Fixes bug #393. It's a hack, but it works well. I tried TONS of other solution (would take too much time to list them here), and it's the only solution I found.

Fix missing default value on company_id when creating a new report instance with default values