### PR TITLE
[16][IMP] mis_builder: improve ui by adding button to resize report instance

### DIFF
--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -588,6 +588,10 @@ class MisReportInstance(models.Model):
         compute="_compute_user_can_edit_annotation",
     )
 
+    wide_display_by_default = fields.Boolean(
+        string="Open report in wide mode by default",
+    )
+
     @api.depends("report_id.move_lines_source")
     def _compute_widget_search_view_id(self):
         for rec in self:

--- a/mis_builder/static/src/components/mis_report_widget.css
+++ b/mis_builder/static/src/components/mis_report_widget.css
@@ -23,6 +23,10 @@
 .oe_mis_builder_content {
 }
 
+.oe_mis_builder_report_wide_sheet {
+    max-width: 95% !important;
+}
+
 /* style for the control panel (search box and buttons) */
 
 .oe_mis_builder_cp {
@@ -42,6 +46,11 @@
     flex-direction: column;
     flex-grow: 2;
     max-width: 1280px;
+}
+
+.oe_mis_builder_cp_right_top_right {
+    display: flex;
+    flex-direction: row;
 }
 
 .oe_mis_builder_cp_right_top {

--- a/mis_builder/static/src/components/mis_report_widget.esm.js
+++ b/mis_builder/static/src/components/mis_report_widget.esm.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import Dialog from "web.Dialog";
-import {Component, onWillStart, useState, useSubEnv} from "@odoo/owl";
+import {Component, onMounted, onWillStart, useState, useSubEnv} from "@odoo/owl";
 import {DatePicker} from "@web/core/datepicker/datepicker";
 import {FilterMenu} from "@web/search/filter_menu/filter_menu";
 import {SearchBar} from "@web/search/search_bar/search_bar";
@@ -36,6 +36,8 @@ export class MisReportWidget extends Component {
             this.refresh();
         });
         onWillStart(this.willStart);
+
+        onMounted(this._onMounted);
     }
 
     // Lifecycle
@@ -52,6 +54,7 @@ export class MisReportWidget extends Component {
                 "widget_show_pivot_date",
                 "user_can_read_annotation",
                 "user_can_edit_annotation",
+                "wide_display_by_default",
             ],
             {context: this.context}
         );
@@ -70,10 +73,16 @@ export class MisReportWidget extends Component {
             });
         }
 
+        this.wide_display = result.wide_display_by_default;
+
         // Compute the report
         this.refresh();
         this.state.can_edit_annotation = result.user_can_edit_annotation;
         this.state.can_read_annotation = result.user_can_read_annotation;
+    }
+
+    async _onMounted() {
+        this.resize_sheet();
     }
 
     get showSearchBar() {
@@ -253,6 +262,22 @@ export class MisReportWidget extends Component {
     onDateTimeChanged(ev) {
         this.state.pivot_date = ev;
         this.refresh();
+    }
+
+    async toggle_wide_display() {
+        this.wide_display = !this.wide_display;
+        this.resize_sheet();
+    }
+
+    async resize_sheet() {
+        var sheet_element = document.getElementsByClassName("o_form_sheet")[0];
+        sheet_element.classList.toggle(
+            "oe_mis_builder_report_wide_sheet",
+            this.wide_display
+        );
+        var button_resize_element = document.getElementById("icon_resize");
+        button_resize_element.classList.toggle("fa-expand", !this.wide_display);
+        button_resize_element.classList.toggle("fa-compress", this.wide_display);
     }
 }
 

--- a/mis_builder/static/src/components/mis_report_widget.xml
+++ b/mis_builder/static/src/components/mis_report_widget.xml
@@ -9,6 +9,16 @@
                     <div class="oe_mis_builder_cp_left">
                     </div>
                     <div class="oe_mis_builder_cp_right">
+                        <div class="oe_mis_builder_cp_right_top_right">
+                            <div class="oe_mis_builder_action_buttons">
+                                <button
+                                    t-on-click="toggle_wide_display"
+                                    class="btn btn-secondary"
+                                >
+                                    <i id="icon_resize" class="fa" />
+                                </button>
+                            </div>
+                        </div>
                         <div class="oe_mis_builder_cp_right_top">
                             <SearchBar t-if="showSearchBar" />
                         </div>

--- a/mis_builder/views/mis_report_instance.xml
+++ b/mis_builder/views/mis_report_instance.xml
@@ -195,6 +195,7 @@
                                 <field name="landscape_pdf" />
                                 <field name="no_auto_expand_accounts" />
                                 <field name="display_columns_description" />
+                                <field name="wide_display_by_default" />
                             </group>
                         </page>
                         <page string="Widget">


### PR DESCRIPTION
## Description

Small UI improvement: add possibility to widen the "sheet" of a report instance.
This feature has been developed mainly for report with multiple columns.

### Display setting

On instance report, there's a new setting 'wide_display_by_default' (page 'layout') that sets the default view mode of the report. 

### Screenshots

![image](https://github.com/user-attachments/assets/df5597ba-ba47-4393-a800-edc7ce26931e)
![image](https://github.com/user-attachments/assets/501d70af-eb94-42cc-828a-57403591393a)
![image](https://github.com/user-attachments/assets/166cf480-2a6c-4f0f-9330-ed5230945ef5)
