### PR TITLE
[16.0][FIX] mis_builder: use compute_sudo on field source_aml_model_id to prevent errors due to missing permissions.

### DIFF
--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -330,9 +330,11 @@ class MisReportInstancePeriod(models.Model):
     def _check_source_aml_model_id(self):
         for record in self:
             if record.source_aml_model_id:
-                record_model = record.source_aml_model_id.field_id.filtered(
-                    lambda r: r.name == "account_id"
-                ).relation
+                record_model = (
+                    record.source_aml_model_id.sudo()
+                    .field_id.filtered(lambda r: r.name == "account_id")
+                    .relation
+                )
                 report_account_model = record.report_id.account_model
                 if record_model != report_account_model:
                     raise ValidationError(

--- a/mis_builder/readme/newsfragments/596.bugfix
+++ b/mis_builder/readme/newsfragments/596.bugfix
@@ -1,0 +1,1 @@
+Resolve a permission issue when creating report periods with a user without admin rights.


### PR DESCRIPTION
The field source_aml_model_id refers to the ir.model, which is a technical in nature, and users should not have naturally permission to read them directly.


## Test => PENDING
Don't forget to add unit tests. If your PR fixes a bug, prefer creating a separate
commit for the test so we one see that your test reproduces the bug and is fixed by the
PR.

## Target branch => PENDING TO CHECK IF PREVIOUS BRANCHES ARE AFFECTED

MIS Builder is actively maintained for Odoo versions 9, 10, 11 and 12.

If your feature is applicable with the same implementation to all these versions, please
target branch 10.0. Maintainers will port it to 9, 11 and 12 soon after merging.

In the rare cases your feature or implementation is specific to an Odoo version, then
target the corresponding branch.


## Changelog entry => DONE

