### PR TITLE
[18.0] mis_builder: add checks for P&L and balance sheet

### DIFF
--- a/mis_builder/models/aep.py
+++ b/mis_builder/models/aep.py
@@ -314,17 +314,23 @@ class AccountingExpressionProcessor:
         return account_ids
 
     def get_accounting_variables_for_expr(self, expr):
-        """Iterate accounting variables in an expression.
+        """Return the details of an expression. Used for consistency checks.
 
         Prerequisite: done_parsing() must have been invoked.
 
-        Returns a set of (field, mode) used in the expression.
+        Returns a list of (field, mode, account_ids, expression_item)
+        used in the expression. expression_item is useful to have
+        accurate error messages.
         """
-        vars = set()
+        res = []
         for mo in self._ACC_RE.finditer(expr):
-            field, mode, _, _ = self._parse_match_object(mo)
-            vars.add((field, mode))
-        return vars
+            field, mode, _, acc_domain, _ = self._parse_match_object(mo)
+            account_ids = self._account_ids_by_acc_domain[acc_domain]
+            expr_item_str = mo.group()
+            res.append(
+                (field, mode, account_ids, expr_item_str and expr_item_str.strip())
+            )
+        return res
 
     def get_aml_domain_for_expr(self, expr, date_from, date_to, account_id=None):
         """Get a domain on account.move.line for an expression.

--- a/mis_builder/models/aep.py
+++ b/mis_builder/models/aep.py
@@ -313,6 +313,19 @@ class AccountingExpressionProcessor:
             account_ids.update(self._account_ids_by_acc_domain[acc_domain])
         return account_ids
 
+    def get_accounting_variables_for_expr(self, expr):
+        """Iterate accounting variables in an expression.
+
+        Prerequisite: done_parsing() must have been invoked.
+
+        Returns a set of (field, mode) used in the expression.
+        """
+        vars = set()
+        for mo in self._ACC_RE.finditer(expr):
+            field, mode, _, _ = self._parse_match_object(mo)
+            vars.add((field, mode))
+        return vars
+
     def get_aml_domain_for_expr(self, expr, date_from, date_to, account_id=None):
         """Get a domain on account.move.line for an expression.
 

--- a/mis_builder/models/mis_report.py
+++ b/mis_builder/models/mis_report.py
@@ -461,6 +461,12 @@ class MisReport(models.Model):
         "data source for column Actuals.",
     )
     account_model = fields.Char(compute="_compute_account_model")
+    constraint_type = fields.Selection(
+        [
+            ("profit_and_loss", "Profit & Loss"),
+            ("balance_sheet", "Balance Sheet"),
+        ]
+    )
 
     @api.depends("kpi_ids", "subreport_ids")
     def _compute_all_kpi_ids(self):
@@ -1009,27 +1015,279 @@ class MisReport(models.Model):
         )
         return locals_dict
 
-    @api.model
-    def _profit_and_loss_consistency_check(self, company):
-        """Validate consistency of expressions for a P&L report.
+    def _check_constraint(self, companies):
+        self.ensure_one()
+        if self.constraint_type == "profit_and_loss":
+            self._profit_and_loss_check_constraint(companies)
+        elif self.constraint_type == "balance_sheet":
+            self._balance_sheet_check_constraint(companies)
 
-        - only balp is used in accounting expressions
-        - each P&L account of the company is used exactly once
+    def test_constraint_type_button(self):
+        self.ensure_one()
+        company = self.env.company
+        self._check_constraint(company)
+        action = {
+            "type": "ir.actions.client",
+            "tag": "display_notification",
+            "params": {
+                "message": self.env._(
+                    "Test successful in company '%s'.", company.display_name
+                ),
+                "type": "success",
+                "sticky": False,
+            },
+        }
+        return action
+
+    @api.model
+    def _profit_and_loss_check_constraint(self, companies, raise_if_errors=True):
+        """Validate expressions for a P&L report.
+
+        - 'balp' only
+        - each income and expense account of the company is used exactly once
+        TODO check that expense accounts have +balp and income accounts have -balp
         """
