### PR TITLE
[16.0] Custom fields in accounting expressions (e.g. `fldp.quantity`, `fld.carbon_balance`)

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -169,15 +169,19 @@ Building your KPI
 Expressions can be any valid python expressions.
 
 The following special elements are recognized in the expressions to compute accounting
-data: {bal|crd|deb}{pieu}[account selector][journal items domain].
+data: ``{bal|crd|deb|pbal|nbal|fld}{pieu}(.fieldname)?[account selector][journal items domain]``.
 
-* bal, crd, deb: balance, debit, credit.
-* p, i, e: respectively variation over the period, initial balance, ending balance
-* The account selector is a like expression on the account code (eg 70%, etc).
+* ``bal``, ``crd``, ``deb``: balance, debit, credit.
+* ``pbal``, ``nbal``: positive and negative balances only
+* ``fld``: custom numerical field
+* ``p``, ``i``, ``e``: respectively variation over the period, initial balance, ending balance
+* .fieldname: when ``fld`` is used, the field name to use (eg ``fldp.quantity``).
+* The account selector is a like expression on the account code (eg ``[70%]``, etc),
+  or a domain over accounts (eg ``[("tag_ids.name", "=", "mytag")]``).
 * The journal items domain is an Odoo domain filter on journal items.
-* balu[]: (u for unallocated) is a special expression that shows the unallocated
+* ``balu[]``: (u for unallocated) is a special expression that shows the unallocated
   profit/loss of previous fiscal years.
-* Expression can also involve other KPI and query results by name (eg kpi1 + kpi2).
+* Expression can also involve other KPI and query results by name (eg ``kpi1 + kpi2``).
 
 Additionally following variables are available in the evaluation context:
 
@@ -188,16 +192,18 @@ Additionally following variables are available in the evaluation context:
 
 Examples
 ********
