### PR TITLE
[16.0][FIX] mis_builder: fix rows all having None as row_id

### DIFF
--- a/mis_builder/models/kpimatrix.py
+++ b/mis_builder/models/kpimatrix.py
@@ -47,7 +47,7 @@ class KpiMatrixRow:
 
     @property
     def row_id(self):
-        self._matrix._make_row_id(self.kpi.id, self.account_id)
+        return self._matrix._make_row_id(self.kpi.id, self.account_id)
 
     def iter_cell_tuples(self, cols=None):
         if cols is None:


### PR DESCRIPTION
fix rows all having `None` as `row_id` (introduced in #676).