-        aep = self._prepare_aep(company)
-        used_account_ids = set()
+        aep = self._prepare_aep(companies)
+        acc_obj = self.env["account.account"].with_company(companies[0])
+        errors = []
+        account_id2locations = defaultdict(list)
+        income_expense_account_ids = set(
+            self.env["account.account"]._search(
+                [
+                    ("company_ids", "in", companies.ids),
+                    (
+                        "account_type",
+                        "in",
+                        (
+                            "income",
+                            "income_other",
+                            "expense",
+                            "expense_depreciation",
+                            "expense_direct_cost",
+                        ),
+                    ),
+                ]
+            )
+        )
         for kpi in self.kpi_ids:
             for expression in kpi.expression_ids:
-                expr = expression.name
-                accounting_variables = aep.get_accounting_variables_for_expr(expr)
-                field, mode = accounting_variables.pop()
-                if field != "bal" or mode != aep.MODE_VARIATION:
-                    ... # only balp may be used in P&L reports
-                expression_account_ids = aep.get_account_ids_for_expr(expr)
-                if used_account_ids & expression_account_ids:
-                    ... # accounts used more than once
-                used_account_ids.update(expression_account_ids)
-        all_account_ids = set(self.env["account.account"].search([...]).ids)
-        if used_account_ids != all_account_ids:
-            ... # some accounts not used
+                expr_props = aep.get_accounting_variables_for_expr(expression.name)
+                for field, mode, account_ids, expr_item_str in expr_props:
+                    if not account_ids:
+                        continue
+                    # balp only
+                    if field != "bal" or mode != aep.MODE_VARIATION:
+                        errors.append(
+                            self.env._(
+                                "KPI '%(kpi)s' has expression '%(expression_item)s' "
+                                "but only 'balp' can be used on P&L reports.",
+                                kpi=kpi.display_name,
+                                expression_item=expr_item_str,
+                            )
+                        )
+                        continue
+                    # Check we don't have non income-expense accounts
+                    bad_type_account_ids = account_ids - income_expense_account_ids
+                    if bad_type_account_ids:
+                        bad_type_accounts = acc_obj.browse(bad_type_account_ids)
+                        errors.append(
+                            self.env._(
+                                "KPI '%(kpi)s' has expression '%(expression_item)s' "
+                                "which uses non expense/income account(s): "
+                                "%(accounts)s.",
+                                kpi=kpi.display_name,
+                                expression_item=expr_item_str,
+                                accounts=", ".join(
+                                    [acc.display_name for acc in bad_type_accounts]
+                                ),
+                            )
+                        )
+                        continue
+                    for account_id in account_ids:
+                        account_id2locations[account_id].append(
+                            (kpi.display_name, expr_item_str)
+                        )
+        missing_account_ids = []
+        # Income-expense accounts used more than once
+        for account_id, location_list in account_id2locations.items():
+            if not location_list:
+                missing_account_ids.append(account_id)
+            elif len(location_list) > 1:
+                account = acc_obj.browse(account_id)
+                errors.append(
+                    self.env._(
+                        "Account '%(account)s' is used several times: %(locations)s.",
+                        account=account.display_name,
+                        locations=", ".join(
+                            [
+                                self.env._(
+                                    "KPI '%(kpi)s' formula '%(expr_item_str)s'",
+                                    kpi=kpi,
+                                    expr_item_str=expr_item_str,
+                                )
+                                for (kpi, expr_item_str) in location_list
+                            ]
+                        ),
+                    )
+                )
+        # Income-expense accounts that are not taken in any expression
+        if missing_account_ids:
+            errors.append(
+                self.env._(
+                    "Income/expense account(s) not taken in any expression: %s.",
+                    ", ".join(
+                        [
+                            acc.display_name
+                            for acc in acc_obj.browse(missing_account_ids)
+                        ]
+                    ),
+                )
+            )
+        if errors and raise_if_errors:
+            raise UserError(
+                self.env._(
+                    "MIS Report template '%(report)s' is configured as "
+                    "a Profit and Loss report, but it contains the "
+                    "following error(s):\n%(error_list)s",
+                    report=self.display_name,
+                    error_list="\n".join([f"- {error}" for error in errors]),
+                )
+            )
+        return errors
+
+    @api.model
+    def _balance_sheet_check_constraint(self, companies, raise_if_errors=True):
+        """Validate expressions for a Balance Sheet report.
+
+        - bale/pbale/nbale only
+        - each account of the company is used exactly once (taking into account)
+        TODO check signs: start with + (assets) and then only - (equity and liabilities)
+        """
+        aep = self._prepare_aep(companies)
+        acc_obj = self.env["account.account"].with_company(companies[0])
+        errors = []
+        bs_account_ids = set(
+            self.env["account.account"]._search(
+                [
+                    ("company_ids", "in", companies.ids),
+                    ("account_type", "not in", ("equity_unaffected", "off_balance")),
+                ]
+            )
+        )
+        account_id2location_per_field = {}
+        for account_id in bs_account_ids:
+            account_id2location_per_field[account_id] = {
+                "bal": [],
+                "pbal": [],
+                "nbal": [],
+            }
+        for kpi in self.kpi_ids:
+            for expression in kpi.expression_ids:
+                expr_items = aep.get_accounting_variables_for_expr(expression.name)
+                for field, mode, account_ids, expr_item_str in expr_items:
+                    if not account_ids:
+                        continue
+                    if field not in ("bal", "pbal", "nbal") or mode != aep.MODE_END:
+                        errors.append(
+                            self.env._(
+                                "KPI '%(kpi)s' has expression '%(expression_item)s' "
+                                "but only 'bale', 'pbale' and 'nbale' can be used "
+                                "on balance sheet reports.",
+                                kpi=kpi.display_name,
+                                expression_item=expr_item_str,
+                            )
+                        )
+                        continue
+                    bad_type_account_ids = account_ids - bs_account_ids
+                    if bad_type_account_ids:
+                        bad_type_accounts = acc_obj.browse(bad_type_account_ids)
+                        errors.append(
+                            self.env._(
+                                "KPI '%(kpi)s' has expression '%(expression_item)s' "
+                                "which uses account(s) with type "
+                                "'Current Year Earnings' or "
+                                "'Off-Balance Sheet': %(accounts)s.",
+                                kpi=kpi.display_name,
+                                expression_item=expr_item_str,
+                                accounts=", ".join(
+                                    [acc.display_name for acc in bad_type_accounts]
+                                ),
+                            )
+                        )
+                        continue
+                    for account_id in account_ids:
+                        account_id2location_per_field[account_id][field].append(
+                            (kpi.display_name, expr_item_str)
+                        )
+        missing_accounts = []
+        for account_id, field2location_list in account_id2location_per_field.items():
+            if not (
+                (
+                    len(field2location_list["bal"]) == 1
+                    and not field2location_list["pbal"]
+                    and not field2location_list["nbal"]
+                )
+                or (
+                    not field2location_list["bal"]
+                    and len(field2location_list["pbal"]) == 1
+                    and len(field2location_list["nbal"]) == 1
+                )
+            ):
+                account = acc_obj.browse(account_id)
+                if (
+                    not field2location_list["bal"]
+                    and not field2location_list["pbal"]
+                    and not field2location_list["nbal"]
+                ):
+                    missing_accounts.append(account.display_name)
+                else:
+                    locations = []
+                    for field in ["bal", "pbal", "nbal"]:
+                        if field2location_list[field]:
+                            places = ", ".join(
+                                [
+                                    self.env._(
+                                        "KPI '%(kpi)s' " "formula '%(expr_item_str)s'",
+                                        kpi=kpi,
+                                        expr_item_str=expr_item_str,
+                                    )
+                                    for (
+                                        kpi,
+                                        expr_item_str,
+                                    ) in field2location_list[field]
+                                ]
+                            )
+                            locations.append(
+                                self.env._(
+                                    "as '%(field)s' in %(places)s",
+                                    field=field,
+                                    places=places,
+                                )
+                            )
+                    errors.append(
+                        self.env._(
+                            "Account '%(account)s' is used in the following KPIs: "
+                            "%(locations)s. It can be used only once as 'bale', "
+                            "or once as 'pbale' and once as 'nbale'.",
+                            account=account.display_name,
+                            locations="; ".join(locations),
+                        )
+                    )
+        if missing_accounts:
+            errors.append(
+                self.env._(
+                    "Balance sheet account(s) not taken in any expression: %s.",
+                    ", ".join(missing_accounts),
+                )
+            )
+        if errors and raise_if_errors:
+            raise UserError(
+                self.env._(
+                    "MIS Report template '%(report)s' is configured as a "
+                    "Balance Sheet report, but it contains the "
+                    "following error(s):\n%(error_list)s",
+                    report=self.display_name,
+                    error_list="\n".join([f"- {error}" for error in errors]),
+                )
+            )
         return errors

