### PR TITLE
[18.0][FIX] mis_builder: company_id -> company_ids on account.account

### DIFF
--- a/mis_builder/models/kpimatrix.py
+++ b/mis_builder/models/kpimatrix.py
@@ -469,7 +469,7 @@ class KpiMatrix:
     def _get_account_name(self, account):
         result = f"{account.code} {account.name}"
         if self._multi_company:
-            result = f"{result} [{account.company_id.name}]"
+            result = f"{result} [{account.company_ids[0].name}]"
         return result
 
     def get_account_name(self, account_id):

--- a/mis_builder/tests/test_mis_report_instance.py
+++ b/mis_builder/tests/test_mis_report_instance.py
@@ -383,7 +383,7 @@ class TestMisReportInstance(common.HttpCase):
                 account = self.env["account.account"].browse(row.account_id)
                 self.assertEqual(
                     row.label,
-                    f"{account.code} {account.name} [{account.company_id.name}]",
+                    f"{account.code} {account.name} [{account.company_ids[0].name}]",
                 )
         self.report_instance.write({"multi_company": False})
         matrix = self.report_instance._compute_matrix()


### PR DESCRIPTION
In v18, `account.account` field `company_id` (Many2one) was replaced by `company_ids` (Many2many). This caused an `AttributeError` when computing multi-company reports with auto-expand accounts enabled — `kpimatrix._get_account_name()` accessed the removed `company_id` field.

**Fix:** Use `company_ids[0].name` to match the original single-company display intent (same pattern as account-financial-reporting#1293).

Fixes #774