### PR TITLE
[IMP] mis_builder: Sort reports by sequence

### DIFF
--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -476,8 +476,10 @@ class MisReportInstance(models.Model):
 
     _name = "mis.report.instance"
     _description = "MIS Report Instance"
+    _order = "sequence, id"
 
     name = fields.Char(required=True, translate=True)
+    sequence = fields.Integer(default=10)
     description = fields.Char(related="report_id.description", readonly=True)
     date = fields.Date(
         string="Base date", help="Report base date " "(leave empty to use current date)"

--- a/mis_builder/views/mis_report_instance.xml
+++ b/mis_builder/views/mis_report_instance.xml
@@ -27,6 +27,7 @@
         <field name="model">mis.report.instance</field>
         <field name="arch" type="xml">
             <tree>
+                <field name="sequence" widget="handle" />
                 <button
                     type="object"
                     name="preview"


### PR DESCRIPTION
When there are many different reports for various use cases and companies, it's difficult to quickly find the desired report because the list view is ordered by ID, showing the oldest entries first.

The solution is adding a sequence field to the `mis_report_instance` list view to allow custom ordering and improve usability.

https://www.loom.com/share/52ba1531f4254f3c9823422c3bd7b42b?sid=d232990a-0a55-4847-aa8e-97f7783f9032

MT-10677 

cc @moduon @yajo @EmilioPascual @Andrii9090 