### PR TITLE
[IMP] mis_builder_* : use new 'optional' fields

### DIFF
--- a/mis_builder/views/mis_report.xml
+++ b/mis_builder/views/mis_report.xml
@@ -35,14 +35,16 @@
                                     <field name="sequence" widget="handle" />
                                     <field name="description" />
                                     <field name="name" />
-                                    <field name="type" />
+                                    <field name="type" optional="show" />
                                     <field
                                         name="compare_method"
                                         invisible="type == 'str'"
+                                        optional="show"
                                     />
                                     <field
                                         name="accumulation_method"
                                         invisible="type == 'str'"
+                                        optional="show"
                                     />
                                     <field name="expression" />
                                 </list>
@@ -64,12 +66,12 @@
                                         widget="many2many_tags"
                                     />
                                     <field name="field_names" />
-                                    <field name="aggregate" />
+                                    <field name="aggregate" optional="show" />
                                     <field
                                         name="date_field"
                                         domain="[('model_id', '=', model_id), ('ttype', 'in', ('date', 'datetime'))]"
                                     />
-                                    <field name="domain" />
+                                    <field name="domain" optional="show" />
                                 </list>
                             </field>
                         </page>

--- a/mis_builder_budget/views/mis_report.xml
+++ b/mis_builder_budget/views/mis_report.xml
@@ -11,7 +11,7 @@
                 expr="//field[@name='kpi_ids']/list/field[@name='expression']"
                 position="after"
             >
-                <field name="budgetable" />
+                <field name="budgetable" optional="show" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Quite trivial PR.


Rational: in many MIS templates, some fields are not used. Allow to hide those fields to make lighter display.

<img width="1227" height="215" alt="image" src="https://github.com/user-attachments/assets/e8c43fba-333f-4517-81da-52e58d186ed5" />


CC : @gva-acsone, @lmarion-source, @baimont, @FrancoMaxime