### PR TITLE
[IMP] mis_builder: use more classic h1 tag for name field of the report style form view

### DIFF
--- a/mis_builder/views/mis_report_style.xml
+++ b/mis_builder/views/mis_report_style.xml
@@ -15,9 +15,14 @@
         <field name="arch" type="xml">
             <form string="MIS Report Style">
                 <sheet>
-                    <group string="Style" col="2">
-                        <field name="name" />
-                    </group>
+                    <div class="oe_title">
+                        <label for="name" />
+                        <h1>
+                            <div class="d-flex">
+                                <field name="name" />
+                            </div>
+                        </h1>
+                    </div>
                     <group string="Number" col="4">
                         <field name="dp_inherit" string="Rounding inherit" />
                         <field name="dp" invisible="dp_inherit" />


### PR DESCRIPTION
Quite Trivial PR : 

### Before


<img width="1259" height="193" alt="image" src="https://github.com/user-attachments/assets/a5dd45de-7e14-4294-9793-6023eb51436f" />


### After


<img width="1104" height="178" alt="image" src="https://github.com/user-attachments/assets/5bb7f810-1820-4248-84c4-19f494181c9b" />


CC : @sbidoul, @gva-acsone, @astoffel

PS : do not take into account background color of the field in the screenshots. I have `web_theme_classic` installed.
(https://github.com/OCA/web/tree/18.0/web_theme_classic#web-theme-classic)