### PR TITLE
[16.0][IMP] mis_builder: remove py3.10-style type hints

### DIFF
--- a/mis_builder/models/kpimatrix.py
+++ b/mis_builder/models/kpimatrix.py
@@ -1,6 +1,8 @@
 # Copyright 2014 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
+from __future__ import annotations
+
 import logging
 from collections import OrderedDict, defaultdict
 


### PR DESCRIPTION
[DO NOT FORWARD PORT]

cf https://github.com/OCA/mis-builder/pull/676#issuecomment-2904616126
