### PR TITLE
[FIX] mis_builder: let non-admins print reports

### DIFF
--- a/mis_builder/models/mis_report.py
+++ b/mis_builder/models/mis_report.py
@@ -475,9 +475,11 @@ class MisReport(models.Model):
     @api.depends("move_lines_source")
     def _compute_account_model(self):
         for record in self:
-            record.account_model = record.move_lines_source.field_id.filtered(
-                lambda r: r.name == "account_id"
-            ).relation
+            record.account_model = (
+                record.move_lines_source.sudo()
+                .field_id.filtered(lambda r: r.name == "account_id")
+                .relation
+            )
 
     @api.onchange("subkpi_ids")
     def _on_change_subkpi_ids(self):

--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -372,7 +372,7 @@ class MisReportInstancePeriod(models.Model):
     def _get_aml_model_name(self):
         self.ensure_one()
         if self.source == SRC_ACTUALS:
-            return self.report_id.move_lines_source.model
+            return self.report_id.move_lines_source.sudo().model
         elif self.source == SRC_ACTUALS_ALT:
             return self.source_aml_model_name
         return False

--- a/mis_builder/readme/CONTRIBUTORS.rst
+++ b/mis_builder/readme/CONTRIBUTORS.rst
@@ -24,3 +24,4 @@
 * `CorporateHub <https://corporatehub.eu/>`__
 
   * Alexey Pelykh <alexey.pelykh@corphub.eu>
+* Jairo Llopis (https://www.moduon.team/)

--- a/mis_builder/readme/newsfragments/476.bugfix
+++ b/mis_builder/readme/newsfragments/476.bugfix
@@ -1,0 +1,1 @@
+Fix access error when previewing or printing report.

--- a/mis_builder/tests/test_mis_report_instance.py
+++ b/mis_builder/tests/test_mis_report_instance.py
@@ -586,3 +586,7 @@ class TestMisReportInstance(common.HttpCase):
     def test_raise_when_wrong_tuple_length_with_subkpis(self):
         with self.assertRaises(SubKPITupleLengthError):
             self.report_instance_3.compute()
+
+    def test_unprivileged(self):
+        test_user = common.new_test_user(self.env, "mis_you")
+        self.report_instance.with_user(test_user).compute()


### PR DESCRIPTION
## Description

Before this patch, normal users would get `AccessError` when trying to preview or print reports.

Towards #415.

@moduon MT-1527
