### PR TITLE
[18.0][IMP] mis_builder: Avoid error if a user does not have the Administration/Settings permission

### DIFF
--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -884,7 +884,9 @@ class MisReportInstance(models.Model):
     @api.model
     def _get_drilldown_model_views(self, model_name):
         self.ensure_one()
-        views_records = self.env["ir.ui.view"].search([("model", "=", model_name)])
+        views_records = (
+            self.env["ir.ui.view"].sudo().search([("model", "=", model_name)])
+        )
         views_records = set(views_records.mapped("type"))
         views_order = self._get_drilldown_views_and_orders()
         views = {view_type for view_type in views_records if view_type in views_order}


### PR DESCRIPTION
FWP from 17.0: https://github.com/OCA/mis-builder/pull/683

Avoid error if a user does not have the Administration/Settings permission

**Before**
![antes](https://github.com/user-attachments/assets/0c7e1224-4bc1-48e2-89bb-0cfff33bffb8)

**After**
![despues](https://github.com/user-attachments/assets/3a270a1b-53ef-402a-8724-e77719c120c3)

![imagen](https://github.com/user-attachments/assets/38236a9d-2fb6-4d90-9925-c8c8a61f037a)

Please @pedrobaeza can you review it?

@Tecnativa TT56480
