### PR TITLE
[IMP] mis_builder: Add annotations column to reports

### DIFF
--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -748,6 +748,9 @@ class MisReportInstance(models.Model):
             domain.extend(ast.literal_eval(self.analytic_domain))
         # contextual analytic domain filter
         domain.extend(self.env.context.get("mis_analytic_domain", []))
+        # company filter
+        if self.query_company_ids:
+            domain.append(("company_id", "in", self.query_company_ids.ids))
         return domain
 
     @api.model

--- a/mis_builder/report/mis_report_instance_qweb.xml
+++ b/mis_builder/report/mis_report_instance_qweb.xml
@@ -119,9 +119,7 @@
                                                 t-value="notes and first_cell and notes.get(first_cell.cell_id)"
                                             />
                                             <t t-if="first_cell_note">
-                                                <t
-                                                    t-out="first_cell_note['text']"
-                                                />
+                                                <t t-out="first_cell_note['text']" />
                                             </t>
                                         </div>
                                     </div>

--- a/mis_builder/report/mis_report_instance_qweb.xml
+++ b/mis_builder/report/mis_report_instance_qweb.xml
@@ -115,13 +115,11 @@
                                                 t-value="next(row.iter_cells(), None)"
                                             />
                                             <t
-                                                t-if="first_cell and hasattr(first_cell, 'cell_id')"
+                                                t-if="first_cell and first_cell.cell_id and (notes or {}).get(first_cell.cell_id)"
                                             >
                                                 <t
-                                                    t-if="first_cell and first_cell.cell_id"
-                                                >
-                                                    t-out="(notes or {}).get(first_cell.cell_id, {}).get('text', '')"
-                                                </t>
+                                                    t-out="((notes or {}).get(first_cell.cell_id, {})).get('text', '')"
+                                                />
                                             </t>
                                         </div>
                                     </div>

--- a/mis_builder/report/mis_report_instance_qweb.xml
+++ b/mis_builder/report/mis_report_instance_qweb.xml
@@ -72,6 +72,7 @@
                                             </t>
                                         </div>
                                     </t>
+                                    <div class="mis_cell mis_collabel">Annotations</div>
                                 </div>
                             </div>
                             <div class="mis_tbody">
@@ -108,23 +109,22 @@
                                                 </span>
                                             </div>
                                         </t>
+                                        <div class="mis_cell">
+                                            <t
+                                                t-set="first_cell"
+                                                t-value="next(row.iter_cells(), None)"
+                                            />
+                                            <t
+                                                t-if="first_cell and notes.get(first_cell.cell_id)"
+                                            >
+                                                <t
+                                                    t-out="notes[first_cell.cell_id]['text']"
+                                                />
+                                            </t>
+                                        </div>
                                     </div>
                                 </t>
                             </div>
-                        </div>
-                        <!-- Foot notes -->
-                        <div class="oe_mis_builder_footnote_div">
-                            <table class="oe_mis_builder_footnote_table">
-                                <t
-                                    t-foreach="sorted(notes.values(),key=lambda r:r['sequence'])"
-                                    t-as="note"
-                                >
-                                    <tr>
-                                        <td><t t-out="note['sequence']" />. </td>
-                                        <td t-out="note['text']" />
-                                    </tr>
-                                </t>
-                            </table>
                         </div>
                     </div>
                 </t>

--- a/mis_builder/report/mis_report_instance_qweb.xml
+++ b/mis_builder/report/mis_report_instance_qweb.xml
@@ -114,9 +114,7 @@
                                                 t-set="first_cell"
                                                 t-value="next(row.iter_cells(), None)"
                                             />
-                                            <t
-                                                t-if="first_cell"
-                                            >
+                                            <t t-if="first_cell and hasattr(first_cell, 'cell_id')">
                                                 <t t-if="first_cell and first_cell.cell_id">
                                                     t-out="(notes or {}).get(first_cell.cell_id, {}).get('text', '')"
                                                 </t>

--- a/mis_builder/report/mis_report_instance_qweb.xml
+++ b/mis_builder/report/mis_report_instance_qweb.xml
@@ -114,9 +114,7 @@
                                                 t-set="first_cell"
                                                 t-value="next(row.iter_cells(), None)"
                                             />
-                                            <t
-                                                t-if="first_cell"
-                                            >
+                                            <t t-if="first_cell">
                                                 <t
                                                     t-if="(notes or {}).get(first_cell.cell_id)"
                                                     t-out="(notes.get(first_cell.cell_id) or {}).get('text', '')"

--- a/mis_builder/report/mis_report_instance_qweb.xml
+++ b/mis_builder/report/mis_report_instance_qweb.xml
@@ -115,10 +115,12 @@
                                                 t-value="next(row.iter_cells(), None)"
                                             />
                                             <t
-                                                t-if="first_cell and notes and first_cell.cell_id in notes"
-                                            >
+                                                t-set="first_cell_note"
+                                                t-value="notes and first_cell and notes.get(first_cell.cell_id)"
+                                            />
+                                            <t t-if="first_cell_note">
                                                 <t
-                                                    t-out="notes[first_cell.cell_id]['text']"
+                                                    t-out="first_cell_note['text']"
                                                 />
                                             </t>
                                         </div>

--- a/mis_builder/report/mis_report_instance_qweb.xml
+++ b/mis_builder/report/mis_report_instance_qweb.xml
@@ -115,7 +115,7 @@
                                                 t-value="next(row.iter_cells(), None)"
                                             />
                                             <t
-                                                t-if="first_cell and notes.get(first_cell.cell_id)"
+                                                t-if="first_cell and notes and notes.get(first_cell.cell_id)"
                                             >
                                                 <t
                                                     t-out="notes[first_cell.cell_id]['text']"

--- a/mis_builder/report/mis_report_instance_qweb.xml
+++ b/mis_builder/report/mis_report_instance_qweb.xml
@@ -111,10 +111,14 @@
                                         </t>
                                         <div class="mis_cell">
                                             <t
-                                                t-if="row.cells and (cell_notes or {}).get(row.cells[0].cell_id)"
+                                                t-set="first_cell"
+                                                t-value="next((c for c in row.iter_cells() if c), None)"
+                                            />
+                                            <t
+                                                t-if="first_cell and (cell_notes or {}).get(first_cell.cell_id)"
                                             >
                                                 <t
-                                                    t-out="(cell_notes.get(row.cells[0].cell_id) or {}).get('text', '')"
+                                                    t-out="(cell_notes.get(first_cell.cell_id) or {}).get('text', '')"
                                                 />
                                             </t>
                                         </div>

