### PR TITLE
[15.0] Add option to show account details before KPI on instance

### DIFF
--- a/mis_builder/models/kpimatrix.py
+++ b/mis_builder/models/kpimatrix.py
@@ -432,17 +432,20 @@ class KpiMatrix(object):
                     tooltips=False,
                 )
 
-    def iter_rows(self):
+    def iter_rows(self, inverse_detail=False):
         """Iterate rows in display order.
 
         yields KpiMatrixRow.
         """
         for kpi_row in self._kpi_rows.values():
-            yield kpi_row
+            if not inverse_detail:
+                yield kpi_row
             detail_rows = self._detail_rows[kpi_row.kpi].values()
             detail_rows = sorted(detail_rows, key=lambda r: r.label)
             for detail_row in detail_rows:
                 yield detail_row
+            if inverse_detail:
+                yield kpi_row
 
     def iter_cols(self):
         """Iterate columns in display order.
@@ -480,7 +483,7 @@ class KpiMatrix(object):
             self._load_account_names()
         return self._account_names[account_id]
 
-    def as_dict(self):
+    def as_dict(self, inverse_detail=False):
         header = [{"cols": []}, {"cols": []}]
         for col in self.iter_cols():
             header[0]["cols"].append(
@@ -500,7 +503,7 @@ class KpiMatrix(object):
                 )
 
         body = []
-        for row in self.iter_rows():
+        for row in self.iter_rows(inverse_detail=inverse_detail):
             if (
                 row.style_props.hide_empty and row.is_empty()
             ) or row.style_props.hide_always:

--- a/mis_builder/models/kpimatrix.py
+++ b/mis_builder/models/kpimatrix.py
@@ -432,19 +432,19 @@ class KpiMatrix(object):
                     tooltips=False,
                 )
 
-    def iter_rows(self, inverse_detail=False):
+    def iter_rows(self, details_before_kpi=False):
         """Iterate rows in display order.
 
         yields KpiMatrixRow.
         """
         for kpi_row in self._kpi_rows.values():
-            if not inverse_detail:
+            if not details_before_kpi:
                 yield kpi_row
             detail_rows = self._detail_rows[kpi_row.kpi].values()
             detail_rows = sorted(detail_rows, key=lambda r: r.label)
             for detail_row in detail_rows:
                 yield detail_row
-            if inverse_detail:
+            if details_before_kpi:
                 yield kpi_row
 
     def iter_cols(self):
@@ -483,7 +483,7 @@ class KpiMatrix(object):
             self._load_account_names()
         return self._account_names[account_id]
 
-    def as_dict(self, inverse_detail=False):
+    def as_dict(self, details_before_kpi=False):
         header = [{"cols": []}, {"cols": []}]
         for col in self.iter_cols():
             header[0]["cols"].append(
@@ -503,7 +503,7 @@ class KpiMatrix(object):
                 )
 
         body = []
-        for row in self.iter_rows(inverse_detail=inverse_detail):
+        for row in self.iter_rows(details_before_kpi=details_before_kpi):
             if (
                 row.style_props.hide_empty and row.is_empty()
             ) or row.style_props.hide_always:

--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -563,6 +563,9 @@ class MisReportInstance(models.Model):
     display_columns_description = fields.Boolean(
         help="Display the date range details in the column headers."
     )
+    inverse_detail = fields.Boolean(
+        help="Show detail before KPI.",
+    )
     comparison_mode = fields.Boolean(
         compute="_compute_comparison_mode", inverse="_inverse_comparison_mode"
     )
@@ -869,7 +872,7 @@ class MisReportInstance(models.Model):
     def compute(self):
         self.ensure_one()
         kpi_matrix = self._compute_matrix()
-        return kpi_matrix.as_dict()
+        return kpi_matrix.as_dict(inverse_detail=self.inverse_detail)
 
     def drilldown(self, arg):
         self.ensure_one()

--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -563,8 +563,8 @@ class MisReportInstance(models.Model):
     display_columns_description = fields.Boolean(
         help="Display the date range details in the column headers."
     )
-    inverse_detail = fields.Boolean(
-        help="Show detail before KPI.",
+    details_before_kpi = fields.Boolean(
+        help="Show account details before KPI.",
     )
     comparison_mode = fields.Boolean(
         compute="_compute_comparison_mode", inverse="_inverse_comparison_mode"
@@ -872,7 +872,7 @@ class MisReportInstance(models.Model):
     def compute(self):
         self.ensure_one()
         kpi_matrix = self._compute_matrix()
-        return kpi_matrix.as_dict(inverse_detail=self.inverse_detail)
+        return kpi_matrix.as_dict(details_before_kpi=self.details_before_kpi)
 
     def drilldown(self, arg):
         self.ensure_one()

--- a/mis_builder/report/mis_report_instance_qweb.xml
+++ b/mis_builder/report/mis_report_instance_qweb.xml
@@ -75,7 +75,7 @@
                             </div>
                             <div class="mis_tbody">
                                 <t
-                                    t-foreach="matrix.iter_rows(o.inverse_detail)"
+                                    t-foreach="matrix.iter_rows(o.details_before_kpi)"
                                     t-as="row"
                                 >
                                     <div

--- a/mis_builder/report/mis_report_instance_qweb.xml
+++ b/mis_builder/report/mis_report_instance_qweb.xml
@@ -74,7 +74,10 @@
                                 </div>
                             </div>
                             <div class="mis_tbody">
-                                <t t-foreach="matrix.iter_rows()" t-as="row">
+                                <t
+                                    t-foreach="matrix.iter_rows(o.inverse_detail)"
+                                    t-as="row"
+                                >
                                     <div
                                         t-if="not ((row.style_props.hide_empty and row.is_empty()) or row.style_props.hide_always)"
                                         class="mis_row"

--- a/mis_builder/report/mis_report_instance_xlsx.py
+++ b/mis_builder/report/mis_report_instance_xlsx.py
@@ -102,7 +102,7 @@ class MisBuilderXlsx(models.AbstractModel):
         row_pos += 1
 
         # rows
-        for row in matrix.iter_rows(objects.inverse_detail):
+        for row in matrix.iter_rows(objects.details_before_kpi):
             if (
                 row.style_props.hide_empty and row.is_empty()
             ) or row.style_props.hide_always:

--- a/mis_builder/report/mis_report_instance_xlsx.py
+++ b/mis_builder/report/mis_report_instance_xlsx.py
@@ -102,7 +102,7 @@ class MisBuilderXlsx(models.AbstractModel):
         row_pos += 1
 
         # rows
-        for row in matrix.iter_rows():
+        for row in matrix.iter_rows(objects.inverse_detail):
             if (
                 row.style_props.hide_empty and row.is_empty()
             ) or row.style_props.hide_always:

--- a/mis_builder/tests/test_data_sources.py
+++ b/mis_builder/tests/test_data_sources.py
@@ -219,3 +219,13 @@ class TestMisReportInstanceDataSources(common.TransactionCase):
         self.p1.source_aml_model_id = aml_model.id
         matrix = self.instance._compute_matrix()
         assert_matrix(matrix, [[11, 13], [11, 30]])
+
+    def test_details_after_kpi(self):
+        self.instance.details_before_kpi = False
+        matrix_dict = self.instance.compute()
+        self.assertEqual(matrix_dict["body"][1]["row_id"], "k2")
+
+    def test_details_before_kpi(self):
+        self.instance.details_before_kpi = True
+        matrix_dict = self.instance.compute()
+        self.assertEqual(matrix_dict["body"][1]["parent_row_id"], "k2")

--- a/mis_builder/tests/test_mis_report_instance.py
+++ b/mis_builder/tests/test_mis_report_instance.py
@@ -592,8 +592,3 @@ class TestMisReportInstance(common.HttpCase):
             self.env, "mis_you", groups="base.group_user,account.group_account_user"
         )
         self.report_instance.with_user(test_user).compute()
-
-    def test_details_before_kpi(self):
-        self.report_instance.details_before_kpi = True
-        matrix_dict = self.report_instance.compute()
-        self.assertEqual(matrix_dict["body"][0]["parent_row_id"], "k1")

--- a/mis_builder/tests/test_mis_report_instance.py
+++ b/mis_builder/tests/test_mis_report_instance.py
@@ -592,3 +592,8 @@ class TestMisReportInstance(common.HttpCase):
             self.env, "mis_you", groups="base.group_user,account.group_account_user"
         )
         self.report_instance.with_user(test_user).compute()
+
+    def test_details_before_kpi(self):
+        self.report_instance.details_before_kpi = True
+        matrix_dict = self.report_instance.compute()
+        self.assertEqual(matrix_dict["body"][0]["parent_row_id"], "k1")

--- a/mis_builder/views/mis_report_instance.xml
+++ b/mis_builder/views/mis_report_instance.xml
@@ -192,6 +192,7 @@
                                 <field name="no_auto_expand_accounts" />
                                 <field name="display_columns_description" />
                                 <field name="hide_analytic_filters" />
+                                <field name="inverse_detail" />
                             </group>
                         </page>
                     </notebook>

--- a/mis_builder/views/mis_report_instance.xml
+++ b/mis_builder/views/mis_report_instance.xml
@@ -190,9 +190,12 @@
                             <group name="layout">
                                 <field name="landscape_pdf" />
                                 <field name="no_auto_expand_accounts" />
+                                <field
+                                    name="details_before_kpi"
+                                    attrs="{'invisible': [('no_auto_expand_accounts', '=', True)]}"
+                                />
                                 <field name="display_columns_description" />
                                 <field name="hide_analytic_filters" />
-                                <field name="inverse_detail" />
                             </group>
                         </page>
                     </notebook>


### PR DESCRIPTION
Hello,

I added an option to show the detail of the accounts before the KPI (requested by my customer).
I thought it might interest the community.
I know it lacks unit tests but it can be added if the feature is found useful.

Cheers,

Samuel