### PR TITLE
[15.0][IMP] mis_builder: change analytic account filter to many2many

### DIFF
--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -277,11 +277,11 @@ class MisReportInstancePeriod(models.Model):
         comodel_name="mis.report.instance.period", compute="_compute_allowed_cmpcol_ids"
     )
     # filters
-    analytic_account_id = fields.Many2one(
+    analytic_account_ids = fields.Many2one(
         comodel_name="account.analytic.account",
-        string="Analytic Account",
+        string="Analytic Accounts",
         help=(
-            "Filter column on journal entries that match this analytic account."
+            "Filter column on journal entries that have one of these analytic accounts."
             "This filter is combined with a AND with the report-level filters "
             "and cannot be modified in the preview."
         ),
@@ -422,8 +422,8 @@ class MisReportInstancePeriod(models.Model):
                     self.report_instance_id.target_move, aml_model_name
                 )
             )
-        if self.analytic_account_id:
-            domain.append(("analytic_account_id", "=", self.analytic_account_id.id))
+        if self.analytic_account_ids:
+            domain.append(("analytic_account_id", "in", self.analytic_account_ids.ids))
         if self.analytic_group_id:
             domain.append(
                 ("analytic_account_id.group_id", "=", self.analytic_group_id.id)
@@ -572,8 +572,8 @@ class MisReportInstance(models.Model):
     date_from = fields.Date(string="From")
     date_to = fields.Date(string="To")
     temporary = fields.Boolean(default=False)
-    analytic_account_id = fields.Many2one(
-        comodel_name="account.analytic.account", string="Analytic Account"
+    analytic_account_ids = fields.Many2many(
+        comodel_name="account.analytic.account", string="Analytic Accounts"
     )
     analytic_group_id = fields.Many2one(
         comodel_name="account.analytic.group",
@@ -618,14 +618,15 @@ class MisReportInstance(models.Model):
     @api.model
     def get_filter_descriptions_from_context(self):
         filters = self.env.context.get("mis_report_filters", {})
-        analytic_account_id = filters.get("analytic_account_id", {}).get("value")
+        analytic_account_ids = filters.get("analytic_account_ids", {}).get("value")
         filter_descriptions = []
-        if analytic_account_id:
-            analytic_account = self.env["account.analytic.account"].browse(
-                analytic_account_id
+        if analytic_account_ids:
+            analytic_accounts = self.env["account.analytic.account"].browse(
+                analytic_account_ids
             )
             filter_descriptions.append(
-                _("Analytic Account: %s") % analytic_account.display_name
+                _("Analytic Accounts: %s")
+                % ", ".join(analytic_accounts.mapped("display_name"))
             )
         analytic_group_id = filters.get("analytic_account_id.group_id", {}).get("value")
         if analytic_group_id:
@@ -713,10 +714,10 @@ class MisReportInstance(models.Model):
 
     def _add_analytic_filters_to_context(self, context):
         self.ensure_one()
-        if self.analytic_account_id:
+        if self.analytic_account_ids:
             context["mis_report_filters"]["analytic_account_id"] = {
-                "value": self.analytic_account_id.id,
-                "operator": "=",
+                "value": self.analytic_account_ids.ids,
+                "operator": "in",
             }
         if self.analytic_group_id:
             context["mis_report_filters"]["analytic_account_id.group_id"] = {

--- a/mis_builder/static/src/js/mis_report_widget.js
+++ b/mis_builder/static/src/js/mis_report_widget.js
@@ -31,9 +31,9 @@ odoo.define("mis_builder.widget", function (require) {
             self._super.apply(self, arguments);
             StandaloneFieldManagerMixin.init.call(self);
             self.model = new BasicModel(self); // For FieldManagerMixin
-            self.analytic_account_id_domain = []; // TODO unused for now
-            self.analytic_account_id_label = _t("Analytic Account Filter");
-            self.analytic_account_id_m2o = undefined; // Field widget
+            self.analytic_account_ids_domain = []; // TODO unused for now
+            self.analytic_account_ids_label = _t("Analytic Accounts Filter");
+            self.analytic_account_ids_m2m = undefined; // Field widget
             self.analytic_group_id_domain = []; // TODO unused for now
             self.analytic_group_filter_name = "analytic_account_id.group_id";
             self.analytic_group_id_label = _t("Analytic Account Group");
@@ -174,8 +174,8 @@ odoo.define("mis_builder.widget", function (require) {
             if (self.has_group_analytic_accounting) {
                 fields.push({
                     relation: "account.analytic.account",
-                    type: "many2one",
-                    name: "filter_analytic_account_id",
+                    type: "many2many",
+                    name: "filter_analytic_account_ids",
                     value: self._getFilterValue("analytic_account_id"),
                 });
                 fields.push({
@@ -215,27 +215,28 @@ odoo.define("mis_builder.widget", function (require) {
             var self = this;
 
             if (self.has_group_analytic_accounting) {
-                self.analytic_account_id_m2o = new relational_fields.FieldMany2One(
-                    self,
-                    "filter_analytic_account_id",
-                    record,
-                    {
-                        mode: "edit",
-                        attrs: {
-                            placeholder: self.analytic_account_id_label,
-                            options: {
-                                no_create: "True",
-                                no_open: "True",
+                self.analytic_account_ids_m2m =
+                    new relational_fields.FieldMany2ManyTags(
+                        self,
+                        "filter_analytic_account_ids",
+                        record,
+                        {
+                            mode: "edit",
+                            attrs: {
+                                placeholder: self.analytic_account_ids_label,
+                                options: {
+                                    no_create: "True",
+                                    no_open: "True",
+                                },
                             },
-                        },
-                    }
-                );
+                        }
+                    );
                 self._registerWidget(
                     record.id,
-                    self.analytic_account_id_m2o.name,
-                    self.analytic_account_id_m2o
+                    self.analytic_account_ids_m2m.name,
+                    self.analytic_account_ids_m2m
                 );
-                self.analytic_account_id_m2o.appendTo(self.getMisBuilderFilterBox());
+                self.analytic_account_ids_m2m.appendTo(self.getMisBuilderFilterBox());
 
                 self.analytic_group_id_m2o = new relational_fields.FieldMany2One(
                     self,
@@ -298,6 +299,12 @@ odoo.define("mis_builder.widget", function (require) {
             var self = this;
             var defs = [];
 
+            if (self.has_group_analytic_accounting) {
+                var dataPointAnalytic = record.data.filter_analytic_account_ids;
+                dataPointAnalytic.fieldsInfo.default.display_name = {};
+                defs.push(self.model.reload(dataPointAnalytic.id));
+            }
+
             if (self.has_group_analytic_tags) {
                 var dataPoint = record.data.filter_analytic_tag_ids;
                 dataPoint.fieldsInfo.default.display_name = {};
@@ -339,12 +346,15 @@ odoo.define("mis_builder.widget", function (require) {
                 arguments
             );
 
-            if (self.analytic_account_id_m2o !== undefined) {
-                if (self.analytic_account_id_m2o.value) {
+            if (self.analytic_account_ids_m2m !== undefined) {
+                if (
+                    self.analytic_account_ids_m2m.value &&
+                    self.analytic_account_ids_m2m.value.res_ids.length > 0
+                ) {
                     self._setFilterValue(
                         "analytic_account_id",
-                        self.analytic_account_id_m2o.value.res_id,
-                        "="
+                        self.analytic_account_ids_m2m.value.res_ids,
+                        "in"
                     );
                 } else {
                     self._setFilterValue("analytic_account_id", undefined);

--- a/mis_builder/tests/test_analytic_filters.py
+++ b/mis_builder/tests/test_analytic_filters.py
@@ -13,13 +13,13 @@ class TestAnalyticFilters(TransactionCase):
     def test_context_with_filters(self):
         aaa = self.env["account.analytic.account"].search([], limit=1)
         mri = self.env["mis.report.instance"].new()
-        mri.analytic_account_id = False
+        mri.analytic_account_ids = False
         mri.analytic_group_id = False
         assert mri._context_with_filters().get("mis_report_filters") == {}
-        mri.analytic_account_id = aaa
+        mri.analytic_account_ids = aaa
         mri.analytic_group_id = self.aag
         assert mri._context_with_filters().get("mis_report_filters") == {
-            "analytic_account_id": {"value": aaa.id, "operator": "="},
+            "analytic_account_id": {"value": [aaa.id], "operator": "in"},
             "analytic_account_id.group_id": {"value": self.aag.id, "operator": "="},
         }
         # test _context_with_filters does nothing is a filter is already

--- a/mis_builder/views/mis_report_instance.xml
+++ b/mis_builder/views/mis_report_instance.xml
@@ -172,8 +172,9 @@
                                     widget="many2many_tags"
                                 />
                                 <field
-                                    name="analytic_account_id"
+                                    name="analytic_account_ids"
                                     groups="analytic.group_analytic_accounting"
+                                    widget="many2many_tags"
                                 />
                                 <field
                                     name="analytic_group_id"
@@ -396,7 +397,7 @@
                     </group>
                 </group>
                 <group string="Filters">
-                    <field name="analytic_account_id" />
+                    <field name="analytic_account_ids" widget="many2many_tags" />
                     <field name="analytic_group_id" />
                     <field name="analytic_tag_ids" widget="many2many_tags" />
                 </group>


### PR DESCRIPTION
Changing the analytic account filter in mis report instance to Man2many adds the possibility to show values that has different analytic accounts. The aggregation works as an OR.

@ForgeFlow  