--- a/mis_builder/report/mis_report_instance_qweb.xml
+++ b/mis_builder/report/mis_report_instance_qweb.xml
@@ -110,17 +110,14 @@
                                             </div>
                                         </t>
                                         <div class="mis_cell">
-                                            <t
-                                                t-set="first_cell"
-                                                t-value="next(row.iter_cells(), None)"
-                                            />
-                                            <t
-                                                t-if="first_cell and notes.get(first_cell.cell_id)"
-                                            >
-                                                <t
-                                                    t-out="notes[first_cell.cell_id]['text']"
-                                                />
-                                            </t>
+                                        <t
+                                            t-set="first_cell"
+                                            t-value="next(row.iter_cells(), None)"
+                                        />
+                                        <t t-if="first_cell and notes and first_cell.cell_id in notes">
+                                            <t t-out="notes[first_cell.cell_id]['text']" />
+                                        </t>
+
                                         </div>
                                     </div>
                                 </t>

--- a/mis_builder/report/mis_report_instance_qweb.xml
+++ b/mis_builder/report/mis_report_instance_qweb.xml
@@ -115,11 +115,11 @@
                                                 t-value="next(row.iter_cells(), None)"
                                             />
                                             <t
-                                                t-if="first_cell and (notes or {}).get(first_cell.cell_id)"
+                                                t-if="first_cell"
                                             >
-                                                <t
+                                                <t t-if="first_cell and first_cell.cell_id">
                                                     t-out="(notes or {}).get(first_cell.cell_id, {}).get('text', '')"
-                                                />
+                                                </t>
                                             </t>
                                         </div>
                                     </div>

--- a/mis_builder/report/mis_report_instance_qweb.xml
+++ b/mis_builder/report/mis_report_instance_qweb.xml
@@ -118,7 +118,7 @@
                                                 t-if="first_cell and notes and notes.get(first_cell.cell_id)"
                                             >
                                                 <t
-                                                    t-out="notes[first_cell.cell_id]['text']"
+                                                    t-out="(notes and notes.get(first_cell.cell_id, {}) or {}).get('text', '')"
                                                 />
                                             </t>
                                         </div>

--- a/mis_builder/report/mis_report_instance_qweb.xml
+++ b/mis_builder/report/mis_report_instance_qweb.xml
@@ -99,16 +99,15 @@
                                                 <t
                                                     t-out="cell and cell.val_rendered or ''"
                                                 />
-                                                 <span
-                                                     class="oe_mis_builder_footnote"
-                                                     t-if="cell"
-                                                 >
-                                                     <t
-                                                         t-out="(cell_notes.get(cell.cell_id) or {}).get('sequence', '')"
-                                                     />
-                                                 </span>
-                                             </div>
-
+                                                <span
+                                                    class="oe_mis_builder_footnote"
+                                                    t-if="cell"
+                                                >
+                                                    <t
+                                                        t-out="(cell_notes.get(cell.cell_id) or {}).get('sequence', '')"
+                                                    />
+                                                </span>
+                                            </div>
                                         </t>
                                         <div class="mis_cell">
                                             <t

--- a/mis_builder/report/mis_report_instance_qweb.xml
+++ b/mis_builder/report/mis_report_instance_qweb.xml
@@ -110,14 +110,17 @@
                                             </div>
                                         </t>
                                         <div class="mis_cell">
-                                        <t
-                                            t-set="first_cell"
-                                            t-value="next(row.iter_cells(), None)"
-                                        />
-                                        <t t-if="first_cell and notes and first_cell.cell_id in notes">
-                                            <t t-out="notes[first_cell.cell_id]['text']" />
-                                        </t>
-
+                                            <t
+                                                t-set="first_cell"
+                                                t-value="next(row.iter_cells(), None)"
+                                            />
+                                            <t
+                                                t-set="first_cell_note"
+                                                t-value="notes.get(first_cell.cell_id) if first_cell else None"
+                                            />
+                                            <t t-if="first_cell_note">
+                                                <t t-out="first_cell_note['text']" />
+                                            </t>
                                         </div>
                                     </div>
                                 </t>

--- a/mis_builder/report/mis_report_instance_qweb.xml
+++ b/mis_builder/report/mis_report_instance_qweb.xml
@@ -17,7 +17,7 @@
             <t t-foreach="docs" t-as="o">
                 <t t-call="web.internal_layout">
                     <t t-set="matrix" t-value="o._compute_matrix()" />
-                    <t t-set="notes" t-value="dict(o.get_notes_by_cell_id() or {})" />
+                    <t t-set="notes" t-value="o.get_notes_by_cell_id() or {}" />
                     <t t-set="style_obj" t-value="o.env['mis.report.style']" />
                     <div class="page">
                         <h3>
@@ -115,11 +115,11 @@
                                                 t-value="next(row.iter_cells(), None)"
                                             />
                                             <t
-                                                t-set="first_cell_note"
-                                                t-value="notes.get(first_cell.cell_id) if first_cell and notes else None"
-                                            />
-                                            <t t-if="first_cell_note">
-                                                <t t-out="first_cell_note['text']" />
+                                                t-if="first_cell and notes and first_cell.cell_id in notes"
+                                            >
+                                                <t
+                                                    t-out="notes[first_cell.cell_id]['text']"
+                                                />
                                             </t>
                                         </div>
                                     </div>

--- a/mis_builder/report/mis_report_instance_qweb.xml
+++ b/mis_builder/report/mis_report_instance_qweb.xml
@@ -114,8 +114,12 @@
                                                 t-set="first_cell"
                                                 t-value="next(row.iter_cells(), None)"
                                             />
-                                            <t t-if="first_cell and hasattr(first_cell, 'cell_id')">
-                                                <t t-if="first_cell and first_cell.cell_id">
+                                            <t
+                                                t-if="first_cell and hasattr(first_cell, 'cell_id')"
+                                            >
+                                                <t
+                                                    t-if="first_cell and first_cell.cell_id"
+                                                >
                                                     t-out="(notes or {}).get(first_cell.cell_id, {}).get('text', '')"
                                                 </t>
                                             </t>

--- a/mis_builder/report/mis_report_instance_qweb.xml
+++ b/mis_builder/report/mis_report_instance_qweb.xml
@@ -104,7 +104,7 @@
                                                     t-if="cell"
                                                 >
                                                     <t
-                                                        t-out="(notes and notes.get(cell.cell_id,{}) or {}).get('sequence', '')"
+                                                        t-out="(notes or {}).get(cell.cell_id, {}).get('sequence', '')"
                                                     />
                                                 </span>
                                             </div>
@@ -115,10 +115,10 @@
                                                 t-value="next(row.iter_cells(), None)"
                                             />
                                             <t
