### PR TITLE
[16.0][IMP] mis_builder: add read access to model and fields to group account manager

### DIFF
--- a/mis_builder/security/ir.model.access.csv
+++ b/mis_builder/security/ir.model.access.csv
@@ -20,3 +20,5 @@ access_mis_report_subreport,access_mis_report_subreport,model_mis_report_subrepo
 manage_mis_report_style,access_mis_report_style,model_mis_report_style,account.group_account_manager,1,1,1,1
 access_mis_report_style,access_mis_report_style,model_mis_report_style,base.group_user,1,0,0,0
 access_add_to_dashboard_wizard,access_add_to_dashboard_wizard,model_add_mis_report_instance_dashboard_wizard,base.group_user,1,1,1,0
+access_read_ir_model_fields,access_read_ir_model_fields,base.model_ir_model_fields,account.group_account_manager,1,0,0,0
+access_read_ir_model,access_read_ir_model,base.model_ir_model,account.group_account_manager,1,0,0,0


### PR DESCRIPTION
## Description

Editing a query in a template can throw an access error.

This happens when a 'Billing administrator' (group_account_manager) hasn't the group 'Access Rights' (group_erp_manager).
In fact, only the group 'Access Rights' gives a read access to `ir_model` and `ir_model_fields`.
But, on a `mis.report.query`, the user needs those access to be able to set `model_id` `and field_ids`


