### PR TITLE
[18.0][IMP] mis_builder: small usability improvements

### DIFF
--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -488,8 +488,10 @@ class MisReportInstance(models.Model):
 
     _name = "mis.report.instance"
     _description = "MIS Report Instance"
+    _order = "sequence, id"
 
     name = fields.Char(required=True, translate=True)
+    sequence = fields.Integer()
     description = fields.Char(related="report_id.description")
     date = fields.Date(
         string="Base date", help="Report base date " "(leave empty to use current date)"
@@ -504,7 +506,7 @@ class MisReportInstance(models.Model):
         copy=True,
     )
     target_move = fields.Selection(
-        [("posted", "All Posted Entries"), ("all", "All Entries")],
+        [("posted", "Posted Entries"), ("all", "Draft and Posted Entries")],
         string="Target Moves",
         required=True,
         default="posted",

--- a/mis_builder/views/mis_report_instance.xml
+++ b/mis_builder/views/mis_report_instance.xml
@@ -27,6 +27,7 @@
         <field name="model">mis.report.instance</field>
         <field name="arch" type="xml">
             <list>
+                <field name="sequence" widget="handle" />
                 <button
                     type="object"
                     name="preview"
@@ -40,7 +41,7 @@
                     string="Export"
                     icon="fa-download"
                 />
-                <field name="name" />
+                <field name="name" decoration-bf="1" />
                 <field name="report_id" string="Template" />
                 <field name="company_id" groups="base.group_multi_company" />
                 <field name="multi_company" groups="base.group_multi_company" />
@@ -209,6 +210,48 @@
                     </notebook>
                 </sheet>
             </form>
+        </field>
+    </record>
+    <record model="ir.ui.view" id="mis_report_instance_view_search">
+        <field name="name">mis.report.instance.view.search</field>
+        <field name="model">mis.report.instance</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="name" />
+                <filter
+                    name="multi_company"
+                    string="Multiple Companies"
+                    domain="[('multi_company', '=', True)]"
+                />
+                <filter
+                    name="single_company"
+                    string="Single Company"
+                    domain="[('multi_company', '=', False)]"
+                />
+                <separator />
+                <filter
+                    name="target_move_posted"
+                    string="Posted Entries"
+                    domain="[('target_move', '=', 'posted')]"
+                />
+                <filter
+                    name="target_move_all"
+                    string="Draft and Posted Entries"
+                    domain="[('target_move', '=', 'all')]"
+                />
+                <group name="groupby">
+                    <filter
+                        name="currency_groupby"
+                        string="Currency"
+                        context="{'group_by': 'currency_id'}"
+                    />
+                    <filter
+                        name="report_groupby"
+                        string="Template"
+                        context="{'group_by': 'report_id'}"
+                    />
+                </group>
+            </search>
         </field>
     </record>
     <record model="ir.actions.act_window" id="mis_report_instance_view_action">


### PR DESCRIPTION
- Add sequence field to allow users to configure the order of the report instance.
- Add search view for mis.report.instance.
- Improve string for field target_move, to make it clear that canceled journal entries are not taken into account