### PR TITLE
[14.0][IMP] mis_builder_budget: drilldown: default budget & account

### DIFF
--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -944,6 +944,8 @@ class MisReportInstance(models.Model):
                 account_id,
             )
             domain.extend(period._get_additional_move_line_filter())
+            context = dict(self.env.context)
+            context["active_test"] = False
             return {
                 "name": self._get_drilldown_action_name(arg),
                 "domain": domain,
@@ -952,7 +954,7 @@ class MisReportInstance(models.Model):
                 "views": [[False, "list"], [False, "form"]],
                 "view_mode": "list",
                 "target": "current",
-                "context": {"active_test": False},
+                "context": context,
             }
         else:
             return False

--- a/mis_builder_budget/models/mis_report_instance.py
+++ b/mis_builder_budget/models/mis_report_instance.py
@@ -118,4 +118,9 @@ class MisReportInstance(models.Model):
                     "view_mode": "list",
                     "target": "current",
                 }
+            elif period.source == SRC_MIS_BUDGET_BY_ACCOUNT:
+                self = self.with_context(
+                    default_budget_id=period.source_mis_budget_by_account_id.id,
+                    default_account_id=arg.get("account_id"),
+                )
         return super().drilldown(arg)

--- a/mis_builder_budget/readme/newsfragments/605.feature
+++ b/mis_builder_budget/readme/newsfragments/605.feature
@@ -1,0 +1,3 @@
+Drilldown to "Budget By Account Items": Pass default budget and default account.
+
+If the budget allows items overlap, one can create new budget items in the drilldown.


### PR DESCRIPTION
Drilldown to "Budget By Account Items": Pass default budget and default account.

If the budget allows items overlap, one can create new budget items in the drilldown.
