### PR TITLE
[19.0][FIX] mis_builder: widget instance resolution on Odoo 19 (props.value removed)

### DIFF
--- a/mis_builder/static/src/components/mis_report_widget.esm.js
+++ b/mis_builder/static/src/components/mis_report_widget.esm.js
@@ -102,6 +102,16 @@ export class MisReportWidget extends Component {
      * @returns int
      */
     _instanceId() {
+        /*
+         * When the widget is used as a field in a mis.report.instance
+         * form view, the record it belongs to is the instance itself.
+         * This is the modern owl field API; props.value is kept below
+         * as a fallback for legacy call sites.
+         */
+        if (this.props.record && this.props.record.resId) {
+            return this.props.record.resId;
+        }
+
         if (this.props.value) {
             return this.props.value;
         }


### PR DESCRIPTION
## Root cause

On Odoo 19 the owl field API no longer provides `props.value`, so `MisReportWidget._instanceId()` (mis_builder/static/src/components/mis_report_widget.esm.js) falls straight through to `this.props.record.context.active_id`. Any `mis.report.instance` form opened **without `active_id` in its context** crashes in `willStart`: `orm.read("mis.report.instance", [undefined], ...)` raises an `OwlError` — *"Invalid ids list"* — and the view is unusable.

This happens with a completely standard setup, e.g. a plain `act_window` with `res_id` behind a menuitem:

```xml
<record id="action_my_report" model="ir.actions.act_window">
    <field name="name">My MIS Report</field>
    <field name="res_model">mis.report.instance</field>
    <field name="view_mode">form</field>
    <field name="res_id" ref="my_report_instance"/>
    <field name="view_id" ref="mis_builder.mis_report_instance_result_view_form"/>
</record>
<menuitem id="menu_my_report" name="My MIS Report" action="action_my_report"/>
```

Before this fix: opening that menu crashes with *"Invalid ids list"*. After: the report renders normally.

## Why CI stays green

mis_builder's own flows never hit the broken path: `preview()` and `print_pdf()` return actions whose context carries `active_id` (from `env.context`), so the `active_id` fallback always works there. Only externally-defined actions/menuitems without `active_id` expose the bug — nothing in the test suite exercises that.

## The fix

Resolve the instance from `this.props.record.resId` first — the modern owl field API: when the widget is used as a field in a `mis.report.instance` form view, the record it belongs to *is* the instance. The `props.value` and `context.active_id` fallbacks are kept (with a comment) for legacy call sites and the dashboard trick, where the view is not bound to a record.

## Testing

- Full `mis_builder` Python suite run against this branch on Odoo 19 (module bind-mounted into a clean database): with demo data all tests pass; without demo data 91/92 pass, the sole failure being the pre-existing `test_drilldown_action_name_with_account` no-demo issue addressed separately in #808 — unrelated to this change.
- Root-caused and verified live on an Odoo 19 production-like instance: the repro above crashes before the patch and renders correctly after.
- `prettier --check` and `eslint` pass on the touched file.

## Workaround for affected users (pre-fix)

Add the instance id to the action context so the legacy fallback kicks in:

```xml
<field name="context">{"active_model": "mis.report.instance", "active_id": <instance id>}</field>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
