### PR TITLE
[FIX] resolve_2many_commands

### DIFF
--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -636,12 +636,10 @@ class MisReportInstance(models.Model):
         analytic_tag_value = filters.get("analytic_tag_ids", {}).get("value")
         if analytic_tag_value:
             # TODO 14 we need a test to cover this
-            analytic_tag_names = self.resolve_2many_commands(
-                "analytic_tag_ids", analytic_tag_value, ["name"]
-            )
+            analytic_tag_names = self.new({'analytic_tag_ids': analytic_tag_value}).analytic_tag_ids
             filter_descriptions.append(
                 _("Analytic Tags: %s")
-                % ", ".join([rec["name"] for rec in analytic_tag_names])
+                % ", ".join(analytic_tag_names.mapped('name'))
             )
         return filter_descriptions
 

--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -636,12 +636,11 @@ class MisReportInstance(models.Model):
         analytic_tag_value = filters.get("analytic_tag_ids", {}).get("value")
         if analytic_tag_value:
             # TODO 14 we need a test to cover this
-            analytic_tag_names = self.resolve_2many_commands(
-                "analytic_tag_ids", analytic_tag_value, ["name"]
-            )
+            analytic_tag_names = self.new(
+                {"analytic_tag_ids": analytic_tag_value}
+            ).analytic_tag_ids
             filter_descriptions.append(
-                _("Analytic Tags: %s")
-                % ", ".join([rec["name"] for rec in analytic_tag_names])
+                _("Analytic Tags: %s") % ", ".join(analytic_tag_names.mapped("name"))
             )
         return filter_descriptions
 

--- a/mis_builder/readme/newsfragments/353.bugfix
+++ b/mis_builder/readme/newsfragments/353.bugfix
@@ -1,0 +1,1 @@
+Replace the resolve_2many_commands() function to retrieve analytic_tag_names 

--- a/mis_builder/readme/newsfragments/353.bugfix
+++ b/mis_builder/readme/newsfragments/353.bugfix
@@ -1,1 +1,1 @@
-Replace the resolve_2many_commands() function to retrieve analytic_tag_names 
+Replace the resolve_2many_commands() function to retrieve analytic_tag_names


### PR DESCRIPTION
[FIX] resolve_2many_commands


## Description

resolve_2many_commands does not exist anymore on V15. So this part need to be fixed

## Test

-Previsualise a Report
-Add an Analytic Tags Filter
-Export the report

## Target branch

V15.0



## Changelog entry

This projects uses [towncrier](https://pypi.org/project/towncrier/) to generate it's
changelog. Make sure your PR includes a changelog entry in
`<addon>/readme/newsfragments/`. It must have the issue or PR number as name, and one of
`.feature`, `.bugfix`, `.doc` (for documentation improvements), `.misc` (if a ticket has
been closed, but it is not of interest to users). The changelog entry must be reasonably
short and phrased in a way that is understandable by end users.

## Documentation

Consider improving the documention in `docs/`.