-                                                t-if="first_cell and notes and notes.get(first_cell.cell_id)"
+                                                t-if="first_cell and (notes or {}).get(first_cell.cell_id)"
                                             >
                                                 <t
-                                                    t-out="(notes and notes.get(first_cell.cell_id, {}) or {}).get('text', '')"
+                                                    t-out="(notes or {}).get(first_cell.cell_id, {}).get('text', '')"
                                                 />
                                             </t>
                                         </div>

--- a/mis_builder/report/mis_report_instance_qweb.xml
+++ b/mis_builder/report/mis_report_instance_qweb.xml
@@ -111,19 +111,11 @@
                                         </t>
                                         <div class="mis_cell">
                                             <t
-                                                t-set="first_cell"
-                                                t-value="next(row.iter_cells(), None)"
-                                            />
-                                            <t
-                                                t-set="first_cell_note"
-                                                t-value="cell_notes and first_cell and cell_notes.get(first_cell.cell_id)"
-                                            />
-                                            <t t-if="first_cell_note">
+                                                t-if="row.cells and (cell_notes or {}).get(row.cells[0].cell_id)"
+                                            >
                                                 <t
-                                                    t-set="first_cell_note_text"
-                                                    t-value="first_cell_note['text']"
+                                                    t-out="(cell_notes.get(row.cells[0].cell_id) or {}).get('text', '')"
                                                 />
-                                                <t t-out="first_cell_note_text" />
                                             </t>
                                         </div>
                                     </div>

--- a/mis_builder/report/mis_report_instance_qweb.xml
+++ b/mis_builder/report/mis_report_instance_qweb.xml
@@ -17,7 +17,7 @@
             <t t-foreach="docs" t-as="o">
                 <t t-call="web.internal_layout">
                     <t t-set="matrix" t-value="o._compute_matrix()" />
-                    <t t-set="notes" t-value="o.get_notes_by_cell_id() or {}" />
+                    <t t-set="cell_notes" t-value="o.get_notes_by_cell_id() or {}" />
                     <t t-set="style_obj" t-value="o.env['mis.report.style']" />
                     <div class="page">
                         <h3>
@@ -99,15 +99,16 @@
                                                 <t
                                                     t-out="cell and cell.val_rendered or ''"
                                                 />
-                                                <span
-                                                    class="oe_mis_builder_footnote"
-                                                    t-if="cell"
-                                                >
-                                                    <t
-                                                        t-out="(notes.get(cell.cell_id) or {}).get('sequence', '')"
-                                                    />
-                                                </span>
-                                            </div>
+                                                 <span
+                                                     class="oe_mis_builder_footnote"
+                                                     t-if="cell"
+                                                 >
+                                                     <t
+                                                         t-out="(cell_notes.get(cell.cell_id) or {}).get('sequence', '')"
+                                                     />
+                                                 </span>
+                                             </div>
+
                                         </t>
                                         <div class="mis_cell">
                                             <t
@@ -116,10 +117,14 @@
                                             />
                                             <t
                                                 t-set="first_cell_note"
-                                                t-value="notes and first_cell and notes.get(first_cell.cell_id)"
+                                                t-value="cell_notes and first_cell and cell_notes.get(first_cell.cell_id)"
                                             />
                                             <t t-if="first_cell_note">
-                                                <t t-out="first_cell_note['text']" />
+                                                <t
+                                                    t-set="first_cell_note_text"
+                                                    t-value="first_cell_note['text']"
+                                                />
+                                                <t t-out="first_cell_note_text" />
                                             </t>
                                         </div>
                                     </div>

--- a/mis_builder/report/mis_report_instance_qweb.xml
+++ b/mis_builder/report/mis_report_instance_qweb.xml
@@ -17,7 +17,7 @@
             <t t-foreach="docs" t-as="o">
                 <t t-call="web.internal_layout">
                     <t t-set="matrix" t-value="o._compute_matrix()" />
-                    <t t-set="notes" t-value="o.get_notes_by_cell_id() or {}" />
+                    <t t-set="notes" t-value="dict(o.get_notes_by_cell_id() or {})" />
                     <t t-set="style_obj" t-value="o.env['mis.report.style']" />
                     <div class="page">
                         <h3>
@@ -116,7 +116,7 @@
                                             />
                                             <t
                                                 t-set="first_cell_note"
-                                                t-value="notes.get(first_cell.cell_id) if first_cell else None"
+                                                t-value="notes.get(first_cell.cell_id) if first_cell and notes else None"
                                             />
                                             <t t-if="first_cell_note">
                                                 <t t-out="first_cell_note['text']" />

--- a/mis_builder/report/mis_report_instance_qweb.xml
+++ b/mis_builder/report/mis_report_instance_qweb.xml
@@ -14,11 +14,11 @@
     -->
     <template id="report_mis_report_instance">
         <t t-call="web.html_container">
-                <t t-foreach="docs" t-as="o">
-                    <t t-call="web.internal_layout">
-                        <t t-set="matrix" t-value="o._compute_matrix()" />
-                        <t t-set="notes" t-value="o.get_notes_by_cell_id() or {}" />
-                        <t t-set="style_obj" t-value="o.env['mis.report.style']" />
+            <t t-foreach="docs" t-as="o">
+                <t t-call="web.internal_layout">
+                    <t t-set="matrix" t-value="o._compute_matrix()" />
+                    <t t-set="notes" t-value="o.get_notes_by_cell_id() or {}" />
+                    <t t-set="style_obj" t-value="o.env['mis.report.style']" />
                     <div class="page">
                         <h3>
                             <span t-field="o.name" />

--- a/mis_builder/report/mis_report_instance_qweb.xml
+++ b/mis_builder/report/mis_report_instance_qweb.xml
@@ -104,7 +104,7 @@
                                                     t-if="cell"
                                                 >
                                                     <t
-                                                        t-out="notes.get(cell.cell_id,{}).get('sequence','')"
+                                                        t-out="(notes and notes.get(cell.cell_id,{}) or {}).get('sequence', '')"
                                                     />
                                                 </span>
                                             </div>

--- a/mis_builder/report/mis_report_instance_qweb.xml
+++ b/mis_builder/report/mis_report_instance_qweb.xml
@@ -114,12 +114,14 @@
                                                 t-set="first_cell"
                                                 t-value="next((c for c in row.iter_cells() if c), None)"
                                             />
-                                            <t
-                                                t-if="first_cell and (cell_notes or {}).get(first_cell.cell_id)"
-                                            >
+                                            <t t-if="first_cell">
                                                 <t
