### PR TITLE
[14.0][IMP] Add a generic analytic_domain filter. Backport from v16

### DIFF
--- a/mis_builder/tests/test_mis_report_instance.py
+++ b/mis_builder/tests/test_mis_report_instance.py
@@ -579,6 +579,21 @@ class TestMisReportInstance(common.HttpCase):
             elif row.kpi.name == "k4":
                 self.assertEqual(vals, [AccountingNone, AccountingNone, 1.0])
 
+    def test_mis_report_analytic_domain(self):
+        # Check that matrix has no values when using putting a non
+        # existing account into the analytic domain
+        matrix = self.report_instance.with_context(
+            mis_analytic_domain=[("analytic_account_id", "=", 999)]
+        )._compute_matrix()
+        for row in matrix.iter_rows():
+            vals = [c.val for c in row.iter_cells()]
+            if row.kpi.name == "k1":
+                self.assertEqual(vals, [AccountingNone, AccountingNone, AccountingNone])
+            elif row.kpi.name == "k2":
+                self.assertEqual(vals, [AccountingNone, AccountingNone, None])
+            elif row.kpi.name == "k4":
+                self.assertEqual(vals, [AccountingNone, AccountingNone, 1.0])
+
     def test_raise_when_unknown_kpi_value_type(self):
         with self.assertRaises(SubKPIUnknownTypeError):
             self.report_instance_2.compute()

--- a/mis_builder/views/mis_report_instance.xml
+++ b/mis_builder/views/mis_report_instance.xml
@@ -180,6 +180,12 @@
                                     groups="base.group_multi_company"
                                     widget="many2many_tags"
                                 />
+                                 <field name="source_aml_model_name" invisible="1" />
+                                <field
+                                    name="analytic_domain"
+                                    widget="domain"
+                                    options="{'model': 'source_aml_model_name'}"
+                                />
                                 <field
                                     name="analytic_account_id"
                                     groups="analytic.group_analytic_accounting"
@@ -405,6 +411,12 @@
                     </group>
                 </group>
                 <group string="Filters">
+                    <field
+                        name="analytic_domain"
+                        widget="domain"
+                        options="{'model': 'source_aml_model_name'}"
+                        attrs="{'invisible': [('source_aml_model_name', '=', False)]}"
+                    />
                     <field name="analytic_account_id" />
                     <field name="analytic_group_id" />
                     <field name="analytic_tag_ids" widget="many2many_tags" />


### PR DESCRIPTION
Add a generic analytic_domain filter,
which can be set at the report level or at the column level. The context can contain a mis_analytic_domain key, this domain being always ANDed with the domains configured on the report and columns and in the other filters.

Backport from v16. See commit f2f82a547d6b5998cd60da12ad42a7636fe31cd6

Co-Authored-By: Stéphane Bidoul

