### PR TITLE
[17.0][FIX] mis_builder: use new company in CI

### DIFF
--- a/mis_builder/tests/test_data_sources.py
+++ b/mis_builder/tests/test_data_sources.py
@@ -35,6 +35,14 @@ class TestMisReportInstanceDataSources(common.TransactionCase):
         move._post()
         return move
 
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Perform the tests with a brand new company to avoid intrusive data from other
+        # modules added to the default company
+        cls.company = cls.env["res.company"].create({"name": "Company Test"})
+        cls.env.user.company_id = cls.company
+
     def setUp(self):
         super().setUp()
         self.account_model = self.env["account.account"]


### PR DESCRIPTION
fw of 

- #662 

Some modules could insert data to the default company that could make the tests checks fail. With this patch we ensure, at least for this test cases to be performed with a brand new company.

An example of test failing on this (there were several on this test suite):
```
2024-12-12 14:02:43,190 46 ERROR prod odoo.addons.mis_builder.tests.test_data_sources: FAIL: TestMisReportInstanceDataSources.test_actuals
Traceback (most recent call last):
  File "/opt/odoo/auto/addons/mis_builder/tests/test_data_sources.py", line 204, in test_actuals
    assert_matrix(matrix, [[11, 13], [11, 30], [11, 13], [AccountingNone, 17]])
  File "/opt/odoo/auto/addons/mis_builder/tests/common.py", line 29, in assert_matrix
    assert (
AssertionError:  != 11 in row 2 col 0
```

There was intrusive data (I couldn't identify which module was adding it) that would appear in the report. In the debugging, I got these results. As it can be seen, there are three unexpected rows.

```python
>>> kpi matrix
[[11.0, 13.0], [11.0, 30.0], [AccountingNone, AccountingNone], [AccountingNone, AccountingNone], [AccountingNone, AccountingNone], [11.0, 13.0], [AccountingNone, 17.0]]
>>> expected
[[11, 13], [11, 30], [11, 13], [AccountingNone, 17]]
```

Anyway, we should worry about searching for ghosts every time. Just testing in a new company does the job in a reliable way


cc @Tecnativa 

please review @pedrobaeza @sbidoul  
