### PR TITLE
[17.0][WIP] mis_builder_budget: Define the appropriate value if not budgetable

### DIFF
--- a/mis_builder_budget/models/mis_report_instance.py
+++ b/mis_builder_budget/models/mis_report_instance.py
@@ -11,7 +11,7 @@ from .mis_report_instance_period import SRC_MIS_BUDGET, SRC_MIS_BUDGET_BY_ACCOUN
 
 
 class MisBudgetAwareExpressionEvaluator(ExpressionEvaluator):
-    def __init__(self, date_from, date_to, kpi_data, additional_move_line_filter):
+    def __init__(self, aep, date_from, date_to, kpi_data, additional_move_line_filter):
         super().__init__(
             aep=None,
             date_from=date_from,
@@ -20,6 +20,7 @@ class MisBudgetAwareExpressionEvaluator(ExpressionEvaluator):
             aml_model=None,
         )
         self.kpi_data = kpi_data
+        self._origin_aep = aep
 
     @api.model
     def _get_kpi_for_expressions(self, expressions):
@@ -44,6 +45,10 @@ class MisBudgetAwareExpressionEvaluator(ExpressionEvaluator):
                 vals.append(self.kpi_data.get(expression, AccountingNone))
                 drilldown_args.append({"expr_id": expression.id})
             return vals, drilldown_args, False
+        elif kpi and not kpi.budgetable:
+            self.aep = self._origin_aep
+            self._aep_queries_done = False
+            self.aep_do_queries()
         return super().eval_expressions(expressions, locals_dict)
 
 
@@ -63,6 +68,7 @@ class MisReportInstance(models.Model):
         )
 
         expression_evaluator = MisBudgetAwareExpressionEvaluator(
+            aep,
             period.date_from,
             period.date_to,
             kpi_data,

--- a/mis_builder_budget/tests/test_expression_evaluator.py
+++ b/mis_builder_budget/tests/test_expression_evaluator.py
@@ -11,6 +11,7 @@ from odoo.addons.mis_builder_budget.models.mis_report_instance import (
 class TestBudgetAwareExpressionEvaluator(TransactionCase):
     def _make_evaluator(self, kpi_data=None):
         return MisBudgetAwareExpressionEvaluator(
+            aep=None,
             date_from="2017-01-01",
             date_to="2017-01-16",
             kpi_data=kpi_data or {},


### PR DESCRIPTION
Define the appropriate value if not budgetable

Example use case:
- Uncheck in the KPI of a template (Other for example) the Budgetable option.
- Preview the MIS report.
- The data in this column must be empty.
- The data in the sum column (if any) must be appropriate.

**Before**
![antes](https://github.com/user-attachments/assets/97625ea4-6cb9-424a-9f16-d81749f3abfe)

**After**
![despues](https://github.com/user-attachments/assets/2b03eb70-36fc-4d93-875a-5b59ed3ca03d)

@Tecnativa TT56278
