### PR TITLE
[16.0][FIX] mis_builder: correctly compute context in mis_report_widget

### DIFF
--- a/mis_builder/static/src/components/mis_report_widget.esm.js
+++ b/mis_builder/static/src/components/mis_report_widget.esm.js
@@ -3,6 +3,7 @@
 import {Component, onWillStart, useState, useSubEnv} from "@odoo/owl";
 import {useBus, useService} from "@web/core/utils/hooks";
 import {DatePicker} from "@web/core/datepicker/datepicker";
+import {Domain} from "@web/core/domain";
 import {FilterMenu} from "@web/search/filter_menu/filter_menu";
 import {SearchBar} from "@web/search/search_bar/search_bar";
 import {SearchModel} from "@web/search/search_model";
@@ -104,11 +105,16 @@ export class MisReportWidget extends Component {
     }
 
     get context() {
-        var ctx = super.context;
-        if (this.showSearchBar) {
+        let ctx = this.props.record.context;
+        if (this.showSearchBar && this.searchModel.searchDomain) {
             ctx = {
                 ...ctx,
-                mis_analytic_domain: this.searchModel.searchDomain,
+                mis_analytic_domain: Domain.and([
+                    new Domain(
+                        this.props.record.context.mis_analytic_domain || Domain.TRUE
+                    ),
+                    new Domain(this.searchModel.searchDomain),
+                ]).toList(),
             };
         }
         if (this.showPivotDate && this.state.pivot_date) {


### PR DESCRIPTION
This PR ensures that the context used by the `mis_report_widget` widget RPC calls is correctly computed.

Previously using the `mis_analytic_domain` context key was useless as not taken into account in the widget.
