### PR TITLE
[14.0][FIX] mis_builder: Restrict MIS reports menu visibility

### DIFF
--- a/mis_builder/views/mis_report_instance.xml
+++ b/mis_builder/views/mis_report_instance.xml
@@ -220,6 +220,7 @@
         parent="account.menu_finance_reports"
         name="MIS Reporting"
         sequence="101"
+        groups="account.group_account_user"
     />
     <menuitem
         id="mis_report_instance_view_menu"


### PR DESCRIPTION
Add group to MIS report menu to prevent that users without full accounting permissions can see it. On contrary, they will be able to see sensitive company information in them.

@Tecnativa TT38538