### PR TITLE
[16.0][ADD] mis_builder: add option on report instance to drilldown in popup

### DIFF
--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -580,6 +580,9 @@ class MisReportInstance(models.Model):
         string="Filter box search view",
         help="Search view to customize the filter box in the report widget.",
     )
+    drilldown_open_in_pop_up = fields.Boolean(
+        string="Drilldown in a pop up window",
+    )
 
     @api.depends("report_id.move_lines_source")
     def _compute_widget_search_view_id(self):
@@ -921,7 +924,7 @@ class MisReportInstance(models.Model):
                 "res_model": period.source_aml_model_name,
                 "views": [[False, view] for view in views],
                 "view_mode": ",".join(view for view in views),
-                "target": "current",
+                "target": "new" if self.drilldown_open_in_pop_up else "current",
                 "context": {"active_test": False},
             }
         else:

--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -917,6 +917,10 @@ class MisReportInstance(models.Model):
             )
             domain.extend(period._get_additional_move_line_filter())
             views = self._get_drilldown_model_views(period.source_aml_model_name)
+            # Keep all context for hook
+            context = dict(self.env.context)
+            context.update({"active_test": False})
+
             return {
                 "name": self._get_drilldown_action_name(arg),
                 "domain": domain,
@@ -925,7 +929,7 @@ class MisReportInstance(models.Model):
                 "views": [[False, view] for view in views],
                 "view_mode": ",".join(view for view in views),
                 "target": "new" if self.drilldown_open_in_pop_up else "current",
-                "context": {"active_test": False},
+                "context": context,
             }
         else:
             return False

--- a/mis_builder/views/mis_report_instance.xml
+++ b/mis_builder/views/mis_report_instance.xml
@@ -208,6 +208,11 @@
                                 <field name="widget_show_pivot_date" />
                             </group>
                         </page>
+                        <page string="Drilldown">
+                            <group name="drilldown">
+                                <field name="drilldown_open_in_pop_up" />
+                            </group>
+                        </page>
                     </notebook>
                 </sheet>
             </form>


### PR DESCRIPTION
When drilling down on a cell inside a report, open it in a new pop-up window instead of current window to avoid reloading the report when going back.

It is customizable on each report instance: 
![image](https://github.com/user-attachments/assets/7e3d66c8-273a-42e4-82e5-9e7f810f5902)
