### PR TITLE
Add `pyproject.toml` to `mis_builder_demo`

### DIFF
--- a/mis_builder_demo/pyproject.toml
+++ b/mis_builder_demo/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["whool"]
+build-backend = "whool.buildapi"


### PR DESCRIPTION
Test if the bot works correctly.

Preparing for the progressive replacement of `setuptool-odoo` whith `whool`, and the removal of the `setup/` directories in future branches.
