### PR TITLE
[16.0][FIX] mis_builder: python 3.9 compatibility 

### DIFF
--- a/mis_builder/models/aep.py
+++ b/mis_builder/models/aep.py
@@ -543,4 +543,4 @@ class AccountingExpressionProcessor:
         # TODO shoud we include here the accounts of type "unaffected"
         # or leave that to the caller?
         bals = cls._get_balances(cls.MODE_UNALLOCATED, companies, date, date)
-        return tuple(map(sum, zip(*bals.values(), strict=True)))
+        return tuple(map(sum, zip(*bals.values())))  # noqa: B905

--- a/mis_builder/models/expression_evaluator.py
+++ b/mis_builder/models/expression_evaluator.py
@@ -58,7 +58,7 @@ class ExpressionEvaluator:
             vals = []
             drilldown_args = []
             name_error = False
-            for expr, replaced_expr in zip(exprs, replaced_exprs, strict=True):
+            for expr, replaced_expr in zip(exprs, replaced_exprs):  # noqa: B905
                 val = mis_safe_eval(replaced_expr, locals_dict)
                 vals.append(val)
                 if replaced_expr != expr:

--- a/mis_builder/models/kpimatrix.py
+++ b/mis_builder/models/kpimatrix.py
@@ -234,9 +234,7 @@ class KpiMatrix:
         cell_tuple = []
         assert len(vals) == col.colspan
         assert len(drilldown_args) == col.colspan
-        for val, drilldown_arg, subcol in zip(
-            vals, drilldown_args, col.iter_subcols(), strict=True
-        ):
+        for val, drilldown_arg, subcol in zip(vals, drilldown_args, col.iter_subcols()):  # noqa: B905
             if isinstance(val, DataError):
                 val_rendered = val.name
                 val_comment = val.msg
@@ -347,11 +345,10 @@ class KpiMatrix:
                         if not common_subkpis or cell.subcol.subkpi in common_subkpis
                     ]
                 comparison_cell_tuple = []
-                for val, base_val, comparison_subcol in zip(
+                for val, base_val, comparison_subcol in zip(  # noqa: B905
                     vals,
                     base_vals,
                     comparison_col.iter_subcols(),
-                    strict=True,
                 ):
                     # TODO FIXME average factors
                     comparison = self._style_model.compare_and_render(

--- a/mis_builder/readme/newsfragments/590.bugfix
+++ b/mis_builder/readme/newsfragments/590.bugfix
@@ -1,0 +1,1 @@
+Restore compatibility with python 3.9


### PR DESCRIPTION
Make the code compatible with Python 3.9 to allow using official Odoo Docker containers

Closes https://github.com/OCA/mis-builder/issues/590