### PR TITLE
[16.0][FIX]Do not raise UserError in inverse_expression when using multi

### DIFF
--- a/mis_builder/models/mis_report.py
+++ b/mis_builder/models/mis_report.py
@@ -182,7 +182,7 @@ class MisReportKpi(models.Model):
     def _inverse_expression(self):
         for kpi in self:
             if kpi.multi:
-                raise UserError(_("Can not update a multi kpi from " "the kpi line"))
+                continue
             if kpi.expression_ids:
                 kpi.expression_ids[0].write({"name": kpi.expression, "subkpi_id": None})
                 for expression in kpi.expression_ids[1:]:


### PR DESCRIPTION
I think the raise of the UserError in `_inverse_expression` should be removed:

This is due to the fact that the inverse function is now (in Odoo16.0) played after `_compute_expression`. This results in not being able to set multiple expressions on kpi's. 

This behaviour is not expected and wasn't the one in previous versions.