### PR TITLE
[IMP] mis-builder: set analytic account constraint in the filter when displayed

### DIFF
--- a/mis_builder/__manifest__.py
+++ b/mis_builder/__manifest__.py
@@ -29,6 +29,7 @@
     ],
     "assets": {
         "web.assets_backend": [
+            "mis_builder/static/src/components/search_model.esm.js",
             "mis_builder/static/src/components/mis_report_widget.esm.js",
             "mis_builder/static/src/components/mis_report_widget.xml",
             "mis_builder/static/src/components/mis_report_widget.css",

--- a/mis_builder/static/src/components/mis_report_widget.esm.js
+++ b/mis_builder/static/src/components/mis_report_widget.esm.js
@@ -3,6 +3,7 @@
 import {Component, onWillStart, useState, useSubEnv} from "@odoo/owl";
 import {useBus, useService} from "@web/core/utils/hooks";
 import {DatePicker} from "@web/core/datepicker/datepicker";
+import {Domain} from "@web/core/domain";
 import {FilterMenu} from "@web/search/filter_menu/filter_menu";
 import {SearchBar} from "@web/search/search_bar/search_bar";
 import {SearchModel} from "@web/search/search_model";
@@ -104,11 +105,16 @@ export class MisReportWidget extends Component {
     }
 
     get context() {
-        var ctx = super.context;
-        if (this.showSearchBar) {
+        let ctx = this.props.record.context;
+        if (this.showSearchBar && this.searchModel.searchDomain) {
             ctx = {
                 ...ctx,
-                mis_analytic_domain: this.searchModel.searchDomain,
+                mis_analytic_domain: Domain.and([
+                    new Domain(
+                        this.props.record.context.mis_analytic_domain || Domain.TRUE
+                    ),
+                    new Domain(this.searchModel.searchDomain),
+                ]).toList(),
             };
         }
         if (this.showPivotDate && this.state.pivot_date) {

--- a/mis_builder/static/src/components/search_model.esm.js
+++ b/mis_builder/static/src/components/search_model.esm.js
@@ -1,0 +1,105 @@
+/** @odoo-module **/
+
+import {SearchModel} from "@web/search/search_model";
+import {useService} from "@web/core/utils/hooks";
+
+export class MisReportSearchModel extends SearchModel {
+    /**
+     * @override
+     */
+    setup() {
+        this.notificationService = useService("notification");
+        super.setup(...arguments);
+    }
+
+    /**
+     * @override
+     */
+    deactivateGroup(groupId) {
+        // Prevent removing the analytic account filter and let the user know.
+        let reactivateAnalyticAccountFilter = false;
+        if (this.analyticAccountSearchItem.groupId === groupId) {
+            if (
+                this.query.filter(
+                    (query) => query.searchItemId === this.analyticAccountSearchItem.id
+                ).length === 1
+            ) {
+                this.notificationService.add(
+                    this.env._t("The analytic account filter cannot be removed"),
+                    {type: "info"}
+                );
+                return;
+            }
+            // As there are more than one filter on the analytic account, let
+            // super remove them and add it back after.
+            reactivateAnalyticAccountFilter = true;
+        }
+        super.deactivateGroup(groupId);
+        if (reactivateAnalyticAccountFilter) {
+            this._addAnalyticAccountFilter();
+        }
+    }
+
+    /**
+     * @override
+     */
+    async load(config) {
+        // Store analytic account id in the SearchModel for reuse in other functions.
+        this.analyticAccountId = config.analyticAccountId;
+        const analyticAccountNamePromise = this._loadAnalyticAccountName();
+        await Promise.all([analyticAccountNamePromise, super.load(...arguments)]);
+        this._determineAnalyticAccountSearchItem();
+        this._addAnalyticAccountFilter();
+    }
+
+    /**
+     * Add the filter regarding the analytic account in the search model.
+     * @private
+     */
+    _addAnalyticAccountFilter() {
+        if (!this.analyticAccountSearchItem || !this.analyticAccountName) {
+            return;
+        }
+        this.addAutoCompletionValues(this.analyticAccountSearchItem.id, {
+            label: this.analyticAccountName,
+            operator: "=",
+            value: this.analyticAccountId,
+        });
+    }
+
+    /**
+     * Find the searchItem that correspond to the analytic account field and store it
+     * under analyticAccountSearchItem.
+     * @private
+     */
+    _determineAnalyticAccountSearchItem() {
+        // Store analytic account searchItem in the SearchModel for reuse in other functions.
+        for (const searchItem of Object.values(this.searchItems)) {
+            if (
+                searchItem.type === "field" &&
+                searchItem.fieldName === "analytic_account_id"
+            ) {
+                this.analyticAccountSearchItem = searchItem;
+                break;
+            }
+        }
+    }
+
+    /**
+     * Load the analytic account name and store it under analyticAccountName.
+     * @returns {Promise<void>}
+     * @private
+     */
+    async _loadAnalyticAccountName() {
+        if (!this.analyticAccountId) {
+            return;
+        }
+        const readResult = await this.orm.read(
+            "account.analytic.account",
+            [this.analyticAccountId],
+            ["display_name"]
+        );
+        const analyticAccount = readResult[0];
+        this.analyticAccountName = analyticAccount.display_name;
+    }
+}


### PR DESCRIPTION
Up to now, the domain on analytic_account was not visible to the user. After this commit, the domain will be visible in the filters if they are displayed.

Blocked by https://github.com/OCA/mis-builder/pull/591