### PR TITLE
[13.0][FIX] mis_builder: Add group to correct MIS report menu to prevent users without full accounting permissions can see it.

### DIFF
--- a/mis_builder/views/mis_report.xml
+++ b/mis_builder/views/mis_report.xml
@@ -310,7 +310,6 @@
         parent="account.menu_finance_configuration"
         name="MIS Reporting"
         sequence="90"
-        groups="account.group_account_user"
     />
     <menuitem
         id="mis_report_view_menu"

--- a/mis_builder/views/mis_report_instance.xml
+++ b/mis_builder/views/mis_report_instance.xml
@@ -220,6 +220,7 @@
         parent="account.menu_finance_reports"
         name="MIS Reporting"
         sequence="101"
+        groups="account.group_account_user"
     />
     <menuitem
         id="mis_report_instance_view_menu"


### PR DESCRIPTION
Add group to correct (related to https://github.com/OCA/mis-builder/pull/458) MIS report menu to prevent users without full accounting permissions can see it.

This is required too in v14 and v15.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT38538