### PR TITLE
[17.0][FIX] mis_builder_budget: correct manifest version

### DIFF
--- a/mis_builder_budget/__manifest__.py
+++ b/mis_builder_budget/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "MIS Builder Budget",
     "summary": """
         Create budgets for MIS reports""",
-    "version": "16.0.5.0.2",
+    "version": "17.0.1.0.0",
     "license": "AGPL-3",
     "author": "ACSONE SA/NV, " "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/mis-builder",


### PR DESCRIPTION
Thanks for your pull request. Please take a moment to review if it meets the following
guidelines.

## Description

Correct manifest version as it crashes Odoo start due to wrong version.

## Test

No test

## Target branch
17.0

## CLA

Have you signed the OCA Contributor License Agreement? If not, please visit
https://odoo-community.org/page/cla to learn how.

## Changelog entry

This projects uses [towncrier](https://pypi.org/project/towncrier/) to generate it's
changelog. Make sure your PR includes a changelog entry in
`<addon>/readme/newsfragments/`. It must have the issue or PR number as name, and one of
`.feature`, `.bugfix`, `.doc` (for documentation improvements), `.misc` (if a ticket has
been closed, but it is not of interest to users). The changelog entry must be reasonably
short and phrased in a way that is understandable by end users.

## Documentation

Consider improving the documention in `docs/`.
