### PR TITLE
[18.0][FIX] mis_builder: fix multi-company account display

### DIFF
--- a/mis_builder/models/kpimatrix.py
+++ b/mis_builder/models/kpimatrix.py
@@ -139,12 +139,19 @@ class KpiMatrixCell:  # noqa: B903 (immutable data class)
 
 
 class KpiMatrix:
-    def __init__(self, env, multi_company=False, account_model="account.account"):
+    def __init__(
+        self,
+        env,
+        multi_company=False,
+        query_companies=None,
+        account_model="account.account",
+    ):
         # cache language id for faster rendering
         lang_model = env["res.lang"]
         self.lang = lang_model._lang_get(env.user.lang)
         self._style_model = env["mis.report.style"]
         self._account_model = env[account_model]
+        self._query_companies = query_companies
         # data structures
         # { kpi: KpiMatrixRow }
         self._kpi_rows = OrderedDict()
@@ -467,9 +474,18 @@ class KpiMatrix:
         self._account_names = {a.id: self._get_account_name(a) for a in accounts}
 
     def _get_account_name(self, account):
-        result = f"{account.code} {account.name}"
+        code = account.code
+        # In Odoo 18, account.code is company-dependent. If the current env
+        # company doesn't match the account's company, code may be False.
+        # Read the code from the account's owning company.
+        if not code and self._query_companies:
+            account_companies = account.company_ids & self._query_companies
+            if account_companies:
+                code = account.with_company(account_companies[0]).code
+        result = f"{code} {account.name}" if code else account.name
         if self._multi_company:
-            result = f"{result} [{account.company_id.name}]"
+            company_names = ", ".join(account.company_ids.mapped("name"))
+            result = f"{result} [{company_names}]"
         return result
 
     def get_account_name(self, account_id):

--- a/mis_builder/models/mis_report.py
+++ b/mis_builder/models/mis_report.py
@@ -539,9 +539,11 @@ class MisReport(models.Model):
 
     # TODO: kpi name cannot be start with query name
 
-    def prepare_kpi_matrix(self, multi_company=False):
+    def prepare_kpi_matrix(self, multi_company=False, query_companies=None):
         self.ensure_one()
-        kpi_matrix = KpiMatrix(self.env, multi_company, self.account_model)
+        kpi_matrix = KpiMatrix(
+            self.env, multi_company, query_companies, self.account_model
+        )
         for kpi in self.kpi_ids:
             kpi_matrix.declare_kpi(kpi)
         return kpi_matrix
@@ -619,7 +621,7 @@ class MisReport(models.Model):
                         v = data[0][field_name]
                     except KeyError:
                         _logger.error(
-                            "field %s not found in read_group " "for %s; not summable?",
+                            "field %s not found in read_group for %s; not summable?",
                             field_name,
                             model._name,
                         )

--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -423,8 +423,7 @@ class MisReportInstancePeriod(models.Model):
                 if rec.mode == MODE_NONE:
                     raise DateFilterRequired(
                         self.env._(
-                            "A date filter is mandatory for this source "
-                            "in column %s.",
+                            "A date filter is mandatory for this source in column %s.",
                             rec.name,
                         )
                     )
@@ -432,8 +431,7 @@ class MisReportInstancePeriod(models.Model):
                 if rec.mode != MODE_NONE:
                     raise DateFilterForbidden(
                         self.env._(
-                            "No date filter is allowed for this source "
-                            "in column %s.",
+                            "No date filter is allowed for this source in column %s.",
                             rec.name,
                         )
                     )
@@ -460,8 +458,7 @@ class MisReportInstancePeriod(models.Model):
                 ):
                     raise ValidationError(
                         self.env._(
-                            "Columns to compare must belong to the same report "
-                            "in %s",
+                            "Columns to compare must belong to the same report in %s",
                             rec.name,
                         )
                     )
@@ -499,7 +496,7 @@ class MisReportInstance(models.Model):
     sequence = fields.Integer(default=10)
     description = fields.Char(related="report_id.description")
     date = fields.Date(
-        string="Base date", help="Report base date " "(leave empty to use current date)"
+        string="Base date", help="Report base date (leave empty to use current date)"
     )
     pivot_date = fields.Date(compute="_compute_pivot_date")
     report_id = fields.Many2one("mis.report", required=True, string="Report")
@@ -765,9 +762,7 @@ class MisReportInstance(models.Model):
             context.get("from_dashboard")
             and context.get("active_model") == "mis.report.instance"
         ):
-            view_id = self.env.ref(
-                "mis_builder." "mis_report_instance_result_view_form"
-            )
+            view_id = self.env.ref("mis_builder.mis_report_instance_result_view_form")
             mis_report_form_view = view_id and [view_id.id, "form"]
             for view in views:
                 if view and view[1] == "form":
@@ -778,7 +773,7 @@ class MisReportInstance(models.Model):
 
     def preview(self):
         self.ensure_one()
