### PR TITLE
[16.0][IMP] mis_builder: support multi company on non-accounting queries

### DIFF
--- a/mis_builder/models/mis_report.py
+++ b/mis_builder/models/mis_report.py
@@ -392,12 +392,19 @@ class MisReportQuery(models.Model):
     date_field = fields.Many2one(
         comodel_name="ir.model.fields",
         required=True,
-        domain=[("ttype", "in", ("date", "datetime"))],
+        domain="[('ttype', 'in', ('date', 'datetime')),('model_id', '=', model_id)]",
         ondelete="cascade",
     )
     domain = fields.Char()
     report_id = fields.Many2one(
         comodel_name="mis.report", required=True, ondelete="cascade"
+    )
+    company_field_id = fields.Many2one(
+        comodel_name="ir.model.fields",
+        ondelete="set null",
+        domain="[('model_id', '=', model_id)]",
+        help="Field that defines company on related model."
+        "When set, it will be automatically be added in search domain of query.",
     )
 
     _order = "name"

--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -407,7 +407,12 @@ class MisReportInstancePeriod(models.Model):
         Returns an Odoo domain expression (a python list)
         compatible with the model of the query."""
         self.ensure_one()
-        return []
+        domain = []
+        if company_field := query.sudo().company_field_id:
+            query_company_ids = self.report_instance_id.query_company_ids.ids
+            assert query_company_ids
+            domain = [(company_field.name, "in", query_company_ids)]
+        return domain
 
     @api.constrains("mode", "source")
     def _check_mode_source(self):

--- a/mis_builder/tests/test_mis_report_instance.py
+++ b/mis_builder/tests/test_mis_report_instance.py
@@ -633,3 +633,22 @@ class TestMisReportInstance(common.HttpCase):
             self.env, "mis_you", groups="base.group_user,account.group_account_readonly"
         )
         self.report_instance.with_user(test_user).compute()
+
+    def test_query_company(self):
+        c1 = self.report_instance.company_id
+
+        query = self.report.query_ids
+        self.assertEqual(len(query), 1)
+
+        period = self.report_instance.period_ids[0]
+        domain = period.with_company(c1)._get_additional_query_filter(query)
+
+        self.assertEqual(domain, [])
+
+        query.company_field_id = self.env["ir.model.fields"].search(
+            [("name", "=", "company_id"), ("model", "=", "res.partner")]
+        )
+
+        domain = period.with_company(c1)._get_additional_query_filter(query)
+
+        self.assertEqual(domain, [("company_id", "in", c1.ids)])

--- a/mis_builder/views/mis_report.xml
+++ b/mis_builder/views/mis_report.xml
@@ -69,6 +69,7 @@
                                         name="date_field"
                                         domain="[('model_id', '=', model_id), ('ttype', 'in', ('date', 'datetime'))]"
                                     />
+                                    <field name="company_field_id" />
                                     <field name="domain" />
                                 </tree>
                             </field>


### PR DESCRIPTION
## Description

Adds the possibility to specify a company field on queries.
This field will be used to filter records that are on the company of the instance report (using 'query_company_ids')
