### PR TITLE
[14.0][IMP] use cell_style_props for val_rendered in kpi matrix

### DIFF
--- a/mis_builder/models/kpimatrix.py
+++ b/mis_builder/models/kpimatrix.py
@@ -236,21 +236,6 @@ class KpiMatrix(object):
         assert len(vals) == col.colspan
         assert len(drilldown_args) == col.colspan
         for val, drilldown_arg, subcol in zip(vals, drilldown_args, col.iter_subcols()):
-            if isinstance(val, DataError):
-                val_rendered = val.name
-                val_comment = val.msg
-            else:
-                val_rendered = self._style_model.render(
-                    self.lang, row.style_props, kpi.type, val
-                )
-                if row.kpi.multi and subcol.subkpi:
-                    val_comment = "{}.{} = {}".format(
-                        row.kpi.name,
-                        subcol.subkpi.name,
-                        row.kpi._get_expression_str_for_subkpi(subcol.subkpi),
-                    )
-                else:
-                    val_comment = "{} = {}".format(row.kpi.name, row.kpi.expression)
             cell_style_props = row.style_props
             if row.kpi.style_expression:
                 # evaluate style expression
@@ -272,6 +257,21 @@ class KpiMatrix(object):
                         )
                     else:
                         _logger.error("Style '%s' not found.", style_name)
+            if isinstance(val, DataError):
+                val_rendered = val.name
+                val_comment = val.msg
+            else:
+                val_rendered = self._style_model.render(
+                    self.lang, cell_style_props, kpi.type, val
+                )
+                if row.kpi.multi and subcol.subkpi:
+                    val_comment = "{}.{} = {}".format(
+                        row.kpi.name,
+                        subcol.subkpi.name,
+                        row.kpi._get_expression_str_for_subkpi(subcol.subkpi),
+                    )
+                else:
+                    val_comment = "{} = {}".format(row.kpi.name, row.kpi.expression)
             cell = KpiMatrixCell(
                 row,
                 subcol,


### PR DESCRIPTION
So far, the values set in set_values_detail_account were rendered using the row style properties, before evaluating the row's style expression. Thus, even though the correct style properties are passed as cell_style_props, some changes by the style_expression (e.g. prefix, suffix, ...) would not take effect.
With these changes, the style_expression gets evaluated before rendering the value, and the correct cell_style_props are passed to style_model.render.