--- a/mis_builder/models/mis_report.py
+++ b/mis_builder/models/mis_report.py
@@ -1008,3 +1008,28 @@ class MisReport(models.Model):
             no_auto_expand_accounts=True,
         )
         return locals_dict
+
+    @api.model
+    def _profit_and_loss_consistency_check(self, company):
+        """Validate consistency of expressions for a P&L report.
+
+        - only balp is used in accounting expressions
+        - each P&L account of the company is used exactly once
+        """
+        aep = self._prepare_aep(company)
+        used_account_ids = set()
+        for kpi in self.kpi_ids:
+            for expression in kpi.expression_ids:
+                expr = expression.name
+                accounting_variables = aep.get_accounting_variables_for_expr(expr)
+                field, mode = accounting_variables.pop()
+                if field != "bal" or mode != aep.MODE_VARIATION:
+                    ... # only balp may be used in P&L reports
+                expression_account_ids = aep.get_account_ids_for_expr(expr)
+                if used_account_ids & expression_account_ids:
+                    ... # accounts used more than once
+                used_account_ids.update(expression_account_ids)
+        all_account_ids = set(self.env["account.account"].search([...]).ids)
+        if used_account_ids != all_account_ids:
+            ... # some accounts not used
+        return errors

--- a/mis_builder/models/mis_report.py
+++ b/mis_builder/models/mis_report.py
@@ -141,6 +141,8 @@ class MisReportKpi(models.Model):
         "Average: values of included period are averaged "
         "with a pro-rata temporis weight.",
     )
