### PR TITLE
[13.0][IMP] mis_builder: Add group to MIS report menu to prevent users without full accounting permissions can see it.

### DIFF
--- a/mis_builder/views/mis_report.xml
+++ b/mis_builder/views/mis_report.xml
@@ -310,6 +310,7 @@
         parent="account.menu_finance_configuration"
         name="MIS Reporting"
         sequence="90"
+        groups="account.group_account_user"
     />
     <menuitem
         id="mis_report_view_menu"


### PR DESCRIPTION
Add group to MIS report menu to prevent users without full accounting permissions can see it.

This is required too in v14 and v15.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT38538