### PR TITLE
[18.0][IMP]mis_builder: improve rounding

### DIFF
--- a/mis_builder/models/mis_report_style.py
+++ b/mis_builder/models/mis_report_style.py
@@ -7,6 +7,7 @@ import sys
 
 from odoo import api, fields, models
 from odoo.exceptions import ValidationError
+from odoo.tools import float_round
 
 from .accounting_none import AccountingNone
 from .data_error import DataError
@@ -218,7 +219,7 @@ class MisReportKpiStyle(models.Model):
         # format number following user language
         if value is None or value is AccountingNone:
             return ""
-        value = round(value / float(divider or 1), dp or 0) or 0
+        value = float_round(value / float(divider or 1), dp or 0) or 0
         r = lang.format("%%%s.%df" % (sign, dp or 0), value, grouping=True)
         r = r.replace("-", "\N{NON-BREAKING HYPHEN}")
         if prefix:

--- a/mis_builder/tests/test_render.py
+++ b/mis_builder/tests/test_render.py
@@ -91,6 +91,13 @@ class TestRendering(common.TransactionCase):
         self.style.dp = 0
         self.assertEqual("1,000,000", self._render(1))
 
+    def test_render_ieee754(self):
+        self.style.dp_inherit = False
+        self.style.dp = 1
+        self.assertEqual("9.5", self._render(9.45))
+        self.assertEqual("9.6", self._render(9.55))
+        self.assertEqual("10.0", self._render(9.95))
+
     def test_render_pct(self):
         self.assertEqual("100\xa0%", self._render(1, TYPE_PCT))
         self.assertEqual("50\xa0%", self._render(0.5, TYPE_PCT))


### PR DESCRIPTION
The rounding of pythons built-in may lead to unexpected results. 
The following values are round with built-in python round to 1 digit:
9.15 -> 9.2
9.25 -> 9.2
9.35 -> 9.3
9.45 -> 9.4
9.55 -> 9.6
9.65 -> 9.7
9.75 -> 9.8
9.85 -> 9.8
9.95 -> 9.9
There is no consistency if the value is round up or down. The odoo float_round leads to consitent result. For that example always rounds up:
9.15 -> 9.2
9.25 -> 9.3
9.35 -> 9.4
9.45 -> 9.5
9.55 -> 9.6
9.65 -> 9.7
9.75 -> 9.8
9.85 -> 9.9
9.95 -> 10.0