### PR TITLE
[FIX] mis_builder xlsxwriter compatibility

### DIFF
--- a/mis_builder/models/mis_report_style.py
+++ b/mis_builder/models/mis_report_style.py
@@ -272,7 +272,7 @@ class MisReportKpiStyle(models.Model):
         xlsx_attributes = [
             ("italic", props.font_style == "italic"),
             ("bold", props.font_weight == "bold"),
-            ("size", self._font_size_to_xlsx_size.get(props.font_size, 11)),
+            ("font_size", self._font_size_to_xlsx_size.get(props.font_size, 11)),
             ("font_color", props.color),
             ("bg_color", props.background_color),
         ]

--- a/mis_builder/report/mis_report_instance_xlsx.py
+++ b/mis_builder/report/mis_report_instance_xlsx.py
@@ -163,7 +163,7 @@ class MisBuilderXlsx(models.AbstractModel):
         # Add date/time footer
         row_pos += 1
         footer_format = workbook.add_format(
-            {"italic": True, "font_color": "#202020", "size": 9}
+            {"italic": True, "font_color": "#202020", "font_size": 9}
         )
         lang_model = self.env["res.lang"]
         lang = lang_model._lang_get(self.env.user.lang)

--- a/mis_builder/tests/test_render.py
+++ b/mis_builder/tests/test_render.py
@@ -268,7 +268,7 @@ class TestRendering(common.TransactionCase):
             {
                 "italic": True,
                 "bold": True,
-                "size": 9,
+                "font_size": 9,
                 "font_color": "#FF0000",
                 "bg_color": "#0000FF",
                 "num_format": '"p "#,##0.00" s"',
@@ -281,7 +281,7 @@ class TestRendering(common.TransactionCase):
             {
                 "italic": True,
                 "bold": True,
-                "size": 9,
+                "font_size": 9,
                 "font_color": "#FF0000",
                 "bg_color": "#0000FF",
                 "num_format": '"p "#,##0.00" s"',
@@ -294,7 +294,7 @@ class TestRendering(common.TransactionCase):
             {
                 "italic": True,
                 "bold": True,
-                "size": 9,
+                "font_size": 9,
                 "font_color": "#FF0000",
                 "bg_color": "#0000FF",
                 "num_format": "0.00%",
@@ -308,7 +308,7 @@ class TestRendering(common.TransactionCase):
             {
                 "italic": True,
                 "bold": True,
-                "size": 9,
+                "font_size": 9,
                 "font_color": "#FF0000",
                 "bg_color": "#0000FF",
             },


### PR DESCRIPTION
xlsxwriter has removed the internal aliases set_font() (set_font_name()), set_size() (set_font_size()) and set_color() (set_font_color()) from version 3.2.1 but reintroduced them in 3.2.3 to avoid code break. Since these aliases were there only for internal purpose they will be removed (https://xlsxwriter.readthedocs.io/changes.html).
So mis_builder is moving forward with the right names.
