### PR TITLE
[FIX][18.0] mis_builder: Error in multicompany report

### DIFF
--- a/mis_builder/models/kpimatrix.py
+++ b/mis_builder/models/kpimatrix.py
@@ -159,6 +159,7 @@ class KpiMatrix:
         # { account_id: account_name }
         self._account_names = {}
         self._multi_company = multi_company
+        self._env = env
 
     def declare_kpi(self, kpi):
         """Declare a new kpi (row) in the matrix.
@@ -468,8 +469,12 @@ class KpiMatrix:
 
     def _get_account_name(self, account):
         result = f"{account.code} {account.name}"
-        if self._multi_company:
-            result = f"{result} [{account.company_id.name}]"
+        if not account.code:
+            account = account.with_company(account.company_ids[0])
+            result = f"{account.code} {account.name}"
+        if self._multi_company and account.company_ids and len(self._env.companies) > 1:
+            company_names = ", ".join(account.company_ids.mapped("name"))
+            result = f"{result} [{company_names}]"
         return result
 
     def get_account_name(self, account_id):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

When we have two companies selected, and we go to Invoicing > Reporting > MIS reports, select a report template, check ‘Multiple companies’ and click on preview, we get an error message.

Desired behavior after PR is merged:

The error no longer appears, and the preview is displayed correctly.

https://www.loom.com/share/cfeb4d5ee7a2431481d263ae6c2058ea?sid=d87d3d57-f3ab-49a3-8b07-77bb1cdd3d22

fix https://github.com/OCA/mis-builder/issues/710

cc: @Moduon MT-10671


