### PR TITLE
[16.0][IMP] mis_builder: use odoo_test_helper in tests

### DIFF
--- a/mis_builder/tests/common.py
+++ b/mis_builder/tests/common.py
@@ -6,19 +6,6 @@ import doctest
 from odoo.tests import BaseCase, tagged
 
 
-def setup_test_model(env, model_cls):
-    model_cls._build_model(env.registry, env.cr)
-    env.registry.setup_models(env.cr)
-    env.registry.init_models(
-        env.cr, [model_cls._name], dict(env.context, update_custom_fields=True)
-    )
-
-
-def teardown_test_model(env, model_cls):
-    del env.registry.models[model_cls._name]
-    env.registry.setup_models(env.cr)
-
-
 def _zip(iter1, iter2):
     i = 0
     iter1 = iter(iter1)

--- a/mis_builder/tests/fake_models.py
+++ b/mis_builder/tests/fake_models.py
@@ -1,0 +1,8 @@
+from odoo import models
+
+
+class MisKpiDataTestItem(models.Model):
+
+    _name = "mis.kpi.data.test.item"
+    _inherit = "mis.kpi.data"
+    _description = "MIS Kpi Data test item"

--- a/mis_builder/tests/test_kpi_data.py
+++ b/mis_builder/tests/test_kpi_data.py
@@ -1,24 +1,23 @@
 # Copyright 2017 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import models
+from odoo_test_helper import FakeModelLoader
+
 from odoo.tests.common import TransactionCase
 
 from ..models.mis_kpi_data import ACC_AVG, ACC_SUM
-from .common import setup_test_model, teardown_test_model
 
 
 class TestKpiData(TransactionCase):
-    class MisKpiDataTestItem(models.Model):
-
-        _name = "mis.kpi.data.test.item"
-        _inherit = "mis.kpi.data"
-        _description = "MIS Kpi Data test item"
-
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        setup_test_model(cls.env, cls.MisKpiDataTestItem)
+
+        cls.loader = FakeModelLoader(cls.env, cls.__module__)
+        cls.loader.backup_registry()
+        from .fake_models import MisKpiDataTestItem
+
+        cls.loader.update_registry((MisKpiDataTestItem,))
 
         report = cls.env["mis.report"].create(dict(name="test report"))
         cls.kpi1 = cls.env["mis.report.kpi"].create(
@@ -74,7 +73,7 @@ class TestKpiData(TransactionCase):
 
     @classmethod
     def tearDownClass(cls):
-        teardown_test_model(cls.env, cls.MisKpiDataTestItem)
+        cls.loader.restore_registry()
         return super().tearDownClass()
 
     def test_kpi_data_name(self):

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,1 @@
+odoo-test-helper


### PR DESCRIPTION
Make use of odoo-test-helper to correctly import fake model in tests 
See https://github.com/OCA/odoo-test-helper

This fixes Wrong Import warnings, such as 
odoo_test_helper.fake_model_loader: Wrong Import in module mis_builder, the class <class 'odoo.addons.mis_builder.tests.test_kpi_data.TestKpiData.MisKpiDataTestItem'> have been already imported.
