### PR TITLE
[16.0][IMP] allow multi-company MIS budgets by account

### DIFF
--- a/mis_builder_budget/models/mis_budget_by_account.py
+++ b/mis_builder_budget/models/mis_budget_by_account.py
@@ -12,7 +12,7 @@ class MisBudgetByAccount(models.Model):
     item_ids = fields.One2many(
         comodel_name="mis.budget.by.account.item", inverse_name="budget_id", copy=True
     )
-    company_id = fields.Many2one(required=True)
+    company_id = fields.Many2one(required=False)
     allow_items_overlap = fields.Boolean(
         help="If checked, overlap between budget items is allowed"
     )

--- a/mis_builder_budget/models/mis_budget_by_account_item.py
+++ b/mis_builder_budget/models/mis_budget_by_account_item.py
@@ -22,13 +22,13 @@ class MisBudgetByAccountItem(models.Model):
     )
     company_id = fields.Many2one(
         "res.company",
-        related="budget_id.company_id",
+        related="account_id.company_id",
         readonly=True,
         store=True,
     )
     company_currency_id = fields.Many2one(
         "res.currency",
-        related="budget_id.company_id.currency_id",
+        related="account_id.company_id.currency_id",
         string="Company Currency",
         readonly=True,
         help="Utility field to express amount currency",
@@ -38,7 +38,6 @@ class MisBudgetByAccountItem(models.Model):
         comodel_name="account.account",
         string="Account",
         required=True,
-        # TODO domain (company_id)
     )
 
     _sql_constraints = [


### PR DESCRIPTION
When doing multi-company consolidation with MIS Builder we may want to also display the corresponding budget.

It can therefore be desirable to create a MIS budget by account that applies to multiple companies.

It turns out that making the `company_id` field required for MIS Budgets by Accounts is overly restrictive, and that the really important thing is that the `company_id` on budget items matches the company of the account of the item.
