### PR TITLE
[IMP] mis_builder: display fields allways in the same place.

### DIFF
--- a/mis_builder/views/mis_report_style.xml
+++ b/mis_builder/views/mis_report_style.xml
@@ -24,43 +24,128 @@
                             </div>
                         </h1>
                     </div>
-                    <group string="Number" col="4">
-                        <field name="dp_inherit" string="Rounding inherit" />
-                        <field name="dp" invisible="dp_inherit" />
-                        <field name="divider_inherit" string="Factor inherit" />
-                        <field name="divider" invisible="divider_inherit" />
-                        <field name="prefix_inherit" />
-                        <field name="prefix" invisible="prefix_inherit" />
-                        <field name="suffix_inherit" />
-                        <field name="suffix" invisible="suffix_inherit" />
+                    <group string="Number">
+                        <group>
+                            <group>
+                                <field name="dp_inherit" string="Rounding inherit" />
+                            </group>
+                            <group>
+                                <field name="dp" invisible="dp_inherit" />
+                            </group>
+                            <group>
+                                <field name="prefix_inherit" />
+                            </group>
+                            <group>
+                                <field name="prefix" invisible="prefix_inherit" />
+                            </group>
+                        </group>
+                        <group>
+                            <group>
+                                <field name="divider_inherit" string="Factor inherit" />
+                            </group>
+                            <group>
+                                <field name="divider" invisible="divider_inherit" />
+                            </group>
+                            <group>
+                                <field name="suffix_inherit" />
+                            </group>
+                            <group>
+                                <field name="suffix" invisible="suffix_inherit" />
+                            </group>
+                        </group>
                     </group>
-                    <group string="Color" col="4">
-                        <field name="color_inherit" />
-                        <field name="color" invisible="color_inherit" widget="color" />
-                        <field name="background_color_inherit" />
-                        <field
-                            name="background_color"
-                            invisible="background_color_inherit"
-                            widget="color"
-                        />
+                    <group string="Color">
+                        <group>
+                            <group>
+                                <field name="color_inherit" />
+                            </group>
+                            <group>
+                                <field
+                                    name="color"
+                                    invisible="color_inherit"
+                                    widget="color"
+                                />
+                            </group>
+                        </group>
+                        <group>
+                            <group>
+                                <field name="background_color_inherit" />
+                            </group>
+                            <group>
+                                <field
+                                    name="background_color"
+                                    invisible="background_color_inherit"
+                                    widget="color"
+                                />
+                            </group>
+                        </group>
                     </group>
-                    <group string="Font" col="4">
-                        <field name="font_style_inherit" />
-                        <field name="font_style" invisible="font_style_inherit" />
-                        <field name="font_weight_inherit" />
-                        <field name="font_weight" invisible="font_weight_inherit" />
-                        <field name="font_size_inherit" />
-                        <field name="font_size" invisible="font_size_inherit" />
+                    <group string="Font">
+                        <group>
+                            <group>
+                                <field name="font_style_inherit" />
+                            </group>
+                            <group>
+                                <field
+                                    name="font_style"
+                                    invisible="font_style_inherit"
+                                />
+                            </group>
+                            <group>
+                                <field name="font_size_inherit" />
+                            </group>
+                            <group>
+                                <field name="font_size" invisible="font_size_inherit" />
+                            </group>
+                        </group>
+                        <group>
+                            <group>
+                                <field name="font_weight_inherit" />
+                            </group>
+                            <group>
+                                <field
+                                    name="font_weight"
+                                    invisible="font_weight_inherit"
+                                />
+                            </group>
+                        </group>
                     </group>
-                    <group string="Indent" col="4">
-                        <field name="indent_level_inherit" />
-                        <field name="indent_level" invisible="indent_level_inherit" />
+                    <group string="Indent">
+                        <group>
+                            <group>
+                                <field name="indent_level_inherit" />
+                            </group>
+                            <group>
+                                <field
+                                    name="indent_level"
+                                    invisible="indent_level_inherit"
+                                />
+                            </group>
+                        </group>
                     </group>
-                    <group string="Visibility" col="4">
-                        <field name="hide_empty_inherit" />
-                        <field name="hide_empty" invisible="hide_empty_inherit" />
-                        <field name="hide_always_inherit" />
-                        <field name="hide_always" invisible="hide_always_inherit" />
+                    <group string="Visibility">
+                        <group>
+                            <group>
+                                <field name="hide_empty_inherit" />
+                            </group>
+                            <group>
+                                <field
+                                    name="hide_empty"
+                                    invisible="hide_empty_inherit"
+                                />
+                            </group>
+                        </group>
+                        <group>
+                            <group>
+                                <field name="hide_always_inherit" />
+                            </group>
+                            <group>
+                                <field
+                                    name="hide_always"
+                                    invisible="hide_always_inherit"
+                                />
+                            </group>
+                        </group>
                     </group>
                 </sheet>
             </form>


### PR DESCRIPTION
**Rational:** Before that commits, check (or uncheck) 'inherit' fields move all the other fields, in the report style form view. This is not the best User experience.
With that commit, fields are always in the same places, even if there are hidden

### Before (checked)

<img width="1221" height="150" alt="image" src="https://github.com/user-attachments/assets/29e2f70a-adbf-4b45-8cdd-77ff8cdd047b" />

### Before (unchecked)

<img width="1216" height="199" alt="image" src="https://github.com/user-attachments/assets/2484ccbc-1230-4a25-953f-e7639bf5d880" />

### After (checked)

<img width="1227" height="149" alt="image" src="https://github.com/user-attachments/assets/f176eb4c-9e9c-4102-9ea3-f392c7490002" />

### After (unchecked)

<img width="1218" height="129" alt="image" src="https://github.com/user-attachments/assets/125820dc-100f-49f0-93cb-7e7cc876edd3" />


CC : @sbidoul, @gva-acsone, @astoffel
