### PR TITLE
[FIX] mis_builder: Allow to copy mis.report.instance models in case it has comparison (and/or sum?) periods

### DIFF
--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -461,15 +461,14 @@ class MisReportInstancePeriod(models.Model):
                     )
 
     def copy_data(self, default=None):
-        if self.source == SRC_CMPCOL:
-            # While duplicating a MIS report instance, comparison columns are
-            # ignored because they would raise an error, as they keep the old
-            # `source_cmpcol_from_id` and `source_cmpcol_to_id` from the
-            # original record.
-            return [
-                False,
-            ]
-        return super().copy_data(default=default)
+        # While duplicating a MIS report instance, comparison columns are
+        # ignored because they would raise an error, as they keep the old
+        # `source_cmpcol_from_id` and `source_cmpcol_to_id` from the
+        # original record.
+        filtered_records = self.filtered(lambda x: x.source != SRC_CMPCOL)
+        return super(MisReportInstancePeriod, filtered_records).copy_data(
+            default=default
+        )
 
 
 class MisReportInstance(models.Model):

--- a/mis_builder/tests/test_mis_report_instance.py
+++ b/mis_builder/tests/test_mis_report_instance.py
@@ -637,3 +637,7 @@ class TestMisReportInstance(common.HttpCase):
             self.env, "mis_you", groups="base.group_user,account.group_account_readonly"
         )
         self.report_instance.with_user(test_user).compute()
+
+    def test_copy_mis_report_instance(self):
+        new_instance = self.report_instance.copy()
+        self.assertEqual(new_instance.name, f"{self.report_instance.name} (copy)")


### PR DESCRIPTION
Fixes: #714

Rational: For the time being, copy_data is failing, if there are many periods in an mis.report.instance, because self.source only works with a singleton.

Bug introduced in version 13.0, in #343

CC : @LoisRForgeFlow
