### PR TITLE
[13.0][FIX] mis_builder: add sudo to access field_id due missing permissions (backport)

### DIFF
--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -322,9 +322,11 @@ class MisReportInstancePeriod(models.Model):
     def _check_source_aml_model_id(self):
         for record in self:
             if record.source_aml_model_id:
-                record_model = record.source_aml_model_id.field_id.filtered(
-                    lambda r: r.name == "account_id"
-                ).relation
+                record_model = (
+                    record.source_aml_model_id.sudo()
+                    .field_id.filtered(lambda r: r.name == "account_id")
+                    .relation
+                )
                 report_account_model = record.report_id.account_model
                 if record_model != report_account_model:
                     raise ValidationError(

--- a/mis_builder/readme/newsfragments/596.bugfix
+++ b/mis_builder/readme/newsfragments/596.bugfix
@@ -1,0 +1,1 @@
+Resolve a permission issue when creating report periods with a user without admin rights.


### PR DESCRIPTION
Backport of https://github.com/OCA/mis-builder/pull/596.