### PR TITLE
[19.0][FIX] mis_builder: test_drilldown_action_name_with_account on no-demo DB

### DIFF
--- a/mis_builder/tests/test_mis_report_instance.py
+++ b/mis_builder/tests/test_mis_report_instance.py
@@ -425,7 +425,16 @@ class TestMisReportInstance(common.HttpCase):
 
     def test_drilldown_action_name_with_account(self):
         period = self.report_instance.period_ids[0]
-        account = self.env["account.account"].search([], limit=1)
+        # Create the account instead of searching for an existing one, so the
+        # test also works on a database without demo data (where the search
+        # returns an empty recordset and the expected name would embed "False").
+        account = self.env["account.account"].create(
+            {
+                "code": "200999",
+                "name": "test drilldown account",
+                "account_type": "asset_current",
+            }
+        )
         args = {
             "period_id": period.id,
             "kpi_id": self.kpi1.id,


### PR DESCRIPTION
`test_drilldown_action_name_with_account` fails on a database without demo data.

**Root cause:** the test does `self.env["account.account"].search([], limit=1)`, which returns an empty recordset when no chart of accounts is loaded. The expected string then embeds `False`:

```
expected: "kpi 1 - False - p1"
actual:   "kpi 1 - p1"
```

The production code is correct — `_get_drilldown_action_name` properly takes the account-less branch for a falsy `account_id`. It is the test's data assumption that breaks.

**Repro:** install `mis_builder` on a fresh no-demo database (stock `odoo:19.0`) with `--test-enable`; the test fails with `AssertionError` at the `assert action_name == expected_name` line. Found while validating 19.0 on a production-like no-demo database.

**Fix:** create the `account.account` in the test instead of relying on pre-existing data, so the search-for-any-account is replaced by a deterministic fixture and the with-account branch is actually exercised on any database.

Verified locally on `odoo:19.0` without demo data: the single test fails before / passes after, and the full `TestMisReportInstance` class is green (27 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)