### PR TITLE
[IMP] mis_builder_budget: allow to specify a company on budget by kpi

### DIFF
--- a/mis_builder_budget/models/mis_budget_item.py
+++ b/mis_builder_budget/models/mis_budget_item.py
@@ -19,10 +19,30 @@ class MisBudgetItem(models.Model):
         )
     )
 
+    company_id = fields.Many2one(
+        comodel_name="res.company",
+        compute="_compute_company_id",
+        store=True,
+        readonly=False,
+    )
+    budget_company_id = fields.Many2one(
+        string="#Technical field: Budget Company", related="budget_id.company_id"
+    )
+
+    @api.depends("budget_id.company_id")
+    def _compute_company_id(self):
+        for rec in self:
+            rec.company_id = rec.budget_id.company_id
+
     def _prepare_overlap_domain(self):
         """Prepare a domain to check for overlapping budget items."""
         domain = super()._prepare_overlap_domain()
-        domain.extend([("kpi_expression_id", "=", self.kpi_expression_id.id)])
+        domain.extend(
+            [
+                ("kpi_expression_id", "=", self.kpi_expression_id.id),
+                ("company_id", "=", self.company_id.id),
+            ]
+        )
         return domain
 
     @api.constrains(
@@ -31,6 +51,7 @@ class MisBudgetItem(models.Model):
         "date_to",
         "budget_id",
         "kpi_expression_id",
+        "company_id",
     )
     def _check_dates(self):
         super()._check_dates()

--- a/mis_builder_budget/models/mis_report_instance_period.py
+++ b/mis_builder_budget/models/mis_report_instance_period.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
+from odoo.osv.expression import AND
 
 SRC_MIS_BUDGET = "mis_budget"
 SRC_MIS_BUDGET_BY_ACCOUNT = "mis_budget_by_account"
@@ -69,4 +70,17 @@ class MisReportInstancePeriod(models.Model):
         compatible with mis.budget.item."""
         self.ensure_one()
         filters = self._get_additional_move_line_filter()
+
+        query_companies = self.report_instance_id.query_company_ids
+        filters = AND(
+            [
+                filters,
+                [
+                    "|",
+                    ("company_id", "in", query_companies.ids),
+                    ("company_id", "=", False),
+                ],
+            ]
+        )
+
         return filters

--- a/mis_builder_budget/security/mis_budget_item.xml
+++ b/mis_builder_budget/security/mis_budget_item.xml
@@ -24,7 +24,7 @@
         <field name="name">mis.budget.item multi company</field>
         <field name="model_id" ref="model_mis_budget_item" />
         <field name="domain_force">
-            ['|',('budget_id.company_id','=',False),('budget_id.company_id','in',company_ids)]
+            ['|',('company_id','=',False),('company_id','in',company_ids)]
         </field>
     </record>
 </odoo>

--- a/mis_builder_budget/tests/test_mis_budget.py
+++ b/mis_builder_budget/tests/test_mis_budget.py
@@ -132,6 +132,9 @@ class TestMisBudget(TransactionCase):
                 ("date_to", ">=", datetime.date(2017, 1, 1)),
                 ("kpi_expression_id", "=", self.expr1.id),
                 ("budget_id", "=", self.budget.id),
+                "|",
+                ("company_id", "in", [self.env.company.id]),
+                ("company_id", "=", False),
             ],
         )
 

--- a/mis_builder_budget/views/mis_budget_item.xml
+++ b/mis_builder_budget/views/mis_budget_item.xml
@@ -22,11 +22,16 @@
                 <field name="report_id" invisible="1" />
                 <field name="budget_date_from" invisible="1" />
                 <field name="budget_date_to" invisible="1" />
+                <field name="budget_company_id" invisible="1" />
                 <field name="kpi_expression_id" />
                 <field name="date_range_id" />
                 <field name="date_from" />
                 <field name="date_to" />
                 <field name="amount" />
+                <field
+                    name="company_id"
+                    attrs="{'readonly':[('budget_company_id','!=',False)]}"
+                />
             </tree>
         </field>
     </record>


### PR DESCRIPTION
Fixes issue: https://github.com/OCA/mis-builder/issues/620

The goal here is to be able to have one 'budget by kpi' for multiple companies.
Therefore, we need to be able to specify to which company a 'budget item' belongs