+    ignore_constraint = fields.Boolean()
+    report_constraint_type = fields.Selection(related="report_id.constraint_type")
     sequence = fields.Integer(default=100)
     report_id = fields.Many2one("mis.report", required=True, ondelete="cascade")
 
@@ -1069,7 +1071,7 @@ class MisReport(models.Model):
                 ]
             )
         )
-        for kpi in self.kpi_ids:
+        for kpi in self.kpi_ids.filtered(lambda x: not x.ignore_constraint):
             for expression in kpi.expression_ids:
                 expr_props = aep.get_accounting_variables_for_expr(expression.name)
                 for field, mode, account_ids, expr_item_str in expr_props:
@@ -1181,7 +1183,7 @@ class MisReport(models.Model):
                 "pbal": [],
                 "nbal": [],
             }
-        for kpi in self.kpi_ids:
+        for kpi in self.kpi_ids.filtered(lambda x: not x.ignore_constraint):
             for expression in kpi.expression_ids:
                 expr_items = aep.get_accounting_variables_for_expr(expression.name)
                 for field, mode, account_ids, expr_item_str in expr_items:

--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -771,8 +771,13 @@ class MisReportInstance(models.Model):
         result = super().get_views(views, options)
         return result
 
+    def _check_report_constraint(self):
+        self.ensure_one()
+        self.report_id._check_constraint(self.query_company_ids)
+
     def preview(self):
         self.ensure_one()
