### PR TITLE
[16.0][IMP] mis_builder: preserve the filters when navigating back from drill-down

### DIFF
--- a/mis_builder/__manifest__.py
+++ b/mis_builder/__manifest__.py
@@ -32,6 +32,8 @@
             "mis_builder/static/src/components/mis_report_widget.esm.js",
             "mis_builder/static/src/components/mis_report_widget.xml",
             "mis_builder/static/src/components/mis_report_widget.css",
+            "mis_builder/static/src/views/form/mis_report_form_controller.esm.js",
+            "mis_builder/static/src/views/form/mis_report_form_view.esm.js",
         ],
         "web.report_assets_common": [
             "/mis_builder/static/src/css/report.css",

--- a/mis_builder/static/src/components/mis_report_widget.esm.js
+++ b/mis_builder/static/src/components/mis_report_widget.esm.js
@@ -3,6 +3,7 @@
 import {Component, onWillStart, useState, useSubEnv} from "@odoo/owl";
 import {useBus, useService} from "@web/core/utils/hooks";
 import {DatePicker} from "@web/core/datepicker/datepicker";
+import {Domain} from "@web/core/domain";
 import {FilterMenu} from "@web/search/filter_menu/filter_menu";
 import {SearchBar} from "@web/search/search_bar/search_bar";
 import {SearchModel} from "@web/search/search_model";
@@ -104,11 +105,16 @@ export class MisReportWidget extends Component {
     }
 
     get context() {
-        var ctx = super.context;
-        if (this.showSearchBar) {
+        let ctx = this.props.record.context;
+        if (this.showSearchBar && this.searchModel.searchDomain) {
             ctx = {
                 ...ctx,
-                mis_analytic_domain: this.searchModel.searchDomain,
+                mis_analytic_domain: Domain.and([
+                    new Domain(
+                        this.props.record.context.mis_analytic_domain || Domain.TRUE
+                    ),
+                    new Domain(this.searchModel.searchDomain),
+                ]).toList(),
             };
         }
         if (this.showPivotDate && this.state.pivot_date) {

--- a/mis_builder/static/src/components/mis_report_widget.esm.js
+++ b/mis_builder/static/src/components/mis_report_widget.esm.js
@@ -9,6 +9,7 @@ import {SearchBar} from "@web/search/search_bar/search_bar";
 import {SearchModel} from "@web/search/search_model";
 import {parseDate} from "@web/core/l10n/dates";
 import {registry} from "@web/core/registry";
+import {useSetupAction} from "@web/webclient/actions/action_hook";
 
 export class MisReportWidget extends Component {
     setup() {
@@ -33,6 +34,18 @@ export class MisReportWidget extends Component {
             this.refresh();
         });
         onWillStart(this.willStart);
+        useSetupAction({
+            getGlobalState: () => {
+                if (!this.showSearchBar) {
+                    return {};
+                }
+                return {
+                    misReportSearchModelState: JSON.stringify(
+                        this.searchModel.exportState()
+                    ),
+                };
+            },
+        });
     }
 
     // Lifecycle
@@ -59,10 +72,14 @@ export class MisReportWidget extends Component {
         this.widget_show_pivot_date = result.widget_show_pivot_date;
         if (this.showSearchBar) {
             // Initialize the search model
-            await this.searchModel.load({
+            const config = {
                 resModel: this.source_aml_model_name,
                 searchViewId: this.widget_search_view_id,
-            });
+            };
+            if (this.env.misReportSearchModelState) {
+                config.state = JSON.parse(this.env.misReportSearchModelState);
+            }
+            await this.searchModel.load(config);
         }
 
         // Compute the report

--- a/mis_builder/static/src/views/form/mis_report_form_controller.esm.js
+++ b/mis_builder/static/src/views/form/mis_report_form_controller.esm.js
@@ -1,0 +1,15 @@
+/** @odoo-module */
+
+import {FormController} from "@web/views/form/form_controller";
+import {useSubEnv} from "@odoo/owl";
+
+export class MisReportFormController extends FormController {
+    setup() {
+        super.setup();
+        useSubEnv({
+            misReportSearchModelState:
+                this.props.globalState &&
+                this.props.globalState.misReportSearchModelState,
+        });
+    }
+}

--- a/mis_builder/static/src/views/form/mis_report_form_view.esm.js
+++ b/mis_builder/static/src/views/form/mis_report_form_view.esm.js
@@ -1,0 +1,14 @@
+/** @odoo-module **/
+
+import {MisReportFormController} from "@mis_builder/views/form/mis_report_form_controller.esm";
+import {formView} from "@web/views/form/form_view";
+import {registry} from "@web/core/registry";
+
+// The view to use when mounting `mis_report_widget` widget in order to preserve the
+// filters when returning from the drill-down views.
+export const misReportFormView = {
+    ...formView,
+    Controller: MisReportFormController,
+};
+
+registry.category("views").add("mis_report_form_view", misReportFormView);

--- a/mis_builder/views/mis_report_instance.xml
+++ b/mis_builder/views/mis_report_instance.xml
@@ -10,13 +10,14 @@
                 edit="false"
                 create="false"
                 delete="false"
+                js_class="mis_report_form_view"
             >
                 <sheet>
                     <field
                         name="id"
                         widget="mis_report_widget"
                         nolabel="1"
-                        style="width:100%"
+                        class="w-100"
                     />
                 </sheet>
             </form>


### PR DESCRIPTION
Prior to this commit the state of the searchModel was lost when navigating
back from a drill-down.

This commit uses the globalState in order to store and restore the state
of the searchModlel. The use of a SubEnv allows not having to pass props
up to the widget, which would have required overriding the renderer, the
compiler and field.

Blocked by #585 

