### PR TITLE
fix: account.company_id → company_ids for Odoo 18 multi-company

### DIFF
--- a/mis_builder/models/kpimatrix.py
+++ b/mis_builder/models/kpimatrix.py
@@ -469,7 +469,14 @@ class KpiMatrix:
     def _get_account_name(self, account):
         result = f"{account.code} {account.name}"
         if self._multi_company:
-            result = f"{result} [{account.company_id.name}]"
+            companies = (
+                account.company_ids
+                if hasattr(account, "company_ids")
+                else account.company_id
+            )
+            names = ", ".join(companies.mapped("name"))
+            if names:
+                result = f"{result} [{names}]"
         return result
 
     def get_account_name(self, account_id):


### PR DESCRIPTION
## Summary
- Fix `AttributeError: 'account.account' object has no attribute 'company_id'` when using multi-company mode
- In Odoo 18, `account.account` no longer has `company_id` (single company). It uses `company_ids` (Many2many) as accounts are shared across companies
- The fix uses `company_ids` when available, falling back to `company_id` for backwards compatibility

## Steps to reproduce
1. Create a MIS report instance with `multi_company = True`
2. Configure KPIs with `auto_expand_accounts = True`
3. Preview the report → `AttributeError` on `_get_account_name`

## File changed
- `mis_builder/models/kpimatrix.py` - `_get_account_name()` method