### PR TITLE
[17.0][FIX] mis_builder: Add analytic_domain to report instance only if it is set

### DIFF
--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -719,7 +719,8 @@ class MisReportInstance(models.Model):
             )
         )
         # report-level analytic domain filter
-        domain.extend(ast.literal_eval(self.analytic_domain))
+        if self.analytic_domain:
+            domain.extend(ast.literal_eval(self.analytic_domain))
         # contextual analytic domain filter
         domain.extend(self.env.context.get("mis_analytic_domain", []))
         return domain


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/mis-builder/pull/632

Changes done:
- [x] Add `analytic_domain` to report instance only if it is set

Please @pedrobaeza and @pilarvargas-tecnativa can you review it?

@Tecnativa TT50696