### PR TITLE
[14.0][IMP] add: css sticky table header added for mis-builder-widget

### DIFF
--- a/mis_builder/static/src/css/custom.css
+++ b/mis_builder/static/src/css/custom.css
@@ -27,3 +27,8 @@
 .oe_mis_builder_analytic_filter_box {
     padding-bottom: 10px;
 }
+
+.o_web_client .mis_builder thead {
+    position: sticky;
+    top: 0px;
+}


### PR DESCRIPTION
Hello ! 
Here is the modification of the CSS of the table header on mis-builder preview, making the header stick on the top of the page. Only CSS has been modified. 
Thank you in advance for the review,
This is my first PR, so please be gentile :)
 