### PR TITLE
[18.0][FIX] mis_builder: guard against falsy drilldown action

### DIFF
--- a/mis_builder/static/src/components/mis_report_widget.esm.js
+++ b/mis_builder/static/src/components/mis_report_widget.esm.js
@@ -137,7 +137,9 @@ export class MisReportWidget extends Component {
             [this._instanceId(), drilldown],
             {context: this.context}
         );
-        this.action.doAction(action);
+        if (action) {
+            this.action.doAction(action);
+        }
     }
 
     async refresh() {


### PR DESCRIPTION
## Description

Clicking a computed KPI cell (e.g. `profit - loss`) in the MIS report
widget triggers a JS error:

```
No view found for act_window action undefined
```

## Root cause

`mis_report_instance.drilldown()` returns `False` when the expression
has no account variable (`AEP.has_account_var()` is `False` for computed
expressions). The JS handler passes this falsy value directly to
`this.action.doAction()`.

## Fix

Add a truthy check before calling `doAction()`.

Closes #776