### PR TITLE
[18.0][PORT] mis_builder: improve ui by adding button to resize report instance

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -16,6 +16,7 @@ const config = [{
             openerp: "readonly",
             owl: "readonly",
             luxon: "readonly",
+            document: "readonly",
         },
 
         ecmaVersion: 2024,

--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -592,6 +592,10 @@ class MisReportInstance(models.Model):
         help="Search view to customize the filter box in the report widget.",
     )
 
+    wide_display_by_default = fields.Boolean(
+        string="Open report in wide mode by default",
+    )
+
     @api.depends("report_id.move_lines_source")
     def _compute_widget_search_view_id(self):
         for rec in self:

--- a/mis_builder/static/src/components/mis_report_widget.esm.js
+++ b/mis_builder/static/src/components/mis_report_widget.esm.js
@@ -1,4 +1,4 @@
-import {Component, onWillStart, useState, useSubEnv} from "@odoo/owl";
+import {Component, onMounted, onWillStart, useState, useSubEnv} from "@odoo/owl";
 import {useBus, useService} from "@web/core/utils/hooks";
 import {DateTimeInput} from "@web/core/datetime/datetime_input";
 import {SearchBar} from "@web/search/search_bar/search_bar";
@@ -27,6 +27,8 @@ export class MisReportWidget extends Component {
             this.refresh();
         });
         onWillStart(this.willStart);
+
+        onMounted(this._onMounted);
     }
 
     // Lifecycle
@@ -41,6 +43,7 @@ export class MisReportWidget extends Component {
                 "widget_search_view_id",
                 "pivot_date",
                 "widget_show_pivot_date",
+                "wide_display_by_default",
             ],
             {context: this.context}
         );
@@ -60,8 +63,14 @@ export class MisReportWidget extends Component {
             });
         }
 
+        this.wide_display = result.wide_display_by_default;
+
         // Compute the report
         this.refresh();
+    }
+
+    async _onMounted() {
+        this.resize_sheet();
     }
 
     get showSearchBar() {
@@ -163,6 +172,22 @@ export class MisReportWidget extends Component {
     onDateTimeChanged(ev) {
         this.state.pivot_date = ev;
         this.refresh();
+    }
+
+    async toggle_wide_display() {
+        this.wide_display = !this.wide_display;
+        this.resize_sheet();
+    }
+
+    async resize_sheet() {
+        var sheet_element = document.getElementsByClassName("o_form_sheet_bg")[0];
+        sheet_element.classList.toggle(
+            "oe_mis_builder_report_wide_sheet",
+            this.wide_display
+        );
+        var button_resize_element = document.getElementById("icon_resize");
+        button_resize_element.classList.toggle("fa-expand", !this.wide_display);
+        button_resize_element.classList.toggle("fa-compress", this.wide_display);
     }
 }
 

--- a/mis_builder/static/src/components/mis_report_widget.scss
+++ b/mis_builder/static/src/components/mis_report_widget.scss
@@ -26,6 +26,10 @@
 
 /* style for the control panel (search box and buttons) */
 
+.oe_mis_builder_report_wide_sheet {
+    max-width: 100% !important;
+}
+
 .oe_mis_builder_cp {
     display: flex;
     flex-direction: row;
@@ -64,5 +68,10 @@
             flex-grow: 1;
             justify-content: flex-end;
         }
+    }
+
+    .oe_mis_builder_cp_right_top_right {
+        display: flex;
+        flex-direction: row;
     }
 }

--- a/mis_builder/static/src/components/mis_report_widget.xml
+++ b/mis_builder/static/src/components/mis_report_widget.xml
@@ -6,6 +6,13 @@
                 <div class="oe_mis_builder_cp">
                     <div class="oe_mis_builder_cp_left" />
                     <div class="oe_mis_builder_cp_right">
+                        <div class="oe_mis_builder_cp_right_top_right">
+                            <div class="oe_mis_builder_action_buttons">
+                                <button t-on-click="toggle_wide_display" class="btn">
+                                    <i id="icon_resize" class="fa" />
+                                </button>
+                            </div>
+                        </div>
                         <div class="oe_mis_builder_cp_right_top">
                             <SearchBar t-if="showSearchBar" />
                         </div>

--- a/mis_builder/views/mis_report_instance.xml
+++ b/mis_builder/views/mis_report_instance.xml
@@ -192,6 +192,7 @@
                                 <field name="landscape_pdf" />
                                 <field name="no_auto_expand_accounts" />
                                 <field name="display_columns_description" />
+                                <field name="wide_display_by_default" />
                             </group>
                         </page>
                         <page string="Widget">


### PR DESCRIPTION
port forward of #678 

## Small modification

When widening, I now set the 'sheet wide' to be 100% (previously 90%).

## Description

Small UI improvement: add possibility to widen the "sheet" of a report instance.
This feature has been developed mainly for report with multiple columns.

### Display setting

On instance report, there's a new setting 'wide_display_by_default' (page 'layout') that sets the default view mode of the report. 