### PR TITLE
[IMP] mis_builder: Add dynamic company filter

### DIFF
--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -748,6 +748,9 @@ class MisReportInstance(models.Model):
             domain.extend(ast.literal_eval(self.analytic_domain))
         # contextual analytic domain filter
         domain.extend(self.env.context.get("mis_analytic_domain", []))
+        # company filter
+        if self.query_company_ids:
+            domain.append(("company_id", "in", self.query_company_ids.ids))
         return domain
 
     @api.model


### PR DESCRIPTION
This PR addresses issue #328.\n\nIt adds a dynamic company filter to the MIS report view, allowing users to switch between companies in a multi-company environment.\n\nThe implementation leverages the existing , , and  fields on the  model.\n\nThe  method has been modified to include a filter based on the selected company or companies.