### PR TITLE
[16.0] backport #648 #649

### DIFF
--- a/mis_builder/models/aep.py
+++ b/mis_builder/models/aep.py
@@ -317,7 +317,11 @@ class AccountingExpressionProcessor:
         aml_model = aml_model.with_context(active_test=False)
         company_rates = self._get_company_rates(date_to)
         # {(domain, mode): {account_id: (debit, credit)}}
-        self._data = defaultdict(lambda: defaultdict(lambda: SimpleArray((0.0, 0.0))))
+        self._data = defaultdict(
+            lambda: defaultdict(
+                lambda: SimpleArray((AccountingNone, AccountingNone)),
+            )
+        )
         domain_by_mode = {}
         ends = []
         for key in self._map_account_ids:

--- a/mis_builder/models/aep.py
+++ b/mis_builder/models/aep.py
@@ -12,6 +12,7 @@ from odoo.tools.float_utils import float_is_zero
 from odoo.tools.safe_eval import datetime, dateutil, safe_eval, time
 
 from .accounting_none import AccountingNone
+from .simple_array import SimpleArray
 
 _logger = logging.getLogger(__name__)
 
@@ -316,7 +317,7 @@ class AccountingExpressionProcessor:
         aml_model = aml_model.with_context(active_test=False)
         company_rates = self._get_company_rates(date_to)
         # {(domain, mode): {account_id: (debit, credit)}}
-        self._data = defaultdict(dict)
+        self._data = defaultdict(lambda: defaultdict(lambda: SimpleArray((0.0, 0.0))))
         domain_by_mode = {}
         ends = []
         for key in self._map_account_ids:
@@ -366,16 +367,7 @@ class AccountingExpressionProcessor:
                     continue
                 # due to branches, it's possible to have multiple acc
                 # with the same account_id
-                if acc["account_id"][0] in self._data[key]:
-                    existing_debit, existing_credit = self._data[key][
-                        acc["account_id"][0]
-                    ]
-                else:
-                    existing_debit, existing_credit = (0.0, 0.0)
-                self._data[key][acc["account_id"][0]] = (
-                    existing_debit + debit * rate,
-                    existing_credit + credit * rate,
-                )
+                self._data[key][acc["account_id"][0]] += (debit * rate, credit * rate)
         # compute ending balances by summing initial and variation
         for key in ends:
             domain, mode = key

--- a/mis_builder/models/aep.py
+++ b/mis_builder/models/aep.py
@@ -364,7 +364,18 @@ class AccountingExpressionProcessor:
                 ):
                     # in initial mode, ignore accounts with 0 balance
                     continue
-                self._data[key][acc["account_id"][0]] = (debit * rate, credit * rate)
+                # due to branches, it's possible to have multiple acc
+                # with the same account_id
+                if acc["account_id"][0] in self._data[key]:
+                    existing_debit, existing_credit = self._data[key][
+                        acc["account_id"][0]
+                    ]
+                else:
+                    existing_debit, existing_credit = (0.0, 0.0)
+                self._data[key][acc["account_id"][0]] = (
+                    existing_debit + debit * rate,
+                    existing_credit + credit * rate,
+                )
         # compute ending balances by summing initial and variation
         for key in ends:
             domain, mode = key

--- a/mis_builder/tests/test_aep.py
+++ b/mis_builder/tests/test_aep.py
@@ -83,6 +83,7 @@ class TestAEP(common.TransactionCase):
         self.aep.parse_expr("bali[700IN]")
         self.aep.parse_expr("bale[700IN]")
         self.aep.parse_expr("balp[700IN]")
+        self.aep.parse_expr("balp[700NA]")  # account that does not exist
         self.aep.parse_expr("bali[400AR]")
         self.aep.parse_expr("bale[400AR]")
         self.aep.parse_expr("balp[400AR]")
@@ -193,6 +194,8 @@ class TestAEP(common.TransactionCase):
         # check ending balance
         self.assertEqual(self._eval("bale[400AR]"), 400)
         self.assertEqual(self._eval("bale[700IN]"), -300)
+        # check result for non existing account
+        self.assertIs(self._eval("bale[700NA]"), AccountingNone)
 
         # let's query for March
         self._do_queries(
@@ -227,8 +230,13 @@ class TestAEP(common.TransactionCase):
 
         # unallocated p&l from previous year
         self.assertEqual(self._eval("balu[]"), -100)
-
         # TODO allocate profits, and then...
+
+        # let's query for December where there is no data
+        self._do_queries(
+            datetime.date(self.curr_year, 12, 1), datetime.date(self.curr_year, 12, 31)
+        )
+        self.assertIs(self._eval("balp[700IN]"), AccountingNone)
 
     def test_aep_by_account(self):
         self.aep.done_parsing()

--- a/mis_builder/tests/test_aep.py
+++ b/mis_builder/tests/test_aep.py
@@ -403,28 +403,3 @@ class TestAEP(common.TransactionCase):
                 datetime.date(self.prev_year, 12, 1),
             )
         assert "Error while querying move line source" in str(cm.exception)
-
-    def test_aep_branch(self):
-        # create branch
-        self.branch = self.res_company.create(
-            {
-                "name": "AEP Branch",
-                "parent_id": self.company.id,
-            }
-        )
-        # create branch move in March this year
-        branch_move = self._create_move(
-            date=datetime.date(self.curr_year, 3, 1),
-            amount=50,
-            debit_acc=self.account_ar,
-            credit_acc=self.account_in,
-        )
-        branch_move.company_id = self.branch
-        self.aep = AEP(self.company | self.branch)
-        self.aep.parse_expr("balp[]")
-        self.aep.done_parsing()
-        self._do_queries(
-            datetime.date(self.curr_year, 3, 1), datetime.date(self.curr_year, 3, 31)
-        )
-        variation = self._eval_by_account_id("balp[]")
-        self.assertEqual(variation, {self.account_ar.id: 550, self.account_in.id: -550})

--- a/mis_builder/tests/test_aep.py
+++ b/mis_builder/tests/test_aep.py
@@ -395,3 +395,28 @@ class TestAEP(common.TransactionCase):
                 datetime.date(self.prev_year, 12, 1),
             )
         assert "Error while querying move line source" in str(cm.exception)
+
+    def test_aep_branch(self):
+        # create branch
+        self.branch = self.res_company.create(
+            {
+                "name": "AEP Branch",
+                "parent_id": self.company.id,
+            }
+        )
+        # create branch move in March this year
+        branch_move = self._create_move(
+            date=datetime.date(self.curr_year, 3, 1),
+            amount=50,
+            debit_acc=self.account_ar,
+            credit_acc=self.account_in,
+        )
+        branch_move.company_id = self.branch
+        self.aep = AEP(self.company | self.branch)
+        self.aep.parse_expr("balp[]")
+        self.aep.done_parsing()
+        self._do_queries(
+            datetime.date(self.curr_year, 3, 1), datetime.date(self.curr_year, 3, 31)
+        )
+        variation = self._eval_by_account_id("balp[]")
+        self.assertEqual(variation, {self.account_ar.id: 550, self.account_in.id: -550})


### PR DESCRIPTION
Backport an improvement (#648, #649) that is useful in 17+, but still compatible with 16 (and earlier), so subsequent changes in 16 (such as #584)  will be easier to forward port.