-                                                    t-out="(cell_notes.get(first_cell.cell_id) or {}).get('text', '')"
-                                                />
+                                                    t-if="(cell_notes or {}).get(first_cell.cell_id)"
+                                                >
+                                                    <t
+                                                        t-out="(cell_notes.get(first_cell.cell_id) or {}).get('text', '')"
+                                                    />
+                                                </t>
                                             </t>
                                         </div>
                                     </div>

--- a/mis_builder/report/mis_report_instance_qweb.xml
+++ b/mis_builder/report/mis_report_instance_qweb.xml
@@ -114,10 +114,11 @@
                                                 t-set="first_cell"
                                                 t-value="next(row.iter_cells(), None)"
                                             />
-                                            <t t-if="first_cell">
+                                            <t
+                                                t-if="first_cell and notes.get(first_cell.cell_id)"
+                                            >
                                                 <t
-                                                    t-if="(notes or {}).get(first_cell.cell_id)"
-                                                    t-out="(notes.get(first_cell.cell_id) or {}).get('text', '')"
+                                                    t-out="notes[first_cell.cell_id]['text']"
                                                 />
                                             </t>
                                         </div>

--- a/mis_builder/report/mis_report_instance_qweb.xml
+++ b/mis_builder/report/mis_report_instance_qweb.xml
@@ -14,11 +14,11 @@
     -->
     <template id="report_mis_report_instance">
         <t t-call="web.html_container">
-            <t t-foreach="docs" t-as="o">
-                <t t-call="web.internal_layout">
-                    <t t-set="matrix" t-value="o._compute_matrix()" />
-                    <t t-set="notes" t-value="o.get_notes_by_cell_id()" />
-                    <t t-set="style_obj" t-value="o.env['mis.report.style']" />
+                <t t-foreach="docs" t-as="o">
+                    <t t-call="web.internal_layout">
+                        <t t-set="matrix" t-value="o._compute_matrix()" />
+                        <t t-set="notes" t-value="o.get_notes_by_cell_id() or {}" />
+                        <t t-set="style_obj" t-value="o.env['mis.report.style']" />
                     <div class="page">
                         <h3>
                             <span t-field="o.name" />
@@ -115,10 +115,10 @@
                                                 t-value="next(row.iter_cells(), None)"
                                             />
                                             <t
-                                                t-if="first_cell and first_cell.cell_id and (notes or {}).get(first_cell.cell_id)"
+                                                t-if="first_cell and (notes or {}).get(first_cell.cell_id)"
                                             >
                                                 <t
-                                                    t-out="((notes or {}).get(first_cell.cell_id, {})).get('text', '')"
+                                                    t-out="(notes.get(first_cell.cell_id) or {}).get('text', '')"
                                                 />
                                             </t>
                                         </div>

--- a/mis_builder/report/mis_report_instance_qweb.xml
+++ b/mis_builder/report/mis_report_instance_qweb.xml
@@ -111,15 +111,26 @@
                                         </t>
                                         <div class="mis_cell">
                                             <t
-                                                t-set="first_cell"
-                                                t-value="next((c for c in row.iter_cells() if c), None)"
+                                                t-set="first_cell_found"
+                                                t-value="False"
                                             />
-                                            <t t-if="first_cell">
+                                            <t
+                                                t-foreach="row.iter_cells()"
+                                                t-as="potential_first_cell"
+                                            >
                                                 <t
-                                                    t-if="(cell_notes or {}).get(first_cell.cell_id)"
+                                                    t-if="not first_cell_found and potential_first_cell and potential_first_cell.cell_id"
                                                 >
                                                     <t
-                                                        t-out="(cell_notes.get(first_cell.cell_id) or {}).get('text', '')"
+                                                        t-if="(cell_notes or {}).get(potential_first_cell.cell_id)"
+                                                    >
+                                                        <t
+                                                            t-out="(cell_notes.get(potential_first_cell.cell_id) or {}).get('text', '')"
+                                                        />
+                                                    </t>
+                                                    <t
+                                                        t-set="first_cell_found"
+                                                        t-value="True"
                                                     />
                                                 </t>
                                             </t>

--- a/mis_builder/report/mis_report_instance_qweb.xml
+++ b/mis_builder/report/mis_report_instance_qweb.xml
@@ -115,9 +115,10 @@
                                                 t-value="next(row.iter_cells(), None)"
                                             />
                                             <t
-                                                t-if="first_cell and (notes or {}).get(first_cell.cell_id)"
+                                                t-if="first_cell"
                                             >
                                                 <t
+                                                    t-if="(notes or {}).get(first_cell.cell_id)"
                                                     t-out="(notes.get(first_cell.cell_id) or {}).get('text', '')"
                                                 />
                                             </t>

--- a/mis_builder/report/mis_report_instance_qweb.xml
+++ b/mis_builder/report/mis_report_instance_qweb.xml
@@ -104,7 +104,7 @@
                                                     t-if="cell"
                                                 >
                                                     <t
-                                                        t-out="(notes or {}).get(cell.cell_id, {}).get('sequence', '')"
+                                                        t-out="(notes.get(cell.cell_id) or {}).get('sequence', '')"
                                                     />
                                                 </span>
                                             </div>

--- a/mis_builder/report/mis_report_instance_xlsx.py
+++ b/mis_builder/report/mis_report_instance_xlsx.py
@@ -2,15 +2,9 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 import logging
-import numbers
 from collections import defaultdict
-from datetime import datetime
 
-from odoo import api, fields, models
-
-from ..models.accounting_none import AccountingNone
-from ..models.data_error import DataError
-from ..models.mis_report_style import TYPE_STR
+from odoo import api, models
 
 _logger = logging.getLogger(__name__)
 
@@ -46,141 +40,34 @@ class MisBuilderXlsx(models.AbstractModel):
         )
         sheet = workbook.add_worksheet(report_name[:31])
         row_pos = 0
-        col_pos = 0
         # width of the labels column
         label_col_width = MIN_COL_WIDTH
         # {col_pos: max width in characters}
         col_width = defaultdict(lambda: MIN_COL_WIDTH)
 
