### PR TITLE
[16.0][IMP]  - css sticky table header added on mis-builder reports

### DIFF
--- a/mis_builder/static/src/components/mis_report_widget.css
+++ b/mis_builder/static/src/components/mis_report_widget.css
@@ -3,7 +3,7 @@
     overflow: auto;
     position: relative;
     /* limit height in order for the vertical scroll to work */
-    height: 80vh;
+    max-height: 80vh;
 }
 
 .oe_mis_builder_content .o_list_renderer thead th {

--- a/mis_builder/static/src/components/mis_report_widget.css
+++ b/mis_builder/static/src/components/mis_report_widget.css
@@ -1,39 +1,27 @@
 .oe_mis_builder_content {
-    width:95vw;
+    width: 95vw;
     overflow-x: auto;
-    
     /*limit the width of the parent of the parent component in order for the horizontal scroll to work  */
 }
- 
+
 .o_list_renderer {
     width: 100%;
     overflow: auto;
-    overflow-x: auto;
     position: relative;
-    height:95vh; /*limit the height in order for the vertical scroll to work  */
-    
-    
-    
+    height: 95vh; /*limit the height in order for the vertical scroll to work  */
 }
 .o_list_renderer .o_list_table th {
     position: sticky;
     background-color: #f2f2f2;
-  }
+}
 