+        self._check_report_constraint()
         view_id = self.env.ref("mis_builder.mis_report_instance_result_view_form")
         return {
             "type": "ir.actions.act_window",
@@ -786,6 +791,7 @@ class MisReportInstance(models.Model):
 
     def print_pdf(self):
         self.ensure_one()
+        self._check_report_constraint()
         return (
             self.env.ref("mis_builder.qweb_pdf_export")
             .with_context(landscape=self.landscape_pdf)
@@ -793,6 +799,7 @@ class MisReportInstance(models.Model):
         )
 
     def export_xls(self):
+        self._check_report_constraint()
         return self.env.ref("mis_builder.xls_export").report_action(
             self, data=dict(dummy=True)
         )  # required to propagate context

--- a/mis_builder/views/mis_report.xml
+++ b/mis_builder/views/mis_report.xml
@@ -7,6 +7,7 @@
             <list>
                 <field name="name" />
                 <field name="description" />
+                <field name="constraint_type" optional="show" />
             </list>
         </field>
     </record>
@@ -17,11 +18,29 @@
         <field name="arch" type="xml">
             <form string="MIS Report">
                 <sheet>
-                    <group col="2">
-                        <field name="name" />
-                        <field name="description" />
-                        <field name="style_id" />
-                        <field name="move_lines_source" options="{'no_open': true}" />
+                    <group name="top">
+                        <group name="left">
+                            <field name="name" />
+                            <field name="description" />
+                            <label for="constraint_type" />
+                            <div name="constraint_type">
+                                <field name="constraint_type" class="oe_inline" />
+                                <button
+                                    name="test_constraint_type_button"
+                                    type="object"
+                                    string="Test constraint"
+                                    invisible="not constraint_type"
+                                    class="oe_link"
+                                />
+                            </div>
+                        </group>
+                        <group name="right">
+                            <field name="style_id" />
+                            <field
+                                name="move_lines_source"
+                                options="{'no_open': true}"
+                            />
+                        </group>
                     </group>
                     <notebook>
                         <page string="KPI's">
@@ -108,6 +127,37 @@
                     </notebook>
                 </sheet>
             </form>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="mis_report_view_search">
+        <field name="name">mis.report.view.search</field>
+        <field name="model">mis.report</field>
+        <field name="arch" type="xml">
+            <search>
+                <field
+                    name="name"
+                    filter_domain="['|', ('name', 'ilike', self), ('description', 'ilike', self)]"
+                    string="Name or Description"
+                />
+                <filter
+                    string="Profit &amp; Loss"
+                    name="profit_and_loss"
+                    domain="[('constraint_type', '=', 'profit_and_loss')]"
+                />
+                <filter
+                    string="Balance Sheet"
+                    name="balance_sheet"
+                    domain="[('constraint_type', '=', 'balance_sheet')]"
+                />
+                <group name="groupby">
+                    <filter
+                        name="constraint_type_groupby"
+                        string="Constraint Type"
+                        context="{'group_by': 'constraint_type'}"
+                    />
+                </group>
+            </search>
         </field>
     </record>
 

--- a/mis_builder/views/mis_report.xml
+++ b/mis_builder/views/mis_report.xml
@@ -70,6 +70,11 @@
                                         widget="code"
                                         options="{'mode': 'python'}"
                                     />
+                                    <field
+                                        name="ignore_constraint"
+                                        optional="hide"
+                                        column_invisible="not parent.constraint_type"
+                                    />
                                 </list>
                             </field>
                         </page>
@@ -175,6 +180,11 @@
                     <field name="accumulation_method" />
                     <field name="style_id" />
                     <field name="style_expression" />
+                    <field
+                        name="ignore_constraint"
+                        invisible="not report_constraint_type"
+                    />
+                    <field name="report_constraint_type" invisible="1" />
                     <field name='id' invisible='1' />
                     <field name="report_id" invisible="1" required="id != False" />
                 </group>


### PR DESCRIPTION
This PR adds an optional selection field on mis.report with 2 possible values:
1) P&L
2) Balance Sheet

If this optional selection field is set to P&L, it will check that only balp is used and that each income & expense account is used exactly once and that no other account is used
If the optional selection field is set to Balance sheet, it will check  that only bale/pbale/nbale are used, that each account (unless off_balance and equity_unaffected) is used once for bale, or once in pbale AND once is nbale.

Questions on this PR:

Where should we plug the constraint checks on mis.report.instance ?
At the moment, it is called when you click on the buttons "Preview" or "Print" or "Export". But it is not called when the report is in the dashboard. Which method should we inherit to perform checks in all circumstances ?

In v18, the display_name of an account depends on the company of the context. I use the display_name of accounts in error messages, but a MIS report template can apply to several companies. At the moment, I use the display_name of the first company of the MIS report template.

We could adds checks for the signs in the formula (cf TODO in comments).