-        # document title
-        bold = workbook.add_format({"bold": True})
-        header_format = workbook.add_format(
-            {"bold": True, "align": "center", "bg_color": "#F0EEEE"}
+        row_pos = self._write_report_title(workbook, sheet, row_pos, report_name)
+
+        row_pos = self._write_filters(sheet, row_pos, objects)
+
+        row_pos, col_width = self._write_col_headers(
+            workbook, sheet, row_pos, matrix, col_width
         )
-        sheet.write(row_pos, 0, report_name, bold)
-        row_pos += 2
 
-        # filters
-        filter_descriptions = objects.get_filter_descriptions()
-        if filter_descriptions:
-            for filter_description in objects.get_filter_descriptions():
-                sheet.write(row_pos, 0, filter_description)
-                row_pos += 1
-            row_pos += 1
-
-        # column headers
-        sheet.write(row_pos, 0, "", header_format)
-        col_pos = 1
-        for col in matrix.iter_cols():
-            label = col.label
-            if col.description:
-                label += "\n" + col.description
-                sheet.set_row(row_pos, ROW_HEIGHT * 2)
-            if col.colspan > 1:
-                sheet.merge_range(
-                    row_pos,
-                    col_pos,
-                    row_pos,
-                    col_pos + col.colspan - 1,
-                    label,
-                    header_format,
-                )
-            else:
-                sheet.write(row_pos, col_pos, label, header_format)
-                col_width[col_pos] = max(
-                    col_width[col_pos], len(col.label or ""), len(col.description or "")
-                )
-            col_pos += col.colspan
-        row_pos += 1
-
-        # sub column headers
-        sheet.write(row_pos, 0, "", header_format)
-        col_pos = 1
-        for subcol in matrix.iter_subcols():
-            label = subcol.label
-            if subcol.description:
-                label += "\n" + subcol.description
-                sheet.set_row(row_pos, ROW_HEIGHT * 2)
-            sheet.write(row_pos, col_pos, label, header_format)
-            col_width[col_pos] = max(
-                col_width[col_pos],
-                len(subcol.label or ""),
-                len(subcol.description or ""),
-            )
-            col_pos += 1
-        row_pos += 1
-
-        # rows
-        for row in matrix.iter_rows():
-            if (
-                row.style_props.hide_empty and row.is_empty()
-            ) or row.style_props.hide_always:
-                continue
-            row_xlsx_style = style_obj.to_xlsx_style(TYPE_STR, row.style_props)
-            row_format = workbook.add_format(row_xlsx_style)
-            col_pos = 0
-            label = row.label
-            if row.description:
-                label += "\n" + row.description
-                sheet.set_row(row_pos, ROW_HEIGHT * 2)
-            sheet.write(row_pos, col_pos, label, row_format)
-            label_col_width = max(
-                label_col_width, len(row.label or ""), len(row.description or "")
-            )
-            for cell in row.iter_cells():
-                col_pos += 1
-                self._mis_builder_add_annotation(sheet, cell, row_pos, col_pos, notes)
-                if not cell or cell.val is AccountingNone:
-                    # TODO col/subcol format
-                    sheet.write(row_pos, col_pos, "", row_format)
-                    continue
-                cell_xlsx_style = style_obj.to_xlsx_style(
-                    cell.val_type, cell.style_props, no_indent=True
-                )
-                cell_xlsx_style["align"] = "right"
-                cell_format = workbook.add_format(cell_xlsx_style)
-                if isinstance(cell.val, DataError):
-                    val = cell.val.name
-                    # TODO display cell.val.msg as Excel comment?
-                elif cell.val is None or cell.val is AccountingNone:
-                    val = ""
-                else:
-                    divider = float(cell.style_props.get("divider", 1))
-                    if (
-                        divider != 1
-                        and isinstance(cell.val, numbers.Number)
-                        and not cell.val_type == "pct"
-                    ):
-                        val = cell.val / divider
-                    else:
-                        val = cell.val
-                sheet.write(row_pos, col_pos, val, cell_format)
-                col_width[col_pos] = max(
-                    col_width[col_pos], len(cell.val_rendered or "")
-                )
-            row_pos += 1
-
-        # Add date/time footer
-        row_pos += 1
-        footer_format = workbook.add_format(
-            {"italic": True, "font_color": "#202020", "font_size": 9}
+        row_pos, col_width = self._write_subcol_headers(
+            workbook, sheet, row_pos, matrix, col_width
         )
-        lang_model = self.env["res.lang"]
-        lang = lang_model._lang_get(self.env.user.lang)
 
-        now_tz = fields.Datetime.context_timestamp(
-            self.env["res.users"], datetime.now()
+        row_pos, label_col_width, col_width = self._write_rows(
+            workbook,
+            sheet,
+            row_pos,
+            matrix,
+            notes,
+            style_obj,
+            label_col_width,
+            col_width,
         )
-        create_date = self.env._(
-            "Generated on %(gen_date)s at %(gen_time)s",
-            gen_date=now_tz.strftime(lang.date_format),
-            gen_time=now_tz.strftime(lang.time_format),
-        )
-        sheet.write(row_pos, 0, create_date, footer_format)
 
-        # adjust col widths
-        sheet.set_column(0, 0, min(label_col_width, MAX_COL_WIDTH) * COL_WIDTH)
-        data_col_width = min(MAX_COL_WIDTH, max(col_width.values()))
-        min_col_pos = min(col_width.keys())
-        max_col_pos = max(col_width.keys())
-        sheet.set_column(min_col_pos, max_col_pos, data_col_width * COL_WIDTH)
+        self._write_footer(workbook, sheet, row_pos)
+
+        self._adjust_col_widths(sheet, label_col_width, col_width)

--- a/mis_builder/report/mis_report_instance_xlsx.py
+++ b/mis_builder/report/mis_report_instance_xlsx.py
@@ -2,9 +2,15 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 import logging
+import numbers
 from collections import defaultdict
+from datetime import datetime
 
-from odoo import api, models
+from odoo import api, fields, models
+
+from ..models.accounting_none import AccountingNone
+from ..models.data_error import DataError
+from ..models.mis_report_style import TYPE_STR
 
 _logger = logging.getLogger(__name__)
 
@@ -40,34 +46,155 @@ class MisBuilderXlsx(models.AbstractModel):
         )
         sheet = workbook.add_worksheet(report_name[:31])
         row_pos = 0
+        col_pos = 0
         # width of the labels column
         label_col_width = MIN_COL_WIDTH
         # {col_pos: max width in characters}
         col_width = defaultdict(lambda: MIN_COL_WIDTH)
 
-        row_pos = self._write_report_title(workbook, sheet, row_pos, report_name)
-
-        row_pos = self._write_filters(sheet, row_pos, objects)
-
-        row_pos, col_width = self._write_col_headers(
-            workbook, sheet, row_pos, matrix, col_width
+        # document title
+        bold = workbook.add_format({"bold": True})
+        header_format = workbook.add_format(
+            {"bold": True, "align": "center", "bg_color": "#F0EEEE"}
         )
+        sheet.write(row_pos, 0, report_name, bold)
+        row_pos += 2
 
-        row_pos, col_width = self._write_subcol_headers(
-            workbook, sheet, row_pos, matrix, col_width
+        # filters
+        filter_descriptions = objects.get_filter_descriptions()
+        if filter_descriptions:
+            for filter_description in objects.get_filter_descriptions():
+                sheet.write(row_pos, 0, filter_description)
+                row_pos += 1
+            row_pos += 1
+
+        # column headers
+        sheet.write(row_pos, 0, "", header_format)
+        col_pos = 1
+        for col in matrix.iter_cols():
+            label = col.label
+            if col.description:
+                label += "\n" + col.description
+                sheet.set_row(row_pos, ROW_HEIGHT * 2)
+            if col.colspan > 1:
+                sheet.merge_range(
+                    row_pos,
+                    col_pos,
+                    row_pos,
+                    col_pos + col.colspan - 1,
+                    label,
+                    header_format,
+                )
+            else:
+                sheet.write(row_pos, col_pos, label, header_format)
+                col_width[col_pos] = max(
+                    col_width[col_pos], len(col.label or ""), len(col.description or "")
+                )
+            col_pos += col.colspan
+        row_pos += 1
+
+        # sub column headers
+        sheet.write(row_pos, 0, "", header_format)
+        col_pos = 1
+        for subcol in matrix.iter_subcols():
+            label = subcol.label
+            if subcol.description:
+                label += "\n" + subcol.description
+                sheet.set_row(row_pos, ROW_HEIGHT * 2)
+            sheet.write(row_pos, col_pos, label, header_format)
+            col_width[col_pos] = max(
+                col_width[col_pos],
+                len(subcol.label or ""),
+                len(subcol.description or ""),
+            )
+            col_pos += 1
+        row_pos += 1
+
+        # rows
+        for row in matrix.iter_rows():
+            if (
+                row.style_props.hide_empty and row.is_empty()
+            ) or row.style_props.hide_always:
+                continue
+            row_xlsx_style = style_obj.to_xlsx_style(TYPE_STR, row.style_props)
+            row_format = workbook.add_format(row_xlsx_style)
+            col_pos = 0
+            label = row.label
+            if row.description:
+                label += "\n" + row.description
+                sheet.set_row(row_pos, ROW_HEIGHT * 2)
+            sheet.write(row_pos, col_pos, label, row_format)
+            label_col_width = max(
+                label_col_width, len(row.label or ""), len(row.description or "")
+            )
+            for cell in row.iter_cells():
+                col_pos += 1
+                self._mis_builder_add_annotation(sheet, cell, row_pos, col_pos, notes)
+                if not cell or cell.val is AccountingNone:
+                    # TODO col/subcol format
+                    sheet.write(row_pos, col_pos, "", row_format)
+                    continue
+                cell_xlsx_style = style_obj.to_xlsx_style(
+                    cell.val_type, cell.style_props, no_indent=True
+                )
+                cell_xlsx_style["align"] = "right"
+                cell_format = workbook.add_format(cell_xlsx_style)
+                if isinstance(cell.val, DataError):
+                    val = cell.val.name
+                    # TODO display cell.val.msg as Excel comment?
+                elif cell.val is None or cell.val is AccountingNone:
+                    val = ""
+                else:
+                    divider = float(cell.style_props.get("divider", 1))
+                    if (
+                        divider != 1
+                        and isinstance(cell.val, numbers.Number)
+                        and not cell.val_type == "pct"
+                    ):
+                        val = cell.val / divider
+                    else:
+                        val = cell.val
+                sheet.write(row_pos, col_pos, val, cell_format)
+                col_width[col_pos] = max(
+                    col_width[col_pos], len(cell.val_rendered or "")
+                )
+            row_pos += 1
+
+        # Add date/time footer
+        row_pos += 1
+        footer_format = workbook.add_format(
+            {"italic": True, "font_color": "#202020", "font_size": 9}
         )
+        lang_model = self.env["res.lang"]
+        lang = lang_model._lang_get(self.env.user.lang)
 
-        row_pos, label_col_width, col_width = self._write_rows(
-            workbook,
-            sheet,
-            row_pos,
-            matrix,
-            notes,
-            style_obj,
-            label_col_width,
-            col_width,
+        now_tz = fields.Datetime.context_timestamp(
+            self.env["res.users"], datetime.now()
         )
+        create_date = self.env._(
+            "Generated on %(gen_date)s at %(gen_time)s",
+            gen_date=now_tz.strftime(lang.date_format),
+            gen_time=now_tz.strftime(lang.time_format),
+        )
+        sheet.write(row_pos, 0, create_date, footer_format)
 
-        self._write_footer(workbook, sheet, row_pos)
+        # adjust col widths
+        sheet.set_column(0, 0, min(label_col_width, MAX_COL_WIDTH) * COL_WIDTH)
+        data_col_width = min(MAX_COL_WIDTH, max(col_width.values()))
+        min_col_pos = min(col_width.keys())
+        max_col_pos = max(col_width.keys())
+        sheet.set_column(min_col_pos, max_col_pos, data_col_width * COL_WIDTH)
 
-        self._adjust_col_widths(sheet, label_col_width, col_width)
+    def _write_report_title(self, workbook, sheet, row_pos, report_name):
+        bold = workbook.add_format({"bold": True})
+        sheet.write(row_pos, 0, report_name, bold)
+        return row_pos + 2
+
+    def _write_filters(self, sheet, row_pos, objects):
+        filter_descriptions = objects.get_filter_descriptions()
+        if filter_descriptions:
+            for filter_description in filter_descriptions:
+                sheet.write(row_pos, 0, filter_description)
+                row_pos += 1
+            row_pos += 1
+        return row_pos

--- a/mis_builder/static/src/components/mis_report_widget.esm.js
+++ b/mis_builder/static/src/components/mis_report_widget.esm.js
@@ -2,11 +2,11 @@ import {AnnotationDialog} from "../annotation_dialog/annotation_dialog.esm";
 import {Component, onMounted, onWillStart, useState, useSubEnv} from "@odoo/owl";
 import {DateTimeInput} from "@web/core/datetime/datetime_input";
 import {parseDate} from "@web/core/l10n/dates";
+import {_t} from "@web/core/l10n/translation";
 import {registry} from "@web/core/registry";
+import {useBus, useService} from "@web/core/utils/hooks";
 import {SearchBar} from "@web/search/search_bar/search_bar";
 import {SearchModel} from "@web/search/search_model";
-import {_t} from "@web/core/l10n/translation";
-import {useBus, useService} from "@web/core/utils/hooks";
 
 export class MisReportWidget extends Component {
     setup() {

--- a/mis_builder/static/src/components/mis_report_widget.esm.js
+++ b/mis_builder/static/src/components/mis_report_widget.esm.js
@@ -1,12 +1,12 @@
+import {AnnotationDialog} from "../annotation_dialog/annotation_dialog.esm";
 import {Component, onMounted, onWillStart, useState, useSubEnv} from "@odoo/owl";
-import {useBus, useService} from "@web/core/utils/hooks";
 import {DateTimeInput} from "@web/core/datetime/datetime_input";
+import {parseDate} from "@web/core/l10n/dates";
+import {_t} from "@web/core/l10n/translation";
+import {registry} from "@web/core/registry";
+import {useBus, useService} from "@web/core/utils/hooks";
 import {SearchBar} from "@web/search/search_bar/search_bar";
 import {SearchModel} from "@web/search/search_model";
-import {parseDate} from "@web/core/l10n/dates";
-import {registry} from "@web/core/registry";
-import {AnnotationDialog} from "../annotation_dialog/annotation_dialog.esm";
-import {_t} from "@web/core/l10n/translation";
 
 export class MisReportWidget extends Component {
     setup() {

--- a/mis_builder/static/src/components/mis_report_widget.esm.js
+++ b/mis_builder/static/src/components/mis_report_widget.esm.js
@@ -2,11 +2,11 @@ import {AnnotationDialog} from "../annotation_dialog/annotation_dialog.esm";
 import {Component, onMounted, onWillStart, useState, useSubEnv} from "@odoo/owl";
 import {DateTimeInput} from "@web/core/datetime/datetime_input";
 import {parseDate} from "@web/core/l10n/dates";
-import {_t} from "@web/core/l10n/translation";
 import {registry} from "@web/core/registry";
-import {useBus, useService} from "@web/core/utils/hooks";
 import {SearchBar} from "@web/search/search_bar/search_bar";
 import {SearchModel} from "@web/search/search_model";
+import {_t} from "@web/core/l10n/translation";
+import {useBus, useService} from "@web/core/utils/hooks";
 
 export class MisReportWidget extends Component {
     setup() {

--- a/mis_builder/static/src/components/mis_report_widget.esm.js
+++ b/mis_builder/static/src/components/mis_report_widget.esm.js
@@ -4,9 +4,9 @@ import {DateTimeInput} from "@web/core/datetime/datetime_input";
 import {parseDate} from "@web/core/l10n/dates";
 import {_t} from "@web/core/l10n/translation";
 import {registry} from "@web/core/registry";
-import {useBus, useService} from "@web/core/utils/hooks";
 import {SearchBar} from "@web/search/search_bar/search_bar";
 import {SearchModel} from "@web/search/search_model";
+import {useBus, useService} from "@web/core/utils/hooks";
 
 export class MisReportWidget extends Component {
     setup() {

--- a/mis_builder/static/src/components/mis_report_widget.xml
+++ b/mis_builder/static/src/components/mis_report_widget.xml
@@ -105,7 +105,9 @@
                                                 <t t-esc="cell.val_r" />
                                             </t>
                                             <span class="oe_mis_builder_footnote">
-                                                <div t-if="(notes or {}).get(cell.cell_id)">
+                                                <div
+                                                    t-if="(notes or {}).get(cell.cell_id)"
+                                                >
                                                     <a
                                                         t-att-id="'note_'+((notes or {}).get(cell.cell_id, {})).get('sequence', '')"
                                                         t-out="((notes or {}).get(cell.cell_id, {})).get('sequence', '')"
@@ -151,7 +153,9 @@
                                 </t>
                                 <td>
                                     <t t-if="(notes or {}).get(row.cells[0].cell_id)">
-                                        <t t-out="((notes or {}).get(row.cells[0].cell_id, {})).get('text', '')" />
+                                        <t
+                                            t-out="((notes or {}).get(row.cells[0].cell_id, {})).get('text', '')"
+                                        />
                                     </t>
                                     <button
                                         t-if="state.can_edit_annotation and row.cells[0].can_be_annotated"

--- a/mis_builder/static/src/components/mis_report_widget.xml
+++ b/mis_builder/static/src/components/mis_report_widget.xml
@@ -110,7 +110,7 @@
                                                 >
                                                     <a
                                                         t-att-id="'note_'+((notes or {}).get(cell.cell_id, {})).get('sequence', '')"
-                                                        t-out="((notes or {}).get(cell.cell_id, {})).get('sequence', '')"
+                                                        t-out="(notes.get(cell.cell_id) or {}).get('sequence', '')"
                                                         t-att="{'title': ((notes or {}).get(cell.cell_id, {})).get('text', '')}"
                                                         href="#footnotes"
                                                     />
@@ -154,7 +154,7 @@
                                 <td>
                                     <t t-if="(notes or {}).get(row.cells[0].cell_id)">
                                         <t
-                                            t-out="((notes or {}).get(row.cells[0].cell_id, {})).get('text', '')"
+                                            t-out="(notes.get(row.cells[0].cell_id) or {}).get('text', '')"
                                         />
                                     </t>
                                     <button

--- a/mis_builder/static/src/components/mis_report_widget.xml
+++ b/mis_builder/static/src/components/mis_report_widget.xml
@@ -56,6 +56,7 @@
                                 class="oe_list_header_columns"
                             >
                                 <th class="oe_list_header_char" />
+                                <th class="oe_list_header_char">Annotations</th>
                                 <th
                                     t-foreach="row.cols"
                                     t-as="col"
@@ -84,105 +85,86 @@
                                         <t t-out="row.description" />
                                     </t>
                                 </td>
-                                <td
-                                    t-foreach="row.cells"
-                                    t-as="cell"
-                                    t-key="cell_index"
-                                    t-att="{'style': cell.style, 'title': cell.val_c}"
-                                    class="mis_builder_amount oe_mis_builder_dropdown"
-                                >
-                                    <div>
-                                        <t t-if="cell.drilldown_arg">
-                                            <a
-                                                href="#"
-                                                class="mis_builder_drilldown"
-                                                t-on-click.prevent="drilldown"
-                                                t-att-data-drilldown="JSON.stringify(cell.drilldown_arg)"
-                                            >
-                                                <t t-esc="cell.val_r" />
-                                            </a>
-                                        </t>
-                                        <t t-else="">
-                                            <t t-esc="cell.val_r" />
-                                        </t>
-                                        <span class="oe_mis_builder_footnote">
-                                            <div t-if="notes[cell.cell_id]">
+                                <t t-foreach="row.cells" t-as="cell" t-key="cell_index">
+                                    <td
+                                        t-att="{'style': cell.style, 'title': cell.val_c}"
+                                        class="mis_builder_amount oe_mis_builder_dropdown"
+                                    >
+                                        <div>
+                                            <t t-if="cell.drilldown_arg">
                                                 <a
-                                                    t-att-id="'note_'+notes[cell.cell_id].sequence"
-                                                    t-out="notes[cell.cell_id] and notes[cell.cell_id].sequence"
-                                                    t-att="{'title': notes[cell.cell_id].text}"
-                                                    href="#footnotes"
-                                                />
-                                            </div>
-                                        </span>
-
-                                        <div id="dropdown_menu" class="btn-group">
-                                            <div
-                                                class="dropdown"
-                                                t-if="state.can_edit_annotation and cell.can_be_annotated"
-                                            >
-                                                <div
-                                                    data-bs-toggle="dropdown"
-                                                    t-attf-class="dropdown-toggle"
-                                                />
-
-                                                <div
-                                                    class="dropdown-menu o_filter_menu"
-                                                    role="menu"
+                                                    href="#"
+                                                    class="mis_builder_drilldown"
+                                                    t-on-click.prevent="drilldown"
+                                                    t-att-data-drilldown="JSON.stringify(cell.drilldown_arg)"
                                                 >
+                                                    <t t-esc="cell.val_r" />
+                                                </a>
+                                            </t>
+                                            <t t-else="">
+                                                <t t-esc="cell.val_r" />
+                                            </t>
+                                            <span class="oe_mis_builder_footnote">
+                                                <div t-if="notes[cell.cell_id]">
                                                     <a
-                                                        href="javascript:void(0)"
-                                                        t-on-click="annotate"
-                                                        t-att-data-cell-id="cell.cell_id"
-                                                        role="menuitem"
-                                                        class="dropdown-item js_tag"
-                                                    >
-                                                        Annotate
-                                                    </a>
+                                                        t-att-id="'note_'+notes[cell.cell_id].sequence"
+                                                        t-out="notes[cell.cell_id] and notes[cell.cell_id].sequence"
+                                                        t-att="{'title': notes[cell.cell_id].text}"
+                                                        href="#footnotes"
+                                                    />
                                                 </div>
+                                            </span>
+
+                                            <div id="dropdown_menu" class="btn-group">
+                                                <div
+                                                    class="dropdown"
+                                                    t-if="state.can_edit_annotation and cell.can_be_annotated"
+                                                >
+                                                    <div
+                                                        data-bs-toggle="dropdown"
+                                                        t-attf-class="dropdown-toggle"
+                                                    />
+
+                                                    <div
+                                                        class="dropdown-menu o_filter_menu"
+                                                        role="menu"
+                                                    >
+                                                        <a
+                                                            href="javascript:void(0)"
+                                                            t-on-click="annotate"
+                                                            t-att-data-cell-id="cell.cell_id"
+                                                            role="menuitem"
+                                                            class="dropdown-item js_tag"
+                                                        >
+                                                            Annotate
+                                                        </a>
+                                                    </div>
+                                                </div>
+                                                <!-- show menu as disabled -->
+                                                <div
+                                                    t-else=""
+                                                    class="dropdown-toggle oe_mis_builder_menu_disabled"
+                                                />
                                             </div>
-                                            <!-- show menu as disabled -->
-                                            <div
-                                                t-else=""
-                                                class="dropdown-toggle oe_mis_builder_menu_disabled"
-                                            />
                                         </div>
-                                    </div>
+                                    </td>
+                                </t>
+                                <td>
+                                    <t t-if="notes[row.cells[0].cell_id]">
+                                        <t t-out="notes[row.cells[0].cell_id].text" />
+                                    </t>
+                                    <button
+                                        t-if="state.can_edit_annotation and row.cells[0].can_be_annotated"
+                                        t-on-click="annotate"
+                                        t-att-data-cell-id="row.cells[0].cell_id"
+                                        class="btn fa fa-pencil"
+                                    />
                                 </td>
                             </tr>
                         </tbody>
                         <tfoot>
                             <tr />
                         </tfoot>
-                    </table>
-                </div>
-                <!-- Table with notes -->
-                <div class="oe_mis_builder_footnote_div" id="footnotes">
-                    <table class="oe_mis_builder_footnote_table">
-                        <t
-                            t-foreach="state.mis_report_data.notes"
-                            t-as="cell_id"
-                            t-key="cell_id"
-                        >
-                            <tr>
-                                <td><a
-                                    t-out="notes[cell_id].sequence"
-                                    t-att-href="'#note_'+notes[cell_id].sequence"
-                                />. </td>
-                                <td>
-                                    <t t-out="notes[cell_id].text" />
-                                </td>
-                                <td>
-                                    <i
-                                        href="javascript:void(0)"
-                                        t-on-click="remove_annotation"
-                                        t-att-data-cell-id="cell_id"
-                                        class="btn fa fa-trash-o"
-                                        t-if="state.can_edit_annotation"
-                                    />
-                                </td>
-                            </tr>
-                        </t>
                     </table>
                 </div>
             </t>

--- a/mis_builder/static/src/components/mis_report_widget.xml
+++ b/mis_builder/static/src/components/mis_report_widget.xml
@@ -105,11 +105,11 @@
                                                 <t t-esc="cell.val_r" />
                                             </t>
                                             <span class="oe_mis_builder_footnote">
-                                                <div t-if="notes[cell.cell_id]">
+                                                <div t-if="(notes or {}).get(cell.cell_id)">
                                                     <a
-                                                        t-att-id="'note_'+notes[cell.cell_id].sequence"
-                                                        t-out="notes[cell.cell_id] and notes[cell.cell_id].sequence"
-                                                        t-att="{'title': notes[cell.cell_id].text}"
+                                                        t-att-id="'note_'+((notes or {}).get(cell.cell_id, {})).get('sequence', '')"
+                                                        t-out="((notes or {}).get(cell.cell_id, {})).get('sequence', '')"
+                                                        t-att="{'title': ((notes or {}).get(cell.cell_id, {})).get('text', '')}"
                                                         href="#footnotes"
                                                     />
                                                 </div>
@@ -150,8 +150,8 @@
                                     </td>
                                 </t>
                                 <td>
-                                    <t t-if="notes[row.cells[0].cell_id]">
-                                        <t t-out="notes[row.cells[0].cell_id].text" />
+                                    <t t-if="(notes or {}).get(row.cells[0].cell_id)">
+                                        <t t-out="((notes or {}).get(row.cells[0].cell_id, {})).get('text', '')" />
                                     </t>
                                     <button
                                         t-if="state.can_edit_annotation and row.cells[0].can_be_annotated"


### PR DESCRIPTION
This PR addresses issue #159.\n\nIt adds a new "Annotations" column to the MIS reports (view, PDF, and XLSX).\n\nThe annotation for the first cell of each row is displayed in this new column.\n\nThe user can add or edit annotations by clicking the pencil icon in the "Annotations" column.