-* bal[70]: variation of the balance of account 70 over the period (it is the same as balp[70].
-* bali[70,60]: initial balance of accounts 70 and 60.
-* bale[1%]: balance of accounts starting with 1 at end of period.
-* crdp[40%]: sum of all credits on accounts starting with 40 during the period.
-* debp[55%][('journal_id.code', '=', 'BNK1')]: sum of all debits on accounts 55 and
+* ``bal[70]``: variation of the balance of account 70 over the period (it is the same as balp[70].
+* ``bali[70,60]``: initial balance of accounts 70 and 60.
+* ``bale[1%]``: balance of accounts starting with 1 at end of period.
+* ``crdp[40%]``: sum of all credits on accounts starting with 40 during the period.
+* ``debp[55%][('journal_id.code', '=', 'BNK1')]``: sum of all debits on accounts 55 and
   journal BNK1 during the period.
-* balp[('user_type_id', '=', ref('account.data_account_type_receivable').id)][]:
+* ``balp[('user_type_id', '=', ref('account.data_account_type_receivable').id)][]``:
   variation of the balance of all receivable accounts over the period.
-* balp[][('tax_line_id.tag_ids', '=', ref('l10n_be.tax_tag_56').id)]: balance of move
+* ``balp[][('tax_line_id.tag_ids', '=', ref('l10n_be.tax_tag_56').id)]``: balance of move
   lines related to tax grid 56.
+* ``fldp.quantity[60%]``: sum of the quantity field of all move lines on accounts starting
+  with 60.
 
 Expansion of Account Detail
 ---------------------------

--- a/mis_builder/models/aep.py
+++ b/mis_builder/models/aep.py
@@ -74,12 +74,14 @@ class Accumulator:
 class AccountingExpressionProcessor:
     """Processor for accounting expressions.
 
-    Expressions of the form <field><mode>[accounts][optional move line domain]
+    Expressions of the form
+    <field><mode>(.fieldname)?[accounts][optional move line domain]
     are supported, where:
         * field is bal, crd, deb, pbal (positive balances only),
-          nbal (negative balance only)
+          nbal (negative balance only), fld (custom field)
         * mode is i (initial balance), e (ending balance),
           p (moves over period)
+        * .fieldname is used only with fldp and specifies the field name to sum
         * there is also a special u mode (unallocated P&L) which computes
           the sum from the beginning until the beginning of the fiscal year
           of the period; it is only meaningful for P&L accounts
@@ -93,6 +95,7 @@ class AccountingExpressionProcessor:
           over the period (it is the same as balp[70]);
         * bali[70,60]: balance of accounts 70 and 60 at the start of period;
         * bale[1%]: balance of accounts starting with 1 at end of period.
+        * fldp.quantity[60%]: sum of the quantity field of moves on accounts 60
 
     How to use:
         * repeatedly invoke parse_expr() for each expression containing

--- a/mis_builder/models/aep.py
+++ b/mis_builder/models/aep.py
@@ -406,14 +406,18 @@ class AccountingExpressionProcessor:
                 credit = entry.credit
                 if field == "bal":
                     v += debit - credit
-                elif field == "pbal" and debit >= credit:
-                    v += debit - credit
-                elif field == "nbal" and debit < credit:
-                    v += debit - credit
+                elif field == "pbal":
+                    if debit >= credit:
+                        v += debit - credit
+                elif field == "nbal":
+                    if debit < credit:
+                        v += debit - credit
                 elif field == "deb":
                     v += debit
                 elif field == "crd":
                     v += credit
+                else:
+                    raise AssertionError("should not be here")
             # in initial balance mode, assume 0 is None
             # as it does not make sense to distinguish 0 from "no data"
             if (
@@ -463,6 +467,8 @@ class AccountingExpressionProcessor:
                 v = debit
             elif field == "crd":
                 v = credit
+            else:
+                raise AssertionError("should not be here")
             # in initial balance mode, assume 0 is None
             # as it does not make sense to distinguish 0 from "no data"
             if (

--- a/mis_builder/models/aep.py
+++ b/mis_builder/models/aep.py
@@ -379,11 +379,9 @@ class AccountingExpressionProcessor:
             variation_data = self._data[(domain, self.MODE_VARIATION)]
             account_ids = set(initial_data.keys()) | set(variation_data.keys())
             for account_id in account_ids:
-                di, ci = initial_data.get(account_id, (AccountingNone, AccountingNone))
-                dv, cv = variation_data.get(
-                    account_id, (AccountingNone, AccountingNone)
+                self._data[key][account_id] += (
+                    initial_data[account_id] + variation_data[account_id]
                 )
-                self._data[key][account_id] = (di + dv, ci + cv)
 
     def replace_expr(self, expr):
         """Replace accounting variables in an expression by their amount.
@@ -400,9 +398,7 @@ class AccountingExpressionProcessor:
             v = AccountingNone
             account_ids = self._account_ids_by_acc_domain[acc_domain]
             for account_id in account_ids:
-                debit, credit = account_ids_data.get(
-                    account_id, (AccountingNone, AccountingNone)
-                )
+                debit, credit = account_ids_data[account_id]
                 if field == "bal":
                     v += debit - credit
                 elif field == "pbal" and debit >= credit:
@@ -443,9 +439,7 @@ class AccountingExpressionProcessor:
                 return "(AccountingNone)"
             # here we know account_id is involved in acc_domain
             account_ids_data = self._data[key]
-            debit, credit = account_ids_data.get(
-                account_id, (AccountingNone, AccountingNone)
-            )
+            debit, credit = account_ids_data[account_id]
             if field == "bal":
                 v = debit - credit
             elif field == "pbal":

--- a/mis_builder/models/aggregate.py
+++ b/mis_builder/models/aggregate.py
@@ -64,11 +64,11 @@ def _min(*args):
     >>> min()
     Traceback (most recent call last):
       File "<stdin>", line 1, in ?
-    TypeError: min expected 1 arguments, got 0
+    TypeError: min expected at least 1 argument, got 0
     >>> _min()
     Traceback (most recent call last):
       File "<stdin>", line 1, in ?
-    TypeError: min expected 1 arguments, got 0
+    TypeError: min expected at least 1 argument, got 0
     >>> min([])
     Traceback (most recent call last):
       File "<stdin>", line 1, in ?
@@ -107,11 +107,11 @@ def _max(*args):
     >>> max()
     Traceback (most recent call last):
       File "<stdin>", line 1, in ?
-    TypeError: max expected 1 arguments, got 0
+    TypeError: max expected at least 1 argument, got 0
     >>> _max()
     Traceback (most recent call last):
       File "<stdin>", line 1, in ?
-    TypeError: max expected 1 arguments, got 0
+    TypeError: max expected at least 1 argument, got 0
     >>> max([])
     Traceback (most recent call last):
       File "<stdin>", line 1, in ?

--- a/mis_builder/tests/test_aep.py
+++ b/mis_builder/tests/test_aep.py
@@ -9,9 +9,13 @@ from odoo import fields
 from odoo.exceptions import UserError
 from odoo.tools.safe_eval import safe_eval
 
+from ..models import aep
 from ..models.accounting_none import AccountingNone
 from ..models.aep import AccountingExpressionProcessor as AEP
 from ..models.aep import _is_domain
+from .common import load_doctests
+
+load_tests = load_doctests(aep)
 
 
 class TestAEP(common.TransactionCase):

--- a/mis_builder/tests/test_aep.py
+++ b/mis_builder/tests/test_aep.py
@@ -70,6 +70,7 @@ class TestAEP(common.TransactionCase):
             amount=300,
             debit_acc=self.account_ar,
             credit_acc=self.account_in,
+            credit_quantity=3,
         )
         # create move in March this year
         self._create_move(
@@ -95,6 +96,7 @@ class TestAEP(common.TransactionCase):
         self.aep.parse_expr("crdp[700I%]")
         self.aep.parse_expr("bali[400%]")
         self.aep.parse_expr("bale[700%]")
+        self.aep.parse_expr("fldp.quantity[700%]")
         self.aep.parse_expr("balp[]" "[('account_id.code', '=', '400AR')]")
         self.aep.parse_expr(
             "balp[]" "[('account_id.account_type', '=', " " 'asset_receivable')]"
@@ -109,17 +111,32 @@ class TestAEP(common.TransactionCase):
         self.aep.parse_expr("bal_700IN")  # deprecated
         self.aep.parse_expr("bals[700IN]")  # deprecated
 
-    def _create_move(self, date, amount, debit_acc, credit_acc, post=True):
+    def _create_move(
+        self, date, amount, debit_acc, credit_acc, post=True, credit_quantity=0
+    ):
         move = self.move_model.create(
             {
                 "journal_id": self.journal.id,
                 "date": fields.Date.to_string(date),
                 "line_ids": [
-                    (0, 0, {"name": "/", "debit": amount, "account_id": debit_acc.id}),
                     (
                         0,
                         0,
-                        {"name": "/", "credit": amount, "account_id": credit_acc.id},
+                        {
+                            "name": "/",
+                            "debit": amount,
+                            "account_id": debit_acc.id,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "/",
+                            "credit": amount,
+                            "account_id": credit_acc.id,
+                            "quantity": credit_quantity,
+                        },
                     ),
                 ],
             }
@@ -148,6 +165,20 @@ class TestAEP(common.TransactionCase):
     def test_sanity_check(self):
         self.assertEqual(self.company.fiscalyear_last_day, 31)
         self.assertEqual(self.company.fiscalyear_last_month, "12")
+
+    def test_parse_expr_error_handling(self):
+        aep = AEP(self.company)
+        with self.assertRaises(UserError) as cm:
+            aep.parse_expr("fldi.quantity[700%]")
+        self.assertIn(
+            "`fld` can only be used with mode `p` (variation)", str(cm.exception)
+        )
+        with self.assertRaises(UserError) as cm:
+            aep.parse_expr("fldp[700%]")
+        self.assertIn("`fld` must have a field name", str(cm.exception))
+        with self.assertRaises(UserError) as cm:
+            aep.parse_expr("balp.quantity[700%]")
+        self.assertIn("`bal` cannot have a field name", str(cm.exception))
 
     def test_aep_basic(self):
         self.aep.done_parsing()
@@ -200,6 +231,8 @@ class TestAEP(common.TransactionCase):
         self.assertEqual(self._eval("bale[700IN]"), -300)
         # check result for non existing account
         self.assertIs(self._eval("bale[700NA]"), AccountingNone)
+        # check fldp.quantity
+        self.assertEqual(self._eval("fldp.quantity[700%]"), 3)
 
         # let's query for March
         self._do_queries(
@@ -231,6 +264,8 @@ class TestAEP(common.TransactionCase):
         self.assertEqual(self._eval("debp[400A%]"), 500)
         self.assertEqual(self._eval("bal_700IN"), -500)
         self.assertEqual(self._eval("bals[700IN]"), -800)
+        # check fldp.quantity
+        self.assertEqual(self._eval("fldp.quantity[700%]"), 0)
 
         # unallocated p&l from previous year
         self.assertEqual(self._eval("balu[]"), -100)

--- a/mis_builder/views/mis_report.xml
+++ b/mis_builder/views/mis_report.xml
@@ -170,19 +170,24 @@
                                 <p
                                 > The following special elements are recognized in the expressions
                                     to compute accounting data: <code
-                                    >{bal|crd|deb|pbal|nbal}{pieu}[account
+                                    >{bal|crd|deb|pbal|nbal|fld}{pieu}(.fieldname)[account
                                     selector][journal items domain]</code>. </p>
                                 <ul>
                                     <li>
                                         <code>bal</code>, <code>crd</code>, <code
                                         >deb</code>, <code>
-                                        pbal</code>, <code
-                                        >nbal</code> : balance, debit, credit,
-                                        positive balance, negative balance. </li>
+                                        pbal</code>, <code>nbal</code>, <code
+                                        >fld</code> : balance, debit, credit,
+                                        positive balance, negative balance,
+                                        other numerical field. </li>
                                     <li>
                                         <code>p</code>, <code>i</code>, <code
                                         >e</code> : respectively variation over the period,
                                         initial balance, ending balance </li>
+                                    <li>when <code
+                                        >fld</code> is used : a field name specifier
+                                        must be provided (e.g. <code
+                                        >fldp.quantity</code></li>
                                     <li> The <b
                                         >account selector</b> is a like expression on the
                                         account code (eg <code


### PR DESCRIPTION
This is a very rough experiment on the Accounting Expression Processor to support expressions such as `fldp.quantity[60%]`

This will read the quantity field in the same read_group as debit and credit so we can write efficient expressions on any numerical field that is available in the move-line-like table.

TODO
- [x] add tests
- [x] fix failing tests
- [x] update legend
- [x] update docs
