### PR TITLE
[IMP][16.0] mis_builder: allow definition of style expression on subkpi level

### DIFF
--- a/mis_builder/models/kpimatrix.py
+++ b/mis_builder/models/kpimatrix.py
@@ -235,32 +235,30 @@ class KpiMatrix:
         assert len(vals) == col.colspan
         assert len(drilldown_args) == col.colspan
         for val, drilldown_arg, subcol in zip(vals, drilldown_args, col.iter_subcols()):  # noqa: B905
-            if isinstance(val, DataError):
-                val_rendered = val.name
-                val_comment = val.msg
-            else:
-                val_rendered = self._style_model.render(
-                    self.lang, row.style_props, kpi.type, val
-                )
-                if row.kpi.multi and subcol.subkpi:
-                    val_comment = "{}.{} = {}".format(
-                        row.kpi.name,
-                        subcol.subkpi.name,
-                        row.kpi._get_expression_str_for_subkpi(subcol.subkpi),
-                    )
-                else:
-                    val_comment = f"{row.kpi.name} = {row.kpi.expression}"
             cell_style_props = row.style_props
-            if row.kpi.style_expression:
+
+            style_expression = ""
+            if (
+                row.kpi.multi
+                and subcol.subkpi
+                and row.kpi.expression_ids.filtered(
+                    lambda rec, subkpi=subcol.subkpi: rec.subkpi_id == subkpi
+                ).style_expression
+            ):
+                style_expression = row.kpi.expression_ids.filtered(
+                    lambda rec, subkpi=subcol.subkpi: rec.subkpi_id == subkpi
+                ).style_expression
+            elif row.kpi.style_expression:
+                style_expression = row.kpi.style_expression
+
+            if style_expression:
                 # evaluate style expression
                 try:
-                    style_name = mis_safe_eval(
-                        row.kpi.style_expression, col.locals_dict
-                    )
+                    style_name = mis_safe_eval(style_expression, col.locals_dict)
                 except Exception:
                     _logger.error(
                         "Error evaluating style expression <%s>",
-                        row.kpi.style_expression,
+                        style_expression,
                         exc_info=True,
                     )
                 if style_name:
@@ -271,6 +269,23 @@ class KpiMatrix:
                         )
                     else:
                         _logger.error("Style '%s' not found.", style_name)
+
+            if isinstance(val, DataError):
+                val_rendered = val.name
+                val_comment = val.msg
+            else:
+                val_rendered = self._style_model.render(
+                    self.lang, cell_style_props, kpi.type, val
+                )
+                if row.kpi.multi and subcol.subkpi:
+                    val_comment = "{}.{} = {}".format(
+                        row.kpi.name,
+                        subcol.subkpi.name,
+                        row.kpi._get_expression_str_for_subkpi(subcol.subkpi),
+                    )
+                else:
+                    val_comment = f"{row.kpi.name} = {row.kpi.expression}"
+
             cell = KpiMatrixCell(
                 row,
                 subcol,

--- a/mis_builder/models/mis_report.py
+++ b/mis_builder/models/mis_report.py
@@ -298,6 +298,11 @@ class MisReportKpiExpression(models.Model):
     # TODO FIXME set readonly=True when onchange('subkpi_ids') below works
     subkpi_id = fields.Many2one("mis.report.subkpi", readonly=False, ondelete="cascade")
 
+    style_expression = fields.Char(
+        help="An expression that returns a style depending on the KPI value. "
+        "Such style is applied on top of the row style.",
+    )
+
     _sql_constraints = [
         (
             "subkpi_kpi_unique",

--- a/mis_builder/views/mis_report.xml
+++ b/mis_builder/views/mis_report.xml
@@ -142,6 +142,7 @@
                                         domain="[('report_id', '=', parent.report_id)]"
                                     />
                                     <field name="name" />
+                                    <field name="style_expression" />
                                 </tree>
                             </field>
                             <field


### PR DESCRIPTION
## Description

Solves issue: https://github.com/OCA/mis-builder/issues/614

The goal is to be able to define a style on a cell. Therefore, this PR allows to define a style on a subkpi:
![image](https://github.com/user-attachments/assets/aa7a41f4-c9ed-4ee2-9ce9-b1519c064014)
On my row, I will have my cell with `KPI_1` in red and my cell with `KPI_2` without any style.

## Remark
There are now 3 ways to define a style:

1. `Style` on a KPI
2. `Style expression` on a KPI
3. `Style expression` in expressions of a KPI

The sytle defined in [3] has priority over [2] which has priority over [1].