### PR TITLE
[IMP] mis_builder: provide more views in drilldown

### DIFF
--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -877,6 +877,20 @@ class MisReportInstance(models.Model):
         kpi_matrix = self._compute_matrix()
         return kpi_matrix.as_dict()
 
+    @api.model
+    def _get_drilldown_views_and_orders(self):
+        return {"tree": 1, "form": 2, "pivot": 3, "graph": 4}
+
+    @api.model
+    def _get_drilldown_model_views(self, model_name):
+        self.ensure_one()
+        types = self.env["ir.ui.view"]._read_group(
+            [("model", "=", model_name)], ["type"], ["type"]
+        )
+        views_order = self._get_drilldown_views_and_orders()
+        views = {type["type"] for type in types if type["type"] in views_order}
+        return sorted(list(views), key=lambda x: views_order[x])
+
     def drilldown(self, arg):
         self.ensure_one()
         period_id = arg.get("period_id")
@@ -896,13 +910,14 @@ class MisReportInstance(models.Model):
                 account_id,
             )
             domain.extend(period._get_additional_move_line_filter())
+            views = self._get_drilldown_model_views(period.source_aml_model_name)
             return {
                 "name": self._get_drilldown_action_name(arg),
                 "domain": domain,
                 "type": "ir.actions.act_window",
                 "res_model": period.source_aml_model_name,
-                "views": [[False, "list"], [False, "form"]],
-                "view_mode": "list",
+                "views": [[False, view] for view in views],
+                "view_mode": ",".join(view for view in views),
                 "target": "current",
                 "context": {"active_test": False},
             }

--- a/mis_builder/tests/test_mis_report_instance.py
+++ b/mis_builder/tests/test_mis_report_instance.py
@@ -450,6 +450,52 @@ class TestMisReportInstance(common.HttpCase):
         )
         assert action_name == expected_name
 
+    def test_drilldown_views(self):
+        IrUiView = self.env["ir.ui.view"]
+        model_name = "account.move.line"
+        IrUiView.search([("model", "=", model_name)]).unlink()
+        IrUiView.create(
+            [
+                {
+                    "name": "mis_report_test_drilldown_views_chart",
+                    "model": model_name,
+                    "arch": "<graph><field name='name'/></graph>",
+                },
+                {
+                    "name": "mis_report_test_drilldown_views_tree",
+                    "model": model_name,
+                    "arch": "<pivot><field name='name'/></pivot>",
+                },
+            ]
+        )
+        action = self.report_instance.drilldown(
+            dict(expr="balp[200%]", period_id=self.report_instance.period_ids[0].id)
+        )
+        self.assertEqual(action["view_mode"], "pivot,graph")
+        self.assertEqual(action["views"], [[False, "pivot"], [False, "graph"]])
+        IrUiView.create(
+            [
+                {
+                    "name": "mis_report_test_drilldown_views_form",
+                    "model": model_name,
+                    "arch": "<form><field name='name'/></form>",
+                },
+                {
+                    "name": "mis_report_test_drilldown_views_tree",
+                    "model": model_name,
+                    "arch": "<tree><field name='name'/></tree>",
+                },
+            ]
+        )
+        action = self.report_instance.drilldown(
+            dict(expr="balp[200%]", period_id=self.report_instance.period_ids[0].id)
+        )
+        self.assertEqual(action["view_mode"], "tree,form,pivot,graph")
+        self.assertEqual(
+            action["views"],
+            [[False, "tree"], [False, "form"], [False, "pivot"], [False, "graph"]],
+        )
+
     def test_qweb(self):
         self.report_instance.print_pdf()  # get action
         test_reports.try_report(


### PR DESCRIPTION
Prior to this commit only the `tree` and `form` views where made available while drilldowning in the `mis.report.instance` preview.

After this commit if available, the `tree`, `form`, `pivot` and `chart` views will be provided.

The available views and orders can be easilly overriden.

Thanks for your pull request. Please take a moment to review if it meets the following
guidelines.