-  .o_list_renderer  table {
+.o_list_renderer table {
     border-collapse: collapse;
     overflow-x: scroll;
-    max-width:93vw;
-
+    max-width: 93vw;
 }
 
-.o_list_renderer  th, td {
-    border: 1px solid #f2f2f2;
-    padding: 8px;
-    text-align: left;
-}
-
-.o_list_renderer  thead th {
+.o_list_renderer thead th {
     position: -webkit-sticky; /* Pour Safari */
     position: sticky;
     top: 0;
@@ -46,8 +34,8 @@
     position: sticky;
     left: 0;
     z-index: 1;
-} 
-
+}
+/* adding background colors in order for the text not to overlap on horizontal scroll */
 .table-striped > tbody > tr:nth-of-type(2n) > * {
     background-color: #fafafa;
     border: 0.2px solid #f0f0f0;
@@ -58,20 +46,14 @@
     border: 0.2px solid #f0f0f0;
 }
 
-.o_list_renderer  tbody th, tbody td {
+.o_list_renderer tbody th,
+tbody td {
     position: -webkit-sticky; /* Pour Safari */
     position: sticky;
-    
 }
-.o_list_renderer  table thead th:first-child {
+.o_list_renderer table thead th:first-child {
     left: 0;
     z-index: 2;
-   
-}
-.o_list_renderer tbody th {
-    left: 0;
-    background-color: #f9f9f9;
-    z-index: 1;
 }
 
 .o_web_client .mis_builder_amount {
@@ -95,7 +77,6 @@
     /* underline links on hover to give a visual cue */
     text-decoration: underline;
 }
-
 
 .oe_mis_builder_report_wide_sheet {
     max-width: 95% !important;

--- a/mis_builder/static/src/components/mis_report_widget.css
+++ b/mis_builder/static/src/components/mis_report_widget.css
@@ -7,7 +7,7 @@
     overflow: auto;
     position: relative;
     /* limit height in order for the vertical scroll to work */
-    height: 95vh;
+    height: 80vh;
 }
 
 .oe_mis_builder_content .o_list_renderer thead th {

--- a/mis_builder/static/src/components/mis_report_widget.css
+++ b/mis_builder/static/src/components/mis_report_widget.css
@@ -1,7 +1,3 @@
-.oe_mis_builder_content {
-    max-width: 98vw;
-}
-
 .oe_mis_builder_content .o_list_renderer {
     width: 100%;
     overflow: auto;

--- a/mis_builder/static/src/components/mis_report_widget.css
+++ b/mis_builder/static/src/components/mis_report_widget.css
@@ -11,6 +11,7 @@
     position: -webkit-sticky;
     position: sticky;
     top: 0;
+    z-index: 900;
     background-color: var(--gray-300);
 }
 

--- a/mis_builder/static/src/components/mis_report_widget.css
+++ b/mis_builder/static/src/components/mis_report_widget.css
@@ -1,3 +1,79 @@
+.oe_mis_builder_content {
+    width:95vw;
+    overflow-x: auto;
+    
+    /*limit the width of the parent of the parent component in order for the horizontal scroll to work  */
+}
+ 
+.o_list_renderer {
+    width: 100%;
+    overflow: auto;
+    overflow-x: auto;
+    position: relative;
+    height:95vh; /*limit the height in order for the vertical scroll to work  */
+    
+    
+    
+}
+.o_list_renderer .o_list_table th {
+    position: sticky;
+    background-color: #f2f2f2;
+  }
+
+  .o_list_renderer  table {
+    border-collapse: collapse;
+    overflow-x: scroll;
+    max-width:93vw;
+
+}
+
+.o_list_renderer  th, td {
+    border: 1px solid #f2f2f2;
+    padding: 8px;
+    text-align: left;
+}
+
+.o_list_renderer  thead th {
+    position: -webkit-sticky; /* Pour Safari */
+    position: sticky;
+    top: 0;
+    background-color: #f2f2f2;
+    z-index: 2;
+    border: 0.2px solid #f0f0f0;
+}
+.o_list_renderer tbody tr td:first-child {
+    position: -webkit-sticky; /* Pour Safari */
+    position: sticky;
+    left: 0;
+    z-index: 1;
+} 
+
+.table-striped > tbody > tr:nth-of-type(2n) > * {
+    background-color: #fafafa;
+    border: 0.2px solid #f0f0f0;
+}
+
+.table-striped > tbody > tr:nth-child(odd) > * {
+    background-color: #ffffff;
+    border: 0.2px solid #f0f0f0;
+}
+
+.o_list_renderer  tbody th, tbody td {
+    position: -webkit-sticky; /* Pour Safari */
+    position: sticky;
+    
+}
+.o_list_renderer  table thead th:first-child {
+    left: 0;
+    z-index: 2;
+   
+}
+.o_list_renderer tbody th {
+    left: 0;
+    background-color: #f9f9f9;
+    z-index: 1;
+}
+
 .o_web_client .mis_builder_amount {
     text-align: right;
 }
@@ -20,8 +96,6 @@
     text-decoration: underline;
 }
 
-.oe_mis_builder_content {
-}
 
 .oe_mis_builder_report_wide_sheet {
     max-width: 95% !important;

--- a/mis_builder/static/src/components/mis_report_widget.css
+++ b/mis_builder/static/src/components/mis_report_widget.css
@@ -1,61 +1,22 @@
 .oe_mis_builder_content {
-    width: 95vw;
-    overflow-x: auto;
-    /*limit the width of the parent of the parent component in order for the horizontal scroll to work  */
+    max-width: 98vw;
 }
 
-.o_list_renderer {
+.oe_mis_builder_content .o_list_renderer {
     width: 100%;
     overflow: auto;
     position: relative;
     height: 95vh; /*limit the height in order for the vertical scroll to work  */
 }
-.o_list_renderer .o_list_table th {
-    position: sticky;
-    background-color: #f2f2f2;
-}
 
-.o_list_renderer table {
-    border-collapse: collapse;
-    overflow-x: scroll;
-    max-width: 93vw;
-}
-
-.o_list_renderer thead th {
+.oe_mis_builder_content .o_list_renderer thead th {
     position: -webkit-sticky; /* Pour Safari */
     position: sticky;
     top: 0;
-    background-color: #f2f2f2;
-    z-index: 2;
-    border: 0.2px solid #f0f0f0;
-}
-.o_list_renderer tbody tr td:first-child {
-    position: -webkit-sticky; /* Pour Safari */
-    position: sticky;
-    left: 0;
+    background-color: var(--gray-300);
     z-index: 1;
-}
-/* adding background colors in order for the text not to overlap on horizontal scroll */
-.table-striped > tbody > tr:nth-of-type(2n) > * {
-    background-color: #fafafa;
-    border: 0.2px solid #f0f0f0;
-}
-
-.table-striped > tbody > tr:nth-child(odd) > * {
-    background-color: #ffffff;
-    border: 0.2px solid #f0f0f0;
-}
-
-.o_list_renderer tbody th,
-tbody td {
-    position: -webkit-sticky; /* Pour Safari */
-    position: sticky;
-}
-.o_list_renderer table thead th:first-child {
-    left: 0;
-    z-index: 2;
-}
-
+    border: 0.2px solid var(--gray-100);
+  }
 .o_web_client .mis_builder_amount {
     text-align: right;
 }

--- a/mis_builder/static/src/components/mis_report_widget.css
+++ b/mis_builder/static/src/components/mis_report_widget.css
@@ -16,8 +16,6 @@
     position: sticky;
     top: 0;
     background-color: var(--gray-300);
-    z-index: 1;
-    border: 0.2px solid var(--gray-100);
 }
 
 .o_web_client .mis_builder_amount {

--- a/mis_builder/static/src/components/mis_report_widget.css
+++ b/mis_builder/static/src/components/mis_report_widget.css
@@ -6,17 +6,20 @@
     width: 100%;
     overflow: auto;
     position: relative;
-    height: 95vh; /*limit the height in order for the vertical scroll to work  */
+    /* limit height in order for the vertical scroll to work */
+    height: 95vh;
 }
 
 .oe_mis_builder_content .o_list_renderer thead th {
-    position: -webkit-sticky; /* Pour Safari */
+    /* For Safari */
+    position: -webkit-sticky;
     position: sticky;
     top: 0;
     background-color: var(--gray-300);
     z-index: 1;
     border: 0.2px solid var(--gray-100);
-  }
+}
+
 .o_web_client .mis_builder_amount {
     text-align: right;
 }


### PR DESCRIPTION
Thanks for your pull request. Please take a moment to review if it meets the following
guidelines.

## Description

Following the discussion on the PR for the same feature on V14 https://github.com/OCA/mis-builder/pull/588.
The PR adds a sticky header and first column on the Mis budget report.
On the first gif you can see the vertical scroll, on the second one the horizontal one. 

![mis-builder-vertical-scroll](https://github.com/user-attachments/assets/cb38f97e-eab4-425d-bf99-357e228c1372)


![mis-builder-sticky-header-horizontal-scroll](https://github.com/user-attachments/assets/573a2371-0e84-41a0-8353-72ff2ac08a52)

Thx !