-        view_id = self.env.ref("mis_builder." "mis_report_instance_result_view_form")
+        view_id = self.env.ref("mis_builder.mis_report_instance_result_view_form")
         return {
             "type": "ir.actions.act_window",
             "res_model": "mis.report.instance",
@@ -883,7 +878,9 @@ class MisReportInstance(models.Model):
         self.ensure_one()
         aep = self.report_id._prepare_aep(self.query_company_ids, self.currency_id)
         multi_company = self.multi_company and len(self.query_company_ids) > 1
-        kpi_matrix = self.report_id.prepare_kpi_matrix(multi_company)
+        kpi_matrix = self.report_id.prepare_kpi_matrix(
+            multi_company, self.query_company_ids
+        )
         for period in self.period_ids:
             description = None
             if period.mode == MODE_NONE:

--- a/mis_builder/tests/test_mis_report_instance.py
+++ b/mis_builder/tests/test_mis_report_instance.py
@@ -490,6 +490,68 @@ class TestMisReportInstance(common.HttpCase):
             [[False, "list"], [False, "form"], [False, "pivot"], [False, "graph"]],
         )
 
+    def test_multicompany_account_code_display(self):
+        """Account codes should display correctly in multi-company reports.
+
+        In Odoo 18, account.code is company-dependent. When a report belongs
+        to a different company than the user's current company, account codes
+        must still display correctly in auto-expanded rows.
+        """
+        company2 = self.env["res.company"].create({"name": "Test Co 2"})
+        account = (
+            self.env["account.account"]
+            .with_company(company2)
+            .create(
+                {
+                    "name": "Test Account",
+                    "code": "999001",
+                    "account_type": "expense",
+                    "company_ids": [(6, 0, [company2.id])],
+                }
+            )
+        )
+        # Verify code is visible from company2 but not from main company
+        self.assertEqual(account.with_company(company2).code, "999001")
+        self.assertFalse(account.with_company(self.env.ref("base.main_company")).code)
+        # Create report + instance for company2
+        report = self.env["mis.report"].create({"name": "MC Test Report"})
+        self.env["mis.report.kpi"].create(
+            {
+                "report_id": report.id,
+                "name": "exp",
+                "description": "Test Expense",
+                "auto_expand_accounts": True,
+                "sequence": 1,
+                "expression_ids": [(0, 0, {"name": "balp[999%]"})],
+            }
+        )
+        instance = self.env["mis.report.instance"].create(
+            {
+                "name": "MC Test Instance",
+                "report_id": report.id,
+                "company_id": company2.id,
+                "period_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "2024",
+                            "mode": "fix",
+                            "manual_date_from": "2024-01-01",
+                            "manual_date_to": "2024-12-31",
+                        },
+                    ),
+                ],
+            }
+        )
+        matrix = instance.compute()
+        body = matrix.get("body", [])
+        has_false = any("False" in (r.get("label") or "") for r in body)
+        self.assertFalse(
+            has_false,
+            "Account codes should not show as 'False' in multi-company reports",
+        )
+
     def test_qweb(self):
         self.report_instance.print_pdf()  # get action
         test_reports.try_report(


### PR DESCRIPTION
## Summary

Fixes multi-company MIS report issues in Odoo 18:

1. **`company_id` → `company_ids`**: `account.account.company_id` was replaced by `company_ids` (Many2many) in Odoo 18. `_get_account_name` crashed on multi-company reports.

2. **False account codes**: `account.code` is now company-dependent (stored in `code_store` jsonb). When viewing a report from a different company context, codes displayed as "False". Fix uses `with_company()` to read codes from the account's owning company.

3. **`query_companies` threading**: Passes company context through `KpiMatrix` and `prepare_kpi_matrix()` for proper multi-company resolution.

## Screenshots

### Multi-Company Report — Account Codes with Company Labels

Report pulls data from **both companies** — account codes show correctly with company name in brackets. Total of **$37,000** consolidates Branch Office ($22,000) + YourCompany ($15,000):

![Multi-Company Report](https://storage.googleapis.com/ledo-pr-assets/odoo-qa/mis-builder-pr4/final/mis-builder-wf-06-multicompany-comparison.png)

### Report Configuration

**Comparison Mode** enabled, **Year to Date** period with actuals from Journal Items:

![Config](https://storage.googleapis.com/ledo-pr-assets/odoo-qa/mis-builder-pr4/final/mis-builder-wf-05-multicompany-config.png)

### Single Company Reference (Demo Data)

Standard single-company view for reference — Demo Expenses report with budget columns:

![Single Company](https://storage.googleapis.com/ledo-pr-assets/odoo-qa/mis-builder-pr4/final/mis-builder-wf-02-report-view.png)

## Files changed

- `mis_builder/models/kpimatrix.py` — accept `query_companies` in KpiMatrix
- `mis_builder/models/mis_report.py` — thread `query_companies` through `prepare_kpi_matrix()`
- `mis_builder/models/mis_report_instance.py` — use `with_company()` for account name resolution
- `mis_builder/tests/test_mis_report_instance.py` — multi-company test cases

## Notes

- Migration fix separated into its own PR as requested: ledoent/mis-builder#3
- Pre-commit: all checks pass
- Tests: pass on both Odoo and OCB

Closes #779