### PR TITLE
[18.0][FIX] mis_builder: adapt account codes for reports

### DIFF
--- a/mis_builder/models/kpimatrix.py
+++ b/mis_builder/models/kpimatrix.py
@@ -467,7 +467,8 @@ class KpiMatrix:
         self._account_names = {a.id: self._get_account_name(a) for a in accounts}
 
     def _get_account_name(self, account):
-        result = f"{account.code} {account.name}"
+        code = account.code or account.placeholder_code.split(" (")[0]
+        result = f"{code} {account.name}"
         if self._multi_company:
             result = f"{result} [{account.company_id.name}]"
         return result


### PR DESCRIPTION
In version 18, Odoo displays the account codes using the `placeholder_code` field when it’s a company that is not the main active one. With this change, the code of each account is shown correctly in multi-company reports.

Screenshot of how it works without this new code: 

<img width="363" height="367" alt="2025-11-19_11-46" src="https://github.com/user-attachments/assets/b17071cb-f182-471c-8367-76fffdd15995" />


@ForgeFlow 