### PR TITLE
[IMP] mis_builder: Not display company name with only one effective company

### DIFF
--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -863,7 +863,8 @@ class MisReportInstance(models.Model):
         """
         self.ensure_one()
         aep = self.report_id._prepare_aep(self.query_company_ids, self.currency_id)
-        kpi_matrix = self.report_id.prepare_kpi_matrix(self.multi_company)
+        multi_company = self.multi_company and len(self.query_company_ids) > 1
+        kpi_matrix = self.report_id.prepare_kpi_matrix(multi_company)
         for period in self.period_ids:
             description = None
             if period.mode == MODE_NONE:


### PR DESCRIPTION
The company name is displayed on the side of the account when a MIS report is marked as multi-company but has only one effective company. This is not necessary because there is only one effective company and it is not necessary to know which company the account belongs to.

MT-10671 @moduon

## Description

Issue: https://github.com/OCA/mis-builder/issues/702

@sbidoul @rafaelbn @yajo please review