### PR TITLE
[14.0][IMP] mis_builder: Company not required for report instance

### DIFF
--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -570,6 +570,8 @@ class MisReportInstance(models.Model):
         string="Allowed company",
         default=lambda self: self.env.company,
         required=False,
+        help="If empty, all companies may use - and edit - the report instance. "
+        "The report will be made for the active company.",
     )
     multi_company = fields.Boolean(
         string="Multiple companies",

--- a/mis_builder/readme/newsfragments/569.feature
+++ b/mis_builder/readme/newsfragments/569.feature
@@ -1,0 +1,7 @@
+All companies may use - and edit - the same report instance.
+The report will be made for the active company.
+
+For this behaviour, use these report instance filters:
+
+- Multiple companies: False
+- Allowed company: None

--- a/mis_builder/tests/test_mis_report_instance.py
+++ b/mis_builder/tests/test_mis_report_instance.py
@@ -564,6 +564,17 @@ class TestMisReportInstance(common.HttpCase):
         )
         self.assertFalse(self.report_instance.company_ids)
 
+    def test_use_active_company_when_company_is_not_set(self):
+        self.assertFalse(self.report_instance.multi_company)
+        self.report_instance.company_id = None
+        # test with company
+        company = self.env.ref("base.main_company")
+        self.assertEqual(self.report_instance.query_company_ids[0], company)
+        # test with new company
+        new_company = self.env["res.company"].create({"name": "new company"})
+        self.env.company = new_company
+        self.assertEqual(self.report_instance.query_company_ids[0], new_company)
+
     def test_mis_report_analytic_filters(self):
         # Check that matrix has no values when using a filter with a non
         # existing account

--- a/mis_builder/views/mis_report_instance.xml
+++ b/mis_builder/views/mis_report_instance.xml
@@ -167,7 +167,7 @@
                                 <field
                                     name="company_id"
                                     groups="base.group_multi_company"
-                                    attrs="{'required': [('multi_company', '=', False)], 'invisible': [('multi_company', '=', True)]}"
+                                    attrs="{'invisible': [('multi_company', '=', True)]}"
                                 />
                                 <field
                                     name="company_ids"


### PR DESCRIPTION
All companies may use - and edit - the same report instance.
The report will be made for the active company.

For this behavior, use these report instance filters:

- Multiple companies: False
- Allowed company: None