### PR TITLE
[16.0][IMP] mis_builder: allow to export multiple report in one xls

### DIFF
--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -781,7 +781,6 @@ class MisReportInstance(models.Model):
         )
 
     def export_xls(self):
-        self.ensure_one()
         return self.env.ref("mis_builder.xls_export").report_action(
             self, data=dict(dummy=True)
         )  # required to propagate context
@@ -1009,4 +1008,11 @@ class MisReportInstance(models.Model):
     def _compute_user_can_edit_annotation(self):
         self.user_can_edit_annotation = self.env.user.has_group(
             "mis_builder.group_edit_annotation"
+        )
+
+    def _get_xlsx_report_name(self):
+        self.ensure_one()
+        return "{} - {}".format(
+            self.name,
+            ", ".join([a.name for a in self.query_company_ids]),
         )

--- a/mis_builder/report/mis_report_instance_xlsx.py
+++ b/mis_builder/report/mis_report_instance_xlsx.py
@@ -34,17 +34,18 @@ class MisBuilderXlsx(models.AbstractModel):
         if cell and (annotation := notes.get(cell.cell_id, {}).get("text")):
             sheet.write_comment(row_pos, col_pos, annotation)
 
-    def generate_xlsx_report(self, workbook, data, objects):
+    def _get_worksheet_name(self, mis_instance):
+        return mis_instance._get_xlsx_report_name()[:31]
+
+    def _generate_xlsx_one_report(self, workbook, mis_instance):
         # get the computed result of the report
-        matrix = objects._compute_matrix()
-        notes = objects.get_notes_by_cell_id()
+        matrix = mis_instance._compute_matrix()
+        notes = mis_instance.get_notes_by_cell_id()
         style_obj = self.env["mis.report.style"]
 
         # create worksheet
-        report_name = "{} - {}".format(
-            objects[0].name, ", ".join([a.name for a in objects[0].query_company_ids])
-        )
-        sheet = workbook.add_worksheet(report_name[:31])
+        worksheet_name = self._get_worksheet_name(mis_instance)
+        sheet = workbook.add_worksheet(worksheet_name)
         row_pos = 0
         col_pos = 0
         # width of the labels column
@@ -57,13 +58,14 @@ class MisBuilderXlsx(models.AbstractModel):
         header_format = workbook.add_format(
             {"bold": True, "align": "center", "bg_color": "#F0EEEE"}
         )
+        report_name = mis_instance._get_xlsx_report_name()
         sheet.write(row_pos, 0, report_name, bold)
         row_pos += 2
 
         # filters
-        filter_descriptions = objects.get_filter_descriptions()
+        filter_descriptions = mis_instance.get_filter_descriptions()
         if filter_descriptions:
-            for filter_description in objects.get_filter_descriptions():
+            for filter_description in mis_instance.get_filter_descriptions():
                 sheet.write(row_pos, 0, filter_description)
                 row_pos += 1
             row_pos += 1
@@ -88,7 +90,9 @@ class MisBuilderXlsx(models.AbstractModel):
             else:
                 sheet.write(row_pos, col_pos, label, header_format)
                 col_width[col_pos] = max(
-                    col_width[col_pos], len(col.label or ""), len(col.description or "")
+                    col_width[col_pos],
+                    len(col.label or ""),
+                    len(col.description or ""),
                 )
             col_pos += col.colspan
         row_pos += 1
@@ -184,3 +188,9 @@ class MisBuilderXlsx(models.AbstractModel):
         min_col_pos = min(col_width.keys())
         max_col_pos = max(col_width.keys())
         sheet.set_column(min_col_pos, max_col_pos, data_col_width * COL_WIDTH)
+
+        return sheet
+
+    def generate_xlsx_report(self, workbook, data, objects):
+        for instance in objects:
+            self._generate_xlsx_one_report(workbook, instance)

--- a/mis_builder/report/mis_report_instance_xlsx.xml
+++ b/mis_builder/report/mis_report_instance_xlsx.xml
@@ -8,4 +8,15 @@
         <field name="report_type">xlsx</field>
         <field name="report_file">mis_report_instance</field>
     </record>
+
+    <record model="ir.actions.server" id="mis_builder_print_xls_report">
+        <field name="name">Export XLS</field>
+        <field name="model_id" ref="mis_builder.model_mis_report_instance" />
+        <field name="binding_model_id" ref="mis_builder.model_mis_report_instance" />
+        <field name="binding_view_types">list</field>
+        <field name="state">code</field>
+        <field name="code">
+            action = records.export_xls()
+        </field>
+    </record>
 </odoo>

--- a/mis_builder/tests/test_mis_report_instance.py
+++ b/mis_builder/tests/test_mis_report_instance.py
@@ -355,6 +355,27 @@ class TestMisReportInstance(common.HttpCase):
             )
         )
 
+        # create a duplicate of first instance with different period
+        self.report_instance_4 = self.env["mis.report.instance"].create(
+            dict(
+                name="test instance",
+                report_id=self.report.id,
+                company_id=self.env.ref("base.main_company").id,
+                period_ids=[
+                    (
+                        0,
+                        0,
+                        dict(
+                            name="p2",
+                            mode="fix",
+                            manual_date_from="2015-01-01",
+                            manual_date_to="2015-12-31",
+                        ),
+                    ),
+                ],
+            )
+        )
+
     def test_compute(self):
         matrix = self.report_instance._compute_matrix()
         for row in matrix.iter_rows():
@@ -509,6 +530,16 @@ class TestMisReportInstance(common.HttpCase):
             self.env.uid,
             "mis_builder.mis_report_instance_xlsx",
             [self.report_instance.id],
+            report_type="xlsx",
+        )
+
+    def test_xlsx_multiple_instances(self):
+        self.report_instance.export_xls()  # get action
+        test_reports.try_report(
+            self.env.cr,
+            self.env.uid,
+            "mis_builder.mis_report_instance_xlsx",
+            [self.report_instance.id, self.report_instance_4.id],
             report_type="xlsx",
         )
 


### PR DESCRIPTION
## Description

Allow to export multiple reports at once.
In one '.xls' where every report is a sheet.

To do so, I added one action 'Export XLS' visible on tree view of `mis_report_instance`.
