### PR TITLE
[18.0][FIX] mis_builder_budget: reintroduce missing fields

### DIFF
--- a/mis_builder_budget/views/mis_budget_item.xml
+++ b/mis_builder_budget/views/mis_budget_item.xml
@@ -18,6 +18,10 @@
         <field name="model">mis.budget.item</field>
         <field name="arch" type="xml">
             <list editable="bottom">
+                <field name="budget_id" column_invisible="1" />
+                <field name="report_id" column_invisible="1" />
+                <field name="budget_date_from" column_invisible="1" />
+                <field name="budget_date_to" column_invisible="1" />
                 <field name="kpi_expression_id" />
                 <field name="date_range_id" />
                 <field name="date_from" />


### PR DESCRIPTION
These fields were erroneously removed during migration in #653 and #690 