### PR TITLE
[IMP] mis_builder: add a description field on mis.report.style model

### DIFF
--- a/mis_builder/models/mis_report_style.py
+++ b/mis_builder/models/mis_report_style.py
@@ -133,6 +133,47 @@ class MisReportKpiStyle(models.Model):
     hide_always_inherit = fields.Boolean(default=True)
     hide_always = fields.Boolean(default=False)
 
+    description = fields.Html(
+        compute="_compute_description",
+        help="Describe specific values that are not inherited",
+    )
+
+    def _get_depends_compute_description(self):
+        return PROPS + [f"{prop}_inherit" for prop in PROPS]
+
+    @api.depends(lambda x: x._get_depends_compute_description())
+    def _compute_description(self):
+        for style in self:
+            descriptions = {}
+            for prop in PROPS:
+                if getattr(style, f"{prop}_inherit"):
+                    continue
+                else:
+                    value = getattr(style, prop)
+                    if prop in ["color", "background_color"]:
+                        value = (
+                            "<span style='"
+                            f"background-color: {value};"
+                            " width: 15px;"
+                            " height: 15px;"
+                            " display: inline-block;"
+                            " border: 1px black solid;"
+                            " border-radius: 5px;"
+                            "' />"
+                        )
+                    elif prop in ["font_weight", "font_style"]:
+                        value = (
+                            f"<span style='"
+                            f"{prop.replace('_', '-')} : {value};"
+                            f"'>{value}</span>"
+                        )
+                    elif prop in ["prefix", "suffix"]:
+                        value = f"'<code>{value}</code>'"
+                    descriptions[style._fields[prop].string] = value
+
+            description = " ; ".join([f"{k} : {v}" for k, v in descriptions.items()])
+            style.description = f"<div>{description}</div>"
+
     @api.model
     def merge(self, styles):
         """Merge several styles, giving priority to the last.

--- a/mis_builder/tests/test_render.py
+++ b/mis_builder/tests/test_render.py
@@ -313,3 +313,25 @@ class TestRendering(common.TransactionCase):
                 "bg_color": "#0000FF",
             },
         )
+
+    def test_description(self):
+        self.assertEqual(self.style.description.unescape(), "")
+
+        self.style.dp_inherit = False
+        self.style.dp = 4
+        self.assertEqual(self.style.description.unescape(), "Rounding : 4")
+        self.style.dp_inherit = True
+
+        self.style.color_inherit = False
+        self.style.color = "red"
+        self.assertEqual(
+            self.style.description.unescape(),
+            'Text color : <span style="background-color: red;'
+            " width: 15px; height: 15px; display: inline-block;"
+            ' border: 1px black solid; border-radius: 5px;"></span>',
+        )
+        self.style.color_inherit = True
+
+        self.style.prefix_inherit = False
+        self.style.prefix = "$"
+        self.assertEqual(self.style.description.unescape(), "Prefix : '<code>$</code>'")

--- a/mis_builder/views/mis_report_style.xml
+++ b/mis_builder/views/mis_report_style.xml
@@ -6,6 +6,7 @@
         <field name="arch" type="xml">
             <list>
                 <field name="name" />
+                <field name="description" type="html" optional="show" />
             </list>
         </field>
     </record>


### PR DESCRIPTION

## Description

rational: by default, a new style 'inherits' all the values. It is therefore the specifics values that describe a style. Adds a new 'description' char field, which concatenates all the specific values, available in the tree view, in order to facilitate style selection

### Before

<img width="871" height="224" alt="image" src="https://github.com/user-attachments/assets/953196ab-6e5e-452b-9ebb-37838c1264c4" />

### After

<img width="808" height="168" alt="image" src="https://github.com/user-attachments/assets/5fd686df-ef22-4bf8-9e77-08bb96665054" />

CC  : @sbidoul, @gva-acsone, @astoffel 