### PR TITLE
[18.0][IMP] mis_builder : Use 'code' widget (mode: 'python').

### DIFF
--- a/mis_builder/views/mis_report.xml
+++ b/mis_builder/views/mis_report.xml
@@ -44,7 +44,11 @@
                                         name="accumulation_method"
                                         invisible="type == 'str'"
                                     />
-                                    <field name="expression" />
+                                    <field
+                                        name="expression"
+                                        widget="code"
+                                        options="{'mode': 'python'}"
+                                    />
                                 </list>
                             </field>
                         </page>
@@ -137,11 +141,17 @@
                                         name="subkpi_id"
                                         domain="[('report_id', '=', parent.report_id)]"
                                     />
-                                    <field name="name" />
+                                    <field
+                                        name="name"
+                                        widget="code"
+                                        options="{'mode': 'python'}"
+                                    />
                                 </list>
                             </field>
                             <field
                                 name="expression"
+                                widget="code"
+                                options="{'mode': 'python'}"
                                 colspan="2"
                                 nolabel="1"
                                 invisible="multi"


### PR DESCRIPTION
Rational: without that widget, it's quite hard to know if all the brackets are correctly closed. the 'code' widget can help user avoid errors. 

Tecnical note : this widget is used in odoo core, in the server action for exemple. 

### Before


<img width="1244" height="255" alt="image" src="https://github.com/user-attachments/assets/cbfb0f53-9361-443d-beec-389e11b24b37" />


### After


<img width="1245" height="257" alt="image" src="https://github.com/user-attachments/assets/9924031d-d9f1-4052-b764-3ef0b1e10e4b" />

In case of error, color can help : 

<img width="372" height="54" alt="image" src="https://github.com/user-attachments/assets/32b8bd35-549b-4eaf-b297-fb87ba3e2298" />

(here for exemple, a quote is missing)

CC : @sbidoul, @gva-acsone, @astoffel