### PR TITLE
[FIX] mis_builder: use sudo when calling ir.ui.view

### DIFF
--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -885,8 +885,10 @@ class MisReportInstance(models.Model):
     @api.model
     def _get_drilldown_model_views(self, model_name):
         self.ensure_one()
-        types = self.env["ir.ui.view"]._read_group(
-            [("model", "=", model_name)], ["type"], ["type"]
+        types = (
+            self.env["ir.ui.view"]
+            .sudo()
+            ._read_group([("model", "=", model_name)], ["type"], ["type"])
         )
         views_order = self._get_drilldown_views_and_orders()
         views = {type["type"] for type in types if type["type"] in views_order}


### PR DESCRIPTION
When you try to access to account move lines inside a MIS report with an user that has no admin rights, it returns an Access Error.
That is because the function _get_drilldown_model_views() is trying to get the types by calling ir.ui.view model without sudo permitions.

Here is a video replicating the error: https://app.screencastify.com/v3/watch/mw9vsXxOosnvNKLSfKtc
Regads
