### PR TITLE
[18.0][MIG/IMP] mis_builder: analytic_distribution_search removed in 18

### DIFF
--- a/mis_builder/README.rst
+++ b/mis_builder/README.rst
@@ -763,7 +763,7 @@ promote its widespread use.
 
 Current `maintainer <https://odoo-community.org/page/maintainer-role>`__:
 
-|maintainer-sbidoul| 
+|maintainer-sbidoul|
 
 This module is part of the `OCA/mis-builder <https://github.com/OCA/mis-builder/tree/18.0/mis_builder>`_ project on GitHub.
 

--- a/mis_builder/__manifest__.py
+++ b/mis_builder/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "MIS Builder",
-    "version": "18.0.1.2.6",
+    "version": "18.0.1.3.0",
     "category": "Reporting",
     "summary": """
         Build 'Management Information System' Reports and Dashboards

--- a/mis_builder/migrations/18.0.1.3.0/post-migration.py
+++ b/mis_builder/migrations/18.0.1.3.0/post-migration.py
@@ -1,0 +1,40 @@
+# Copyright 2025 ForgeFlow S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+from odoo.tools.safe_eval import safe_eval
+
+
+@openupgrade.migrate()
+def migrate(cr, version):
+    """Update the value of the analytic_domain field."""
+    # Workaround to execute the migration script without errors
+    # see https://github.com/odoo/odoo/blob/2a839ef1ed09c36f27ce7536ca3052d9f65ceed9/odoo/modules/migration.py#L252-L256
+    env = cr
+    for record in env["mis.report.instance.period"].search(
+        [("analytic_domain", "!=", False)]
+    ):
+        new_domain = _update_domain(record)
+        record.write({"analytic_domain": new_domain})
+
+    for record in env["mis.report.instance"].search([("analytic_domain", "!=", False)]):
+        new_domain = _update_domain(record)
+        record.write({"analytic_domain": new_domain})
+
+
+def _update_domain(record):
+    # analytic_distribution_search has been removed in v18 and it was set on purpose
+    # on mis_builder migration scripts in 16.0.
+    domain = safe_eval(record.analytic_domain)
+    new_domain = []
+    for clause in domain:
+        if (
+            isinstance(clause, list | tuple)
+            and clause[0] == "analytic_distribution_search"
+        ):
+            operator = clause[1]
+            value = clause[2]
+            clause = ("distribution_analytic_account_ids", operator, value)
+        new_domain.append(clause)
+    return new_domain


### PR DESCRIPTION
analytic_distribution_search has been removed in v18 and it was set on purpose on mib_builder migration scripts in 16.0. I think we need to handle it as well in 18.0 migration.