### PR TITLE
[18.0][IMP] mis_builder: Change where the mock has to be loaded

### DIFF
--- a/mis_builder/tests/test_kpi_data.py
+++ b/mis_builder/tests/test_kpi_data.py
@@ -9,19 +9,18 @@ from ..models.mis_kpi_data import ACC_AVG, ACC_SUM
 
 
 class TestKpiData(TransactionCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setUp(self):
+        super().setUp()
 
-        cls.loader = FakeModelLoader(cls.env, cls.__module__)
-        cls.loader.backup_registry()
+        self.loader = FakeModelLoader(self.env, self.__module__)
+        self.loader.backup_registry()
         from .fake_models import MisKpiDataTestItem
 
-        cls.loader.update_registry((MisKpiDataTestItem,))
-        cls.addClassCleanup(cls.loader.restore_registry)
+        self.loader.update_registry((MisKpiDataTestItem,))
+        self.addClassCleanup(self.loader.restore_registry)
 
-        report = cls.env["mis.report"].create(dict(name="test report"))
-        cls.kpi1 = cls.env["mis.report.kpi"].create(
+        report = self.env["mis.report"].create(dict(name="test report"))
+        self.kpi1 = self.env["mis.report.kpi"].create(
             dict(
                 report_id=report.id,
                 name="k1",
@@ -29,8 +28,8 @@ class TestKpiData(TransactionCase):
                 expression="AccountingNone",
             )
         )
-        cls.expr1 = cls.kpi1.expression_ids[0]
-        cls.kpi2 = cls.env["mis.report.kpi"].create(
+        self.expr1 = self.kpi1.expression_ids[0]
+        self.kpi2 = self.env["mis.report.kpi"].create(
             dict(
                 report_id=report.id,
                 name="k2",
@@ -38,39 +37,43 @@ class TestKpiData(TransactionCase):
                 expression="AccountingNone",
             )
         )
-        cls.expr2 = cls.kpi2.expression_ids[0]
-        cls.kd11 = cls.env["mis.kpi.data.test.item"].create(
+        self.expr2 = self.kpi2.expression_ids[0]
+        self.kd11 = self.env["mis.kpi.data.test.item"].create(
             dict(
-                kpi_expression_id=cls.expr1.id,
+                kpi_expression_id=self.expr1.id,
                 date_from="2017-05-01",
                 date_to="2017-05-10",
                 amount=10,
             )
         )
-        cls.kd12 = cls.env["mis.kpi.data.test.item"].create(
+        self.kd12 = self.env["mis.kpi.data.test.item"].create(
             dict(
-                kpi_expression_id=cls.expr1.id,
+                kpi_expression_id=self.expr1.id,
                 date_from="2017-05-11",
                 date_to="2017-05-20",
                 amount=20,
             )
         )
-        cls.kd13 = cls.env["mis.kpi.data.test.item"].create(
+        self.kd13 = self.env["mis.kpi.data.test.item"].create(
             dict(
-                kpi_expression_id=cls.expr1.id,
+                kpi_expression_id=self.expr1.id,
                 date_from="2017-05-21",
                 date_to="2017-05-25",
                 amount=30,
             )
         )
-        cls.kd21 = cls.env["mis.kpi.data.test.item"].create(
+        self.kd21 = self.env["mis.kpi.data.test.item"].create(
             dict(
-                kpi_expression_id=cls.expr2.id,
+                kpi_expression_id=self.expr2.id,
                 date_from="2017-06-01",
                 date_to="2017-06-30",
                 amount=3,
             )
         )
+
+    def tearDown(self):
+        self.loader.restore_registry()
+        return super().tearDown()
 
     def test_kpi_data_name(self):
         self.assertEqual(self.kd11.name, "k1: 2017-05-01 - 2017-05-10")

--- a/mis_builder/tests/test_pro_rata_read_group.py
+++ b/mis_builder/tests/test_pro_rata_read_group.py
@@ -7,18 +7,17 @@ from odoo.tests import TransactionCase
 
 
 class TestProrataReadGroup(TransactionCase):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.loader = FakeModelLoader(cls.env, cls.__module__)
-        cls.loader.backup_registry()
+    def setUp(self):
+        super().setUp()
+        self.loader = FakeModelLoader(self.env, self.__module__)
+        self.loader.backup_registry()
         from .fake_models import ProrataReadGroupThing
 
-        cls.loader.update_registry((ProrataReadGroupThing,))
-        cls.addClassCleanup(cls.loader.restore_registry)
+        self.loader.update_registry((ProrataReadGroupThing,))
+        self.addClassCleanup(self.loader.restore_registry)
 
-        cls.thing_model = cls.env["prorata.read.group.thing"]
-        cls.thing_model.create(
+        self.thing_model = self.env["prorata.read.group.thing"]
+        self.thing_model.create(
             {
                 "date_from": "2024-01-01",
                 "date_to": "2024-01-05",
@@ -27,7 +26,7 @@ class TestProrataReadGroup(TransactionCase):
                 "credit": 0,
             }
         )
-        cls.thing_model.create(
+        self.thing_model.create(
             {
                 "date_from": "2024-01-01",
                 "date_to": "2024-01-20",
@@ -36,7 +35,7 @@ class TestProrataReadGroup(TransactionCase):
                 "credit": 0,
             }
         )
-        cls.thing_model.create(
+        self.thing_model.create(
             {
                 "date_from": "2024-01-15",
                 "date_to": "2024-01-20",
@@ -45,6 +44,10 @@ class TestProrataReadGroup(TransactionCase):
                 "credit": 0,
             }
         )
+
+    def tearDown(self):
+        self.loader.restore_registry()
+        return super().tearDown()
 
     def test_prorata_read_group(self):
         """Test a pro-rata read_group with a date period."""


### PR DESCRIPTION
With the changes introduced in https://github.com/odoo/odoo/commit/de056cc784a3bbe2575fd3c9e81ca62e73c362d4#diff-b37c7fd5520c97a29ddc59495779e7be61a66e15e85603928e27b3affb9dc31f, an error was occurring because the change validation on the model was being performed before tearDownClass was executed. Therefore, it has been modified so that the mock changes are applied in each test and cleaned up after each test. This way, the error will no longer appear and the test will run normally.

@Tecnativa