### PR TITLE
[19.0][IMP] mis_builder: expand KPI detail rows by partner

### DIFF
--- a/mis_builder/README.rst
+++ b/mis_builder/README.rst
@@ -110,6 +110,17 @@ can be found on GitHub.
 Changelog
 =========
 
+19.0.1.1.0 (2026-07-20)
+-----------------------
+
+Features
+~~~~~~~~
+
+- Add KPI option to expand detail rows by partner (customer/vendor), in
+  addition to the existing expansion by account. The new ``detail_by``
+  field supersedes ``auto_expand_accounts`` while keeping backward
+  compatibility.
+
 18.0.1.7.2 (2025-10-29)
 -----------------------
 

--- a/mis_builder/__manifest__.py
+++ b/mis_builder/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "MIS Builder",
-    "version": "19.0.1.0.1",
+    "version": "19.0.1.1.0",
     "category": "Reporting",
     "summary": """
         Build 'Management Information System' Reports and Dashboards

--- a/mis_builder/migrations/19.0.1.1.0/post-migration.py
+++ b/mis_builder/migrations/19.0.1.1.0/post-migration.py
@@ -1,0 +1,14 @@
+# Copyright 2026 Odoo Community Association (OCA)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+
+def migrate(cr, version):
+    """Map legacy auto_expand_accounts onto detail_by."""
+    cr.execute(
+        """
+        UPDATE mis_report_kpi
+           SET detail_by = 'account'
+         WHERE auto_expand_accounts IS TRUE
+           AND (detail_by IS NULL OR detail_by = 'none')
+        """
+    )

--- a/mis_builder/models/aep.py
+++ b/mis_builder/models/aep.py
@@ -313,7 +313,9 @@ class AccountingExpressionProcessor:
             account_ids.update(self._account_ids_by_acc_domain[acc_domain])
         return account_ids
 
-    def get_aml_domain_for_expr(self, expr, date_from, date_to, account_id=None):
+    def get_aml_domain_for_expr(
+        self, expr, date_from, date_to, account_id=None, partner_id=None
+    ):
         """Get a domain on account.move.line for an expression.
 
         Prerequisite: done_parsing() must have been invoked.
@@ -335,6 +337,12 @@ class AccountingExpressionProcessor:
                     aml_domain.append(("account_id", "=", account_id))
                 else:
                     continue
+            if partner_id is not None:
+                # 0 means move lines with an empty partner_id
+                if partner_id:
+                    aml_domain.append(("partner_id", "=", partner_id))
+                else:
+                    aml_domain.append(("partner_id", "=", False))
             if field == "crd":
                 aml_domain.append(("credit", "<>", 0.0))
             elif field == "deb":
@@ -501,6 +509,38 @@ class AccountingExpressionProcessor:
                 self._data[key][account_id] += initial_data[account_id]
                 self._data[key][account_id] += variation_data[account_id]
 
+    def _value_from_entry(self, field, mode, fld_name, entry):
+        debit = entry.debit
+        credit = entry.credit
+        if field == "bal":
+            v = debit - credit
+        elif field == "pbal":
+            if debit >= credit:
+                v = debit - credit
+            else:
+                v = AccountingNone
+        elif field == "nbal":
+            if debit < credit:
+                v = debit - credit
+            else:
+                v = AccountingNone
+        elif field == "deb":
+            v = debit
+        elif field == "crd":
+            v = credit
+        else:
+            assert field == "fld"
+            v = entry.custom_fields[fld_name]
+        # in initial balance mode, assume 0 is None
+        # as it does not make sense to distinguish 0 from "no data"
+        if (
+            v is not AccountingNone
+            and mode in (self.MODE_INITIAL, self.MODE_UNALLOCATED)
+            and float_is_zero(v, precision_digits=self.dp)
+        ):
+            v = AccountingNone
+        return v
+
     def replace_expr(self, expr):
         """Replace accounting variables in an expression by their amount.
 
@@ -517,31 +557,9 @@ class AccountingExpressionProcessor:
             account_ids = self._account_ids_by_acc_domain[acc_domain]
             for account_id in account_ids:
                 entry = account_ids_data[account_id]
-                debit = entry.debit
-                credit = entry.credit
-                if field == "bal":
-                    v += debit - credit
-                elif field == "pbal":
-                    if debit >= credit:
-                        v += debit - credit
-                elif field == "nbal":
-                    if debit < credit:
-                        v += debit - credit
-                elif field == "deb":
-                    v += debit
-                elif field == "crd":
-                    v += credit
-                else:
-                    assert field == "fld"
-                    v += entry.custom_fields[fld_name]
-            # in initial balance mode, assume 0 is None
-            # as it does not make sense to distinguish 0 from "no data"
-            if (
-                v is not AccountingNone
-                and mode in (self.MODE_INITIAL, self.MODE_UNALLOCATED)
-                and float_is_zero(v, precision_digits=self.dp)
-            ):
-                v = AccountingNone
+                part = self._value_from_entry(field, mode, fld_name, entry)
+                if part is not AccountingNone:
+                    v += part
             return "(" + repr(v) + ")"
 
         return self._ACC_RE.sub(f, expr)
@@ -565,35 +583,7 @@ class AccountingExpressionProcessor:
             # here we know account_id is involved in acc_domain
             account_ids_data = self._data[key]
             entry = account_ids_data[account_id]
-            debit = entry.debit
-            credit = entry.credit
-            if field == "bal":
-                v = debit - credit
-            elif field == "pbal":
-                if debit >= credit:
-                    v = debit - credit
-                else:
-                    v = AccountingNone
-            elif field == "nbal":
-                if debit < credit:
-                    v = debit - credit
-                else:
-                    v = AccountingNone
-            elif field == "deb":
-                v = debit
-            elif field == "crd":
-                v = credit
-            else:
-                assert field == "fld"
-                v = entry.custom_fields[fld_name]
-            # in initial balance mode, assume 0 is None
-            # as it does not make sense to distinguish 0 from "no data"
-            if (
-                v is not AccountingNone
-                and mode in (self.MODE_INITIAL, self.MODE_UNALLOCATED)
-                and float_is_zero(v, precision_digits=self.dp)
-            ):
-                v = AccountingNone
+            v = self._value_from_entry(field, mode, fld_name, entry)
             return "(" + repr(v) + ")"
 
         account_ids = set()
@@ -608,6 +598,145 @@ class AccountingExpressionProcessor:
 
         for account_id in account_ids:
             yield account_id, [self._ACC_RE.sub(f, expr) for expr in exprs]
+
+    def do_queries_by_partner(
+        self,
+        date_from,
+        date_to,
+        additional_move_line_filter=None,
+        aml_model=None,
+    ):
+        """Query debit/credit grouped by partner and account.
+
+        Populates ``_data_partner`` for use by ``replace_exprs_by_partner_id``.
+        Must be executed after ``done_parsing()``.
+        """
+        if not aml_model:
+            aml_model = self.env["account.move.line"]
+        else:
+            aml_model = self.env[aml_model]
+        aml_model = aml_model.with_context(active_test=False)
+        company_rates = self._get_company_rates(date_to)
+        # {(domain, mode): {partner_id: {account_id: Accumulator}}}
+        self._data_partner = defaultdict(
+            lambda: defaultdict(
+                lambda: defaultdict(
+                    lambda: Accumulator(self._custom_fields),
+                )
+            )
+        )
+        domain_by_mode = {}
+        ends = []
+        for key in self._map_account_ids:
+            domain, mode = key
+            if mode == self.MODE_END and self.smart_end:
+                ends.append((domain, mode))
+                continue
+            if mode not in domain_by_mode:
+                domain_by_mode[mode] = self.get_aml_domain_for_dates(
+                    date_from, date_to, mode
+                )
+            domain = list(domain) + domain_by_mode[mode]
+            domain.append(("account_id", "in", self._map_account_ids[key]))
+            if additional_move_line_filter:
+                domain.extend(additional_move_line_filter)
+            _logger.debug("read_group partner domain: %s", domain)
+            try:
+                accs = aml_model.with_context(
+                    allowed_company_ids=self.companies.ids
+                )._read_group(
+                    domain,
+                    groupby=("partner_id", "account_id", "company_id"),
+                    aggregates=(
+                        (
+                            "debit:sum",
+                            "credit:sum",
+                            *(f"{field}:sum" for field in self._custom_fields),
+                        )
+                    ),
+                )
+            except ValueError as e:
+                raise UserError(
+                    self.env._(
+                        'Error while querying move line source "%(model_name)s". '
+                        "This is likely due to a filter or expression referencing "
+                        "a field that does not exist in the model.\n\n"
+                        "The technical error message is: %(exception)s. ",
+                        model_name=aml_model._description,
+                        exception=e,
+                    )
+                ) from e
+            for partner, account, company, debit, credit, *custom_fields_sums in accs:
+                rate, _dp = company_rates[company.id]
+                debit = debit or 0.0
+                credit = credit or 0.0
+                if mode in (self.MODE_INITIAL, self.MODE_UNALLOCATED) and float_is_zero(
+                    debit - credit, precision_digits=self.dp
+                ):
+                    continue
+                # Use 0 as sentinel for move lines without a partner
+                partner_id = partner.id if partner else 0
+                account_data = self._data_partner[key][partner_id][account.id]
+                account_data.add_debit_credit(debit * rate, credit * rate)
+                for custom_field, custom_field_sum in zip(
+                    self._custom_fields, custom_fields_sums, strict=True
+                ):
+                    account_data.add_custom_field(
+                        custom_field, custom_field_sum or AccountingNone
+                    )
+        for key in ends:
+            domain, mode = key
+            initial_data = self._data_partner[(domain, self.MODE_INITIAL)]
+            variation_data = self._data_partner[(domain, self.MODE_VARIATION)]
+            partner_ids = set(initial_data.keys()) | set(variation_data.keys())
+            for partner_id in partner_ids:
+                account_ids = set(initial_data[partner_id].keys()) | set(
+                    variation_data[partner_id].keys()
+                )
+                for account_id in account_ids:
+                    self._data_partner[key][partner_id][account_id] += initial_data[
+                        partner_id
+                    ][account_id]
+                    self._data_partner[key][partner_id][account_id] += variation_data[
+                        partner_id
+                    ][account_id]
+
+    def replace_exprs_by_partner_id(self, exprs):
+        """Replace accounting variables iterating by partner.
+
+        yields partner_id, replaced_exprs
+
+        Prerequisite: do_queries_by_partner() must have been invoked.
+        Partner id 0 means move lines with an empty partner_id.
+        """
+
+        def f(mo):
+            field, mode, fld_name, acc_domain, ml_domain = self._parse_match_object(mo)
+            key = (ml_domain, mode)
+            partner_data = self._data_partner[key][partner_id]
+            v = AccountingNone
+            for account_id in self._account_ids_by_acc_domain[acc_domain]:
+                entry = partner_data[account_id]
+                if not entry.has_data():
+                    continue
+                part = self._value_from_entry(field, mode, fld_name, entry)
+                if part is not AccountingNone:
+                    v += part
+            return "(" + repr(v) + ")"
+
+        partner_ids = set()
+        for expr in exprs:
+            for mo in self._ACC_RE.finditer(expr):
+                _, mode, _, acc_domain, ml_domain = self._parse_match_object(mo)
+                key = (ml_domain, mode)
+                for partner_id, accounts_data in self._data_partner[key].items():
+                    for account_id in self._account_ids_by_acc_domain[acc_domain]:
+                        if accounts_data[account_id].has_data():
+                            partner_ids.add(partner_id)
+                            break
+
+        for partner_id in partner_ids:
+            yield partner_id, [self._ACC_RE.sub(f, expr) for expr in exprs]
 
     @classmethod
     def _get_balances(cls, mode, companies, date_from, date_to):

--- a/mis_builder/models/expression_evaluator.py
+++ b/mis_builder/models/expression_evaluator.py
@@ -19,6 +19,7 @@ class ExpressionEvaluator:
         self.additional_move_line_filter = additional_move_line_filter
         self.aml_model = aml_model
         self._aep_queries_done = False
+        self._aep_partner_queries_done = False
 
     def aep_do_queries(self):
         if self.aep and not self._aep_queries_done:
@@ -29,6 +30,16 @@ class ExpressionEvaluator:
                 self.aml_model,
             )
             self._aep_queries_done = True
+
+    def aep_do_partner_queries(self):
+        if self.aep and not self._aep_partner_queries_done:
+            self.aep.do_queries_by_partner(
+                self.date_from,
+                self.date_to,
+                self.additional_move_line_filter,
+                self.aml_model,
+            )
+            self._aep_partner_queries_done = True
 
     def eval_expressions(self, expressions, locals_dict):
         vals = []
@@ -66,3 +77,21 @@ class ExpressionEvaluator:
                 else:
                     drilldown_args.append(None)
             yield account_id, vals, drilldown_args, name_error
+
+    def eval_expressions_by_partner(self, expressions, locals_dict):
+        if not self.aep:
+            return
+        self.aep_do_partner_queries()
+        exprs = [e and e.name or "AccountingNone" for e in expressions]
+        for partner_id, replaced_exprs in self.aep.replace_exprs_by_partner_id(exprs):
+            vals = []
+            drilldown_args = []
+            name_error = False
+            for expr, replaced_expr in zip(exprs, replaced_exprs, strict=True):
+                val = mis_safe_eval(replaced_expr, locals_dict)
+                vals.append(val)
+                if replaced_expr != expr:
+                    drilldown_args.append({"expr": expr, "partner_id": partner_id})
+                else:
+                    drilldown_args.append(None)
+            yield partner_id, vals, drilldown_args, name_error

--- a/mis_builder/models/kpimatrix.py
+++ b/mis_builder/models/kpimatrix.py
@@ -15,18 +15,17 @@ _logger = logging.getLogger(__name__)
 
 
 class KpiMatrixRow:
-    # TODO: ultimately, the kpi matrix will become ignorant of KPI's and
-    #       accounts and know about rows, columns, sub columns and styles only.
-    #       It is already ignorant of period and only knowns about columns.
-    #       This will require a correct abstraction for expanding row details.
+    # Detail rows are keyed by (detail_model, detail_id). Currently supported
+    # detail models are account.account and res.partner.
 
-    def __init__(self, matrix, kpi, account_id=None, parent_row=None):
+    def __init__(self, matrix, kpi, detail_id=None, parent_row=None, detail_model=None):
         self._matrix = matrix
         self.kpi = kpi
-        self.account_id = account_id
+        self.detail_id = detail_id
+        self.detail_model = detail_model
         self.description = ""
         self.parent_row = parent_row
-        if not self.account_id:
+        if self.detail_id is None:
             self.style_props = self._matrix._style_model.merge(
                 [self.kpi.report_id.style_id, self.kpi.style_id]
             )
@@ -36,11 +35,17 @@ class KpiMatrixRow:
             )
 
     @property
+    def account_id(self):
+        """Backward-compatible alias for account detail rows."""
+        if self.detail_model == self._matrix.account_model_name:
+            return self.detail_id
+        return None
+
+    @property
     def label(self):
-        if not self.account_id:
+        if self.detail_id is None:
             return self.kpi.description
-        else:
-            return self._matrix.get_account_name(self.account_id)
+        return self._matrix.get_detail_name(self.detail_model, self.detail_id)
 
     def iter_cell_tuples(self, cols=None):
         if cols is None:
@@ -149,12 +154,14 @@ class KpiMatrix:
         lang_model = env["res.lang"]
         self.lang = lang_model._lang_get(env.user.lang)
         self._style_model = env["mis.report.style"]
+        self.account_model_name = account_model
         self._account_model = env[account_model]
+        self._partner_model = env["res.partner"]
         self._companies = companies
         # data structures
         # { kpi: KpiMatrixRow }
         self._kpi_rows = OrderedDict()
-        # { kpi: {account_id: KpiMatrixRow} }
+        # { kpi: {(detail_model, detail_id): KpiMatrixRow} }
         self._detail_rows = {}
         # { col_key: KpiMatrixCol }
         self._cols = OrderedDict()
@@ -162,8 +169,8 @@ class KpiMatrix:
         self._comparison_todo = defaultdict(list)
         # { col_key (left of sum): (col_key, [(sign, sum_col_key)])
         self._sum_todo = {}
-        # { account_id: account_name }
-        self._account_names = {}
+        # { (detail_model, detail_id): display name }
+        self._detail_names = {}
 
     def declare_kpi(self, kpi):
         """Declare a new kpi (row) in the matrix.
@@ -208,30 +215,58 @@ class KpiMatrix:
 
         Invoke this after declaring the kpi and the column.
         """
-        self.set_values_detail_account(
-            kpi, col_key, None, vals, drilldown_args, tooltips
+        self.set_values_detail(
+            kpi, col_key, None, vals, drilldown_args, tooltips=tooltips
         )
 
     def set_values_detail_account(
         self, kpi, col_key, account_id, vals, drilldown_args, tooltips=True
     ):
-        """Set values for a kpi and a column and a detail account.
+        """Backward-compatible wrapper around set_values_detail."""
+        return self.set_values_detail(
+            kpi,
+            col_key,
+            account_id,
+            vals,
+            drilldown_args,
+            tooltips=tooltips,
+            detail_model=self.account_model_name if account_id is not None else None,
+        )
 
-        Invoke this after declaring the kpi and the column.
-        """
-        if not account_id:
+    def set_values_detail(
+        self,
+        kpi,
+        col_key,
+        detail_id,
+        vals,
+        drilldown_args,
+        tooltips=True,
+        detail_model=None,
+    ):
+        """Set values for a kpi, column and optional detail row."""
+        if detail_id is None:
             row = self._kpi_rows[kpi]
         else:
+            if detail_model is None:
+                detail_model = self.account_model_name
             kpi_row = self._kpi_rows[kpi]
-            if account_id in self._detail_rows[kpi]:
-                row = self._detail_rows[kpi][account_id]
+            detail_key = (detail_model, detail_id)
+            if detail_key in self._detail_rows[kpi]:
+                row = self._detail_rows[kpi][detail_key]
             else:
-                row = KpiMatrixRow(self, kpi, account_id, parent_row=kpi_row)
-                self._detail_rows[kpi][account_id] = row
+                row = KpiMatrixRow(
+                    self,
+                    kpi,
+                    detail_id,
+                    parent_row=kpi_row,
+                    detail_model=detail_model,
+                )
+                self._detail_rows[kpi][detail_key] = row
         col = self._cols[col_key]
         cell_tuple = []
         assert len(vals) == col.colspan
         assert len(drilldown_args) == col.colspan
+        style_name = None
         for val, drilldown_arg, subcol in zip(
             vals, drilldown_args, col.iter_subcols(), strict=True
         ):
@@ -262,6 +297,7 @@ class KpiMatrix:
                         row.kpi.style_expression,
                         exc_info=True,
                     )
+                    style_name = None
                 if style_name:
                     style = self._style_model.search([("name", "=", style_name)])
                     if style:
@@ -410,7 +446,7 @@ class KpiMatrix:
             for row in self.iter_rows():
                 acc = SimpleArray([AccountingNone] * (len(common_subkpis) or 1))
                 if row.kpi.accumulation_method == ACC_SUM and not (
-                    row.account_id and not sum_accdet
+                    row.detail_id is not None and not sum_accdet
                 ):
                     for sign, col_to_sum in col_to_sum_keys:
                         cell_tuple = self._cols[col_to_sum].get_cell_tuple_for_row(row)
@@ -427,13 +463,14 @@ class KpiMatrix:
                             acc += SimpleArray(vals)
                         else:
                             acc -= SimpleArray(vals)
-                self.set_values_detail_account(
+                self.set_values_detail(
                     row.kpi,
                     sumcol_key,
-                    row.account_id,
+                    row.detail_id,
                     acc,
                     [None] * (len(common_subkpis) or 1),
                     tooltips=False,
+                    detail_model=row.detail_model,
                 )
 
     def iter_rows(self):
@@ -464,12 +501,31 @@ class KpiMatrix:
         for col in self.iter_cols():
             yield from col.iter_subcols()
 
-    def _load_account_names(self):
+    def _load_detail_names(self):
         account_ids = set()
+        partner_ids = set()
         for detail_rows in self._detail_rows.values():
-            account_ids.update(detail_rows.keys())
-        accounts = self._account_model.search([("id", "in", list(account_ids))])
-        self._account_names = {a.id: self._get_account_name(a) for a in accounts}
+            for detail_model, detail_id in detail_rows:
+                if detail_model == self.account_model_name:
+                    account_ids.add(detail_id)
+                elif detail_model == "res.partner":
+                    partner_ids.add(detail_id)
+        if account_ids:
+            accounts = self._account_model.search([("id", "in", list(account_ids))])
+            for account in accounts:
+                self._detail_names[(self.account_model_name, account.id)] = (
+                    self._get_account_name(account)
+                )
+        if partner_ids:
+            # 0 is the sentinel used for move lines without partner
+            resolved_ids = [i for i in partner_ids if i]
+            partners = self._partner_model.browse(resolved_ids)
+            for partner in partners:
+                self._detail_names[("res.partner", partner.id)] = partner.display_name
+            if 0 in partner_ids:
+                self._detail_names[("res.partner", 0)] = self._partner_model.env._(
+                    "(No partner)"
+                )
 
     def _get_account_name(self, account):
         # display_name is account code + account name. Note the account may have
@@ -495,16 +551,18 @@ class KpiMatrix:
             # is bound to multiple companies it does not make sense, because we
             # don't know to which companies this detail line effectively
             # contributes, so the list of companies in it would not add useful
-            # information. To be able to accurately display the company on
-            # detail lines when the account is bound to multiple companies,
-            # we'll need a generalized kpi details expansion.
+            # information.
             account_name = f"{account_name} [{account_companies.display_name}]"
         return account_name
 
+    def get_detail_name(self, detail_model, detail_id):
+        key = (detail_model, detail_id)
+        if key not in self._detail_names:
+            self._load_detail_names()
+        return self._detail_names.get(key, "")
+
     def get_account_name(self, account_id):
-        if account_id not in self._account_names:
-            self._load_account_names()
-        return self._account_names[account_id]
+        return self.get_detail_name(self.account_model_name, account_id)
 
     def as_dict(self):
         header = [{"cols": []}, {"cols": []}]
@@ -554,8 +612,8 @@ class KpiMatrix:
                         "style": self._style_model.to_css_style(
                             cell.style_props, no_indent=True
                         ),
-                        # notes can not be added on 'details by account' lines
-                        "can_be_annotated": not cell.row.account_id,
+                        # notes can not be added on detail lines
+                        "can_be_annotated": cell.row.detail_id is None,
                     }
                     if cell.drilldown_arg:
                         col_data["drilldown_arg"] = cell.drilldown_arg
@@ -571,25 +629,63 @@ class KpiMatrix:
     # semantic domain occur.
 
     @classmethod
+    def _detail_key_to_cell_token(cls, detail_model, detail_id):
+        if detail_id is None:
+            return ""
+        if detail_model == "res.partner":
+            return f"p:{detail_id}"
+        # account details keep the historic numeric token for compatibility
+        return str(detail_id)
+
+    @classmethod
     def _make_cell_id(
-        cls, kpi_id: int, account_id: int | None, period_id: int, subkpi_id: int | None
+        cls,
+        kpi_id: int,
+        detail_id: int | None,
+        period_id: int,
+        subkpi_id: int | None,
+        detail_model: str | None = None,
     ) -> str:
-        return f"{kpi_id}#{account_id or ''}#{period_id}#{subkpi_id or ''}"
+        mid = cls._detail_key_to_cell_token(detail_model, detail_id)
+        return f"{kpi_id}#{mid}#{period_id}#{subkpi_id or ''}"
 
     @classmethod
     def _pack_cell_id(cls, cell: KpiMatrixCell) -> str:
         return cls._make_cell_id(
             cell.row.kpi.id,
-            cell.row.account_id,
+            cell.row.detail_id,
             cell.subcol.col.key,
             cell.subcol.subkpi and cell.subcol.subkpi.id,
+            detail_model=cell.row.detail_model,
         )
 
     @classmethod
     def _unpack_cell_id(cls, cell_id: str) -> tuple[int, int | None, int, int | None]:
-        kpi_id, account_id, col_key, subkpi_id = cell_id.split("#")
+        """Unpack a cell id.
+
+        The second element is the detail id. For partner details the raw token
+        is not returned here; callers that need the model should use
+        `_unpack_cell_id_detail`.
+        """
+        kpi_id, detail_id, period_id, subkpi_id = cls._unpack_cell_id_detail(cell_id)[
+            :4
+        ]
+        return kpi_id, detail_id, period_id, subkpi_id
+
+    @classmethod
+    def _unpack_cell_id_detail(
+        cls, cell_id: str
+    ) -> tuple[int, int | None, int, int | None, str | None]:
+        kpi_id, mid, col_key, subkpi_id = cell_id.split("#")
         kpi_id = int(kpi_id)
-        account_id = int(account_id) if account_id else None
         period_id = int(col_key)
         subkpi_id = int(subkpi_id) if subkpi_id else None
-        return kpi_id, account_id, period_id, subkpi_id
+        detail_model = None
+        detail_id = None
+        if mid.startswith("p:"):
+            detail_model = "res.partner"
+            detail_id = int(mid[2:])
+        elif mid:
+            detail_model = "account.account"
+            detail_id = int(mid)
+        return kpi_id, detail_id, period_id, subkpi_id, detail_model

--- a/mis_builder/models/mis_report.py
+++ b/mis_builder/models/mis_report.py
@@ -39,6 +39,10 @@ from .simple_array import SimpleArray, named_simple_array
 
 _logger = logging.getLogger(__name__)
 
+DETAIL_NONE = "none"
+DETAIL_ACCOUNT = "account"
+DETAIL_PARTNER = "partner"
+
 
 class SubKPITupleLengthError(UserError):
     pass
@@ -97,11 +101,32 @@ class MisReportKpi(models.Model):
         copy=True,
         string="Expressions",
     )
-    auto_expand_accounts = fields.Boolean(string="Display details by account")
+    detail_by = fields.Selection(
+        [
+            (DETAIL_NONE, "No details"),
+            (DETAIL_ACCOUNT, "By account"),
+            (DETAIL_PARTNER, "By partner"),
+        ],
+        string="Display details",
+        default=DETAIL_NONE,
+        required=True,
+        help="Expand this KPI into detail rows. "
+        "By account: one row per account involved in the expression. "
+        "By partner: one row per partner (customer/vendor) on matching move lines.",
+    )
+    auto_expand_accounts = fields.Boolean(
+        string="Display details by account",
+        compute="_compute_auto_expand_accounts",
+        inverse="_inverse_auto_expand_accounts",
+        store=True,
+        help="Deprecated: use Display details = By account. "
+        "Kept for backward compatibility.",
+    )
     auto_expand_accounts_style_id = fields.Many2one(
-        string="Style for account detail rows",
+        string="Style for detail rows",
         comodel_name="mis.report.style",
         required=False,
+        help="Style applied to expanded detail rows (account or partner).",
     )
     style_id = fields.Many2one(
         string="Style", comodel_name="mis.report.style", required=False
@@ -153,6 +178,18 @@ class MisReportKpi(models.Model):
     def _compute_display_name(self):
         for rec in self:
             rec.display_name = f"{rec.description} ({rec.name})"
+
+    @api.depends("detail_by")
+    def _compute_auto_expand_accounts(self):
+        for rec in self:
+            rec.auto_expand_accounts = rec.detail_by == DETAIL_ACCOUNT
+
+    def _inverse_auto_expand_accounts(self):
+        for rec in self:
+            if rec.auto_expand_accounts:
+                rec.detail_by = DETAIL_ACCOUNT
+            elif rec.detail_by == DETAIL_ACCOUNT:
+                rec.detail_by = DETAIL_NONE
 
     @api.constrains("name")
     def _check_name(self):
@@ -740,28 +777,41 @@ class MisReport(models.Model):
 
                 kpi_matrix.set_values(kpi, col_key, vals, drilldown_args)
 
-                if (
-                    name_error
-                    or no_auto_expand_accounts
-                    or not kpi.auto_expand_accounts
-                ):
+                detail_by = DETAIL_NONE if no_auto_expand_accounts else kpi.detail_by
+                if name_error or detail_by == DETAIL_NONE:
+                    continue
+
+                if detail_by == DETAIL_ACCOUNT:
+                    detail_iter = expression_evaluator.eval_expressions_by_account(
+                        expressions, locals_dict
+                    )
+                    detail_model = kpi_matrix.account_model_name
+                elif detail_by == DETAIL_PARTNER:
+                    detail_iter = expression_evaluator.eval_expressions_by_partner(
+                        expressions, locals_dict
+                    )
+                    detail_model = "res.partner"
+                else:
                     continue
 
                 for (
-                    account_id,
+                    detail_id,
                     vals,
                     drilldown_args,
                     _name_error,
-                ) in expression_evaluator.eval_expressions_by_account(
-                    expressions, locals_dict
-                ):
+                ) in detail_iter:
                     for drilldown_arg in drilldown_args:
                         if not drilldown_arg:
                             continue
                         drilldown_arg["period_id"] = col_key
                         drilldown_arg["kpi_id"] = kpi.id
-                    kpi_matrix.set_values_detail_account(
-                        kpi, col_key, account_id, vals, drilldown_args
+                    kpi_matrix.set_values_detail(
+                        kpi,
+                        col_key,
+                        detail_id,
+                        vals,
+                        drilldown_args,
+                        detail_model=detail_model,
                     )
 
             if len(recompute_queue) == 0:
@@ -843,7 +893,8 @@ class MisReport(models.Model):
                                             underlying model
         :param locals_dict: personalized locals dictionary used as evaluation
                             context for the KPI expressions
-        :param no_auto_expand_accounts: disable expansion of account details
+        :param no_auto_expand_accounts: disable expansion of detail rows
+                                        (account or partner)
         """
         self.ensure_one()
 

--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -545,7 +545,10 @@ class MisReportInstance(models.Model):
         required=False,
     )
     landscape_pdf = fields.Boolean(string="Landscape PDF")
-    no_auto_expand_accounts = fields.Boolean(string="Disable account details expansion")
+    no_auto_expand_accounts = fields.Boolean(
+        string="Disable details expansion",
+        help="Disable account/partner detail rows for all KPIs of this report.",
+    )
     display_columns_description = fields.Boolean(
         help="Display the date range details in the column headers."
     )
@@ -963,6 +966,7 @@ class MisReportInstance(models.Model):
         period_id = arg.get("period_id")
         expr = arg.get("expr")
         account_id = arg.get("account_id")
+        partner_id = arg.get("partner_id")
         if period_id and expr and AEP.has_account_var(expr):
             period = self.env["mis.report.instance.period"].browse(period_id)
             aep = AEP(
@@ -975,6 +979,7 @@ class MisReportInstance(models.Model):
                 period.date_from,
                 period.date_to,
                 account_id,
+                partner_id=partner_id,
             )
             additional_domain = period._get_additional_move_line_filter()
             if additional_domain:
@@ -999,12 +1004,19 @@ class MisReportInstance(models.Model):
         period_id = arg.get("period_id")
         period = self.env["mis.report.instance.period"].browse(period_id)
         account_id = arg.get("account_id")
+        partner_id = arg.get("partner_id")
 
         if account_id:
             account = self.env[self.report_id.account_model].browse(account_id)
             return f"{kpi.description} - {account.display_name} - {period.display_name}"
-        else:
-            return f"{kpi.description} - {period.display_name}"
+        if partner_id is not None:
+            if partner_id:
+                partner = self.env["res.partner"].browse(partner_id)
+                partner_name = partner.display_name
+            else:
+                partner_name = self.env._("(No partner)")
+            return f"{kpi.description} - {partner_name} - {period.display_name}"
+        return f"{kpi.description} - {period.display_name}"
 
     def _get_annotation_context(self):
         """Return the context used to filter annotation linked to this instance."""

--- a/mis_builder/readme/HISTORY.md
+++ b/mis_builder/readme/HISTORY.md
@@ -1,3 +1,13 @@
+## 19.0.1.1.0 (2026-07-20)
+
+### Features
+
+- Add KPI option to expand detail rows by partner (customer/vendor),
+  in addition to the existing expansion by account. The new
+  ``detail_by`` field supersedes ``auto_expand_accounts`` while keeping
+  backward compatibility.
+
+
 ## 18.0.1.7.2 (2025-10-29)
 
 ### Bugfixes

--- a/mis_builder/static/description/index.html
+++ b/mis_builder/static/description/index.html
@@ -388,59 +388,63 @@ to PDF, Excel and they can be added to Odoo dashboards.</p>
 <li><a class="reference internal" href="#development" id="toc-entry-3">Development</a></li>
 <li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-4">Known issues / Roadmap</a></li>
 <li><a class="reference internal" href="#changelog" id="toc-entry-5">Changelog</a><ul>
-<li><a class="reference internal" href="#section-1" id="toc-entry-6">18.0.1.7.2 (2025-10-29)</a><ul>
-<li><a class="reference internal" href="#bugfixes" id="toc-entry-7">Bugfixes</a></li>
+<li><a class="reference internal" href="#section-1" id="toc-entry-6">19.0.1.1.0 (2026-07-20)</a><ul>
+<li><a class="reference internal" href="#features" id="toc-entry-7">Features</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#section-2" id="toc-entry-8">18.0.1.5.0 (2025-10-27)</a><ul>
-<li><a class="reference internal" href="#features" id="toc-entry-9">Features</a></li>
+<li><a class="reference internal" href="#section-2" id="toc-entry-8">18.0.1.7.2 (2025-10-29)</a><ul>
+<li><a class="reference internal" href="#bugfixes" id="toc-entry-9">Bugfixes</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#section-3" id="toc-entry-10">17.0.1.0.2 (2024-11-11)</a><ul>
+<li><a class="reference internal" href="#section-3" id="toc-entry-10">18.0.1.5.0 (2025-10-27)</a><ul>
 <li><a class="reference internal" href="#features-1" id="toc-entry-11">Features</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#section-4" id="toc-entry-12">16.0.5.1.9 (2024-02-09)</a></li>
-<li><a class="reference internal" href="#section-5" id="toc-entry-13">16.0.5.1.8 (2024-02-08)</a></li>
-<li><a class="reference internal" href="#section-6" id="toc-entry-14">16.0.5.1.0 (2023-04-04)</a></li>
-<li><a class="reference internal" href="#section-7" id="toc-entry-15">16.0.5.0.0 (2023-04-01)</a></li>
-<li><a class="reference internal" href="#section-8" id="toc-entry-16">15.0.4.0.5 (2022-07-19)</a></li>
-<li><a class="reference internal" href="#section-9" id="toc-entry-17">15.0.4.0.4 (2022-07-19)</a></li>
-<li><a class="reference internal" href="#section-10" id="toc-entry-18">15.0.4.0.2 (2022-02-16)</a></li>
-<li><a class="reference internal" href="#section-11" id="toc-entry-19">14.0.4.0.0 (2022-01-08)</a></li>
-<li><a class="reference internal" href="#section-12" id="toc-entry-20">14.0.3.6.7 (2021-06-02)</a></li>
-<li><a class="reference internal" href="#section-13" id="toc-entry-21">14.0.3.6.6 (2021-04-23)</a></li>
-<li><a class="reference internal" href="#section-14" id="toc-entry-22">14.0.3.6.5 (2021-04-23)</a></li>
-<li><a class="reference internal" href="#section-15" id="toc-entry-23">14.0.3.6.4 (2021-04-06)</a></li>
-<li><a class="reference internal" href="#section-16" id="toc-entry-24">13.0.3.6.3 (2020-08-28)</a></li>
-<li><a class="reference internal" href="#section-17" id="toc-entry-25">13.0.3.6.2 (2020-04-22)</a></li>
-<li><a class="reference internal" href="#section-18" id="toc-entry-26">13.0.3.6.1 (2020-04-22)</a></li>
-<li><a class="reference internal" href="#section-19" id="toc-entry-27">13.0.3.6.0 (2020-03-28)</a></li>
-<li><a class="reference internal" href="#section-20" id="toc-entry-28">13.0.3.5.0 (2020-01-??)</a></li>
-<li><a class="reference internal" href="#section-21" id="toc-entry-29">12.0.3.5.0 (2019-10-26)</a></li>
-<li><a class="reference internal" href="#section-22" id="toc-entry-30">12.0.3.4.0 (2019-07-09)</a></li>
-<li><a class="reference internal" href="#section-23" id="toc-entry-31">12.0.3.3.0 (2019-01-26)</a></li>
-<li><a class="reference internal" href="#section-24" id="toc-entry-32">11.0.3.2.2 (2018-06-30)</a></li>
-<li><a class="reference internal" href="#section-25" id="toc-entry-33">11.0.3.2.1 (2018-05-29)</a></li>
-<li><a class="reference internal" href="#section-26" id="toc-entry-34">10.0.3.2.0 (2018-05-02)</a></li>
-<li><a class="reference internal" href="#section-27" id="toc-entry-35">11.0.3.1.2 (2018-02-04)</a></li>
-<li><a class="reference internal" href="#section-28" id="toc-entry-36">10.0.3.1.1 (2017-11-14)</a></li>
-<li><a class="reference internal" href="#section-29" id="toc-entry-37">10.0.3.0.4 (2017-10-14)</a></li>
-<li><a class="reference internal" href="#section-30" id="toc-entry-38">10.0.3.0.3 (2017-10-03)</a></li>
-<li><a class="reference internal" href="#section-31" id="toc-entry-39">10.0.3.0.2 (2017-10-01)</a></li>
-<li><a class="reference internal" href="#unreleased" id="toc-entry-40">10.0.2.0.3 (unreleased)</a></li>
-<li><a class="reference internal" href="#section-32" id="toc-entry-41">9.0.2.0.2 (2016-09-27)</a></li>
-<li><a class="reference internal" href="#section-33" id="toc-entry-42">9.0.2.0.1 (2016-05-26)</a></li>
-<li><a class="reference internal" href="#section-34" id="toc-entry-43">9.0.2.0.0 (2016-05-24)</a></li>
-<li><a class="reference internal" href="#section-35" id="toc-entry-44">8.0.1.0.0 (2016-04-27)</a></li>
-<li><a class="reference internal" href="#section-36" id="toc-entry-45">8.0.0.2.0</a></li>
+<li><a class="reference internal" href="#section-4" id="toc-entry-12">17.0.1.0.2 (2024-11-11)</a><ul>
+<li><a class="reference internal" href="#features-2" id="toc-entry-13">Features</a></li>
 </ul>
 </li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-46">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-47">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-48">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-49">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-50">Maintainers</a></li>
+<li><a class="reference internal" href="#section-5" id="toc-entry-14">16.0.5.1.9 (2024-02-09)</a></li>
+<li><a class="reference internal" href="#section-6" id="toc-entry-15">16.0.5.1.8 (2024-02-08)</a></li>
+<li><a class="reference internal" href="#section-7" id="toc-entry-16">16.0.5.1.0 (2023-04-04)</a></li>
+<li><a class="reference internal" href="#section-8" id="toc-entry-17">16.0.5.0.0 (2023-04-01)</a></li>
+<li><a class="reference internal" href="#section-9" id="toc-entry-18">15.0.4.0.5 (2022-07-19)</a></li>
+<li><a class="reference internal" href="#section-10" id="toc-entry-19">15.0.4.0.4 (2022-07-19)</a></li>
+<li><a class="reference internal" href="#section-11" id="toc-entry-20">15.0.4.0.2 (2022-02-16)</a></li>
+<li><a class="reference internal" href="#section-12" id="toc-entry-21">14.0.4.0.0 (2022-01-08)</a></li>
+<li><a class="reference internal" href="#section-13" id="toc-entry-22">14.0.3.6.7 (2021-06-02)</a></li>
+<li><a class="reference internal" href="#section-14" id="toc-entry-23">14.0.3.6.6 (2021-04-23)</a></li>
+<li><a class="reference internal" href="#section-15" id="toc-entry-24">14.0.3.6.5 (2021-04-23)</a></li>
+<li><a class="reference internal" href="#section-16" id="toc-entry-25">14.0.3.6.4 (2021-04-06)</a></li>
+<li><a class="reference internal" href="#section-17" id="toc-entry-26">13.0.3.6.3 (2020-08-28)</a></li>
+<li><a class="reference internal" href="#section-18" id="toc-entry-27">13.0.3.6.2 (2020-04-22)</a></li>
+<li><a class="reference internal" href="#section-19" id="toc-entry-28">13.0.3.6.1 (2020-04-22)</a></li>
+<li><a class="reference internal" href="#section-20" id="toc-entry-29">13.0.3.6.0 (2020-03-28)</a></li>
+<li><a class="reference internal" href="#section-21" id="toc-entry-30">13.0.3.5.0 (2020-01-??)</a></li>
+<li><a class="reference internal" href="#section-22" id="toc-entry-31">12.0.3.5.0 (2019-10-26)</a></li>
+<li><a class="reference internal" href="#section-23" id="toc-entry-32">12.0.3.4.0 (2019-07-09)</a></li>
+<li><a class="reference internal" href="#section-24" id="toc-entry-33">12.0.3.3.0 (2019-01-26)</a></li>
+<li><a class="reference internal" href="#section-25" id="toc-entry-34">11.0.3.2.2 (2018-06-30)</a></li>
+<li><a class="reference internal" href="#section-26" id="toc-entry-35">11.0.3.2.1 (2018-05-29)</a></li>
+<li><a class="reference internal" href="#section-27" id="toc-entry-36">10.0.3.2.0 (2018-05-02)</a></li>
+<li><a class="reference internal" href="#section-28" id="toc-entry-37">11.0.3.1.2 (2018-02-04)</a></li>
+<li><a class="reference internal" href="#section-29" id="toc-entry-38">10.0.3.1.1 (2017-11-14)</a></li>
+<li><a class="reference internal" href="#section-30" id="toc-entry-39">10.0.3.0.4 (2017-10-14)</a></li>
+<li><a class="reference internal" href="#section-31" id="toc-entry-40">10.0.3.0.3 (2017-10-03)</a></li>
+<li><a class="reference internal" href="#section-32" id="toc-entry-41">10.0.3.0.2 (2017-10-01)</a></li>
+<li><a class="reference internal" href="#unreleased" id="toc-entry-42">10.0.2.0.3 (unreleased)</a></li>
+<li><a class="reference internal" href="#section-33" id="toc-entry-43">9.0.2.0.2 (2016-09-27)</a></li>
+<li><a class="reference internal" href="#section-34" id="toc-entry-44">9.0.2.0.1 (2016-05-26)</a></li>
+<li><a class="reference internal" href="#section-35" id="toc-entry-45">9.0.2.0.0 (2016-05-24)</a></li>
+<li><a class="reference internal" href="#section-36" id="toc-entry-46">8.0.1.0.0 (2016-04-27)</a></li>
+<li><a class="reference internal" href="#section-37" id="toc-entry-47">8.0.0.2.0</a></li>
+</ul>
+</li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-48">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-49">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-50">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-51">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-52">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -505,19 +509,31 @@ can be found on GitHub.</p>
 <div class="section" id="changelog">
 <h2><a class="toc-backref" href="#toc-entry-5">Changelog</a></h2>
 <div class="section" id="section-1">
-<h3><a class="toc-backref" href="#toc-entry-6">18.0.1.7.2 (2025-10-29)</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-6">19.0.1.1.0 (2026-07-20)</a></h3>
+<div class="section" id="features">
+<h4><a class="toc-backref" href="#toc-entry-7">Features</a></h4>
+<ul class="simple">
+<li>Add KPI option to expand detail rows by partner (customer/vendor), in
+addition to the existing expansion by account. The new <tt class="docutils literal">detail_by</tt>
+field supersedes <tt class="docutils literal">auto_expand_accounts</tt> while keeping backward
+compatibility.</li>
+</ul>
+</div>
+</div>
+<div class="section" id="section-2">
+<h3><a class="toc-backref" href="#toc-entry-8">18.0.1.7.2 (2025-10-29)</a></h3>
 <div class="section" id="bugfixes">
-<h4><a class="toc-backref" href="#toc-entry-7">Bugfixes</a></h4>
+<h4><a class="toc-backref" href="#toc-entry-9">Bugfixes</a></h4>
 <ul class="simple">
 <li>Fix computation of currency conversion rates
 (<a class="reference external" href="https://github.com/OCA/mis-builder/issues/737">#737</a>)</li>
 </ul>
 </div>
 </div>
-<div class="section" id="section-2">
-<h3><a class="toc-backref" href="#toc-entry-8">18.0.1.5.0 (2025-10-27)</a></h3>
-<div class="section" id="features">
-<h4><a class="toc-backref" href="#toc-entry-9">Features</a></h4>
+<div class="section" id="section-3">
+<h3><a class="toc-backref" href="#toc-entry-10">18.0.1.5.0 (2025-10-27)</a></h3>
+<div class="section" id="features-1">
+<h4><a class="toc-backref" href="#toc-entry-11">Features</a></h4>
 <ul class="simple">
 <li>Introduction of annotations on report cells. Added notes will be
 pinted when exporting to PDF and Excel.
@@ -525,26 +541,26 @@ pinted when exporting to PDF and Excel.
 </ul>
 </div>
 </div>
-<div class="section" id="section-3">
-<h3><a class="toc-backref" href="#toc-entry-10">17.0.1.0.2 (2024-11-11)</a></h3>
-<div class="section" id="features-1">
-<h4><a class="toc-backref" href="#toc-entry-11">Features</a></h4>
+<div class="section" id="section-4">
+<h3><a class="toc-backref" href="#toc-entry-12">17.0.1.0.2 (2024-11-11)</a></h3>
+<div class="section" id="features-2">
+<h4><a class="toc-backref" href="#toc-entry-13">Features</a></h4>
 <ul class="simple">
 <li>Add support for branch companies.
 (<a class="reference external" href="https://github.com/OCA/mis-builder/issues/648">#648</a>)</li>
 </ul>
 </div>
 </div>
-<div class="section" id="section-4">
-<h3><a class="toc-backref" href="#toc-entry-12">16.0.5.1.9 (2024-02-09)</a></h3>
+<div class="section" id="section-5">
+<h3><a class="toc-backref" href="#toc-entry-14">16.0.5.1.9 (2024-02-09)</a></h3>
 <p><strong>Bugfixes</strong></p>
 <ul class="simple">
 <li>Restore compatibility with python 3.9
 (<a class="reference external" href="https://github.com/OCA/mis-builder/issues/590">#590</a>)</li>
 </ul>
 </div>
-<div class="section" id="section-5">
-<h3><a class="toc-backref" href="#toc-entry-13">16.0.5.1.8 (2024-02-08)</a></h3>
+<div class="section" id="section-6">
+<h3><a class="toc-backref" href="#toc-entry-15">16.0.5.1.8 (2024-02-08)</a></h3>
 <p><strong>Bugfixes</strong></p>
 <ul class="simple">
 <li>Resolve a permission issue when creating report periods with a user
@@ -552,16 +568,16 @@ without admin rights.
 (<a class="reference external" href="https://github.com/OCA/mis-builder/issues/596">#596</a>)</li>
 </ul>
 </div>
-<div class="section" id="section-6">
-<h3><a class="toc-backref" href="#toc-entry-14">16.0.5.1.0 (2023-04-04)</a></h3>
+<div class="section" id="section-7">
+<h3><a class="toc-backref" href="#toc-entry-16">16.0.5.1.0 (2023-04-04)</a></h3>
 <p><strong>Features</strong></p>
 <ul class="simple">
 <li>Improve UX by adding the option to edit the pivot date directly on the
 view.</li>
 </ul>
 </div>
-<div class="section" id="section-7">
-<h3><a class="toc-backref" href="#toc-entry-15">16.0.5.0.0 (2023-04-01)</a></h3>
+<div class="section" id="section-8">
+<h3><a class="toc-backref" href="#toc-entry-17">16.0.5.0.0 (2023-04-01)</a></h3>
 <p><strong>Features</strong></p>
 <ul class="simple">
 <li>Migration to 16.0<ul>
@@ -600,24 +616,24 @@ for the <tt class="docutils literal">account_user</tt> group but this was not fl
 (<a class="reference external" href="https://github.com/OCA/mis-builder/issues/415">#415</a>)</li>
 </ul>
 </div>
-<div class="section" id="section-8">
-<h3><a class="toc-backref" href="#toc-entry-16">15.0.4.0.5 (2022-07-19)</a></h3>
+<div class="section" id="section-9">
+<h3><a class="toc-backref" href="#toc-entry-18">15.0.4.0.5 (2022-07-19)</a></h3>
 <p><strong>Bugfixes</strong></p>
 <ul class="simple">
 <li>Support users without timezone.
 (<a class="reference external" href="https://github.com/OCA/mis-builder/issues/388">#388</a>)</li>
 </ul>
 </div>
-<div class="section" id="section-9">
-<h3><a class="toc-backref" href="#toc-entry-17">15.0.4.0.4 (2022-07-19)</a></h3>
+<div class="section" id="section-10">
+<h3><a class="toc-backref" href="#toc-entry-19">15.0.4.0.4 (2022-07-19)</a></h3>
 <p><strong>Bugfixes</strong></p>
 <ul class="simple">
 <li>Allow deleting a report that has subreports.
 (<a class="reference external" href="https://github.com/OCA/mis-builder/issues/431">#431</a>)</li>
 </ul>
 </div>
-<div class="section" id="section-10">
-<h3><a class="toc-backref" href="#toc-entry-18">15.0.4.0.2 (2022-02-16)</a></h3>
+<div class="section" id="section-11">
+<h3><a class="toc-backref" href="#toc-entry-20">15.0.4.0.2 (2022-02-16)</a></h3>
 <p><strong>Bugfixes</strong></p>
 <ul class="simple">
 <li>Fix access right issue when clicking the “Save” button on a MIS Report
@@ -625,8 +641,8 @@ Instance form.
 (<a class="reference external" href="https://github.com/OCA/mis-builder/issues/410">#410</a>)</li>
 </ul>
 </div>
-<div class="section" id="section-11">
-<h3><a class="toc-backref" href="#toc-entry-19">14.0.4.0.0 (2022-01-08)</a></h3>
+<div class="section" id="section-12">
+<h3><a class="toc-backref" href="#toc-entry-21">14.0.4.0.0 (2022-01-08)</a></h3>
 <p><strong>Features</strong></p>
 <ul class="simple">
 <li>Remove various field size limits.
@@ -657,8 +673,8 @@ use <tt class="docutils literal">parent_state</tt>, we now remove this argument.
 </li>
 </ul>
 </div>
-<div class="section" id="section-12">
-<h3><a class="toc-backref" href="#toc-entry-20">14.0.3.6.7 (2021-06-02)</a></h3>
+<div class="section" id="section-13">
+<h3><a class="toc-backref" href="#toc-entry-22">14.0.3.6.7 (2021-06-02)</a></h3>
 <p><strong>Bugfixes</strong></p>
 <ul class="simple">
 <li>When on a MIS Report Instance, if you wanted to generate a new line of
@@ -670,16 +686,16 @@ record solves the problem.
 (<a class="reference external" href="https://github.com/OCA/mis-builder/issues/361">#361</a>)</li>
 </ul>
 </div>
-<div class="section" id="section-13">
-<h3><a class="toc-backref" href="#toc-entry-21">14.0.3.6.6 (2021-04-23)</a></h3>
+<div class="section" id="section-14">
+<h3><a class="toc-backref" href="#toc-entry-23">14.0.3.6.6 (2021-04-23)</a></h3>
 <p><strong>Bugfixes</strong></p>
 <ul class="simple">
 <li>Fix drilldown action name when the account model has been customized.
 (<a class="reference external" href="https://github.com/OCA/mis-builder/issues/350">#350</a>)</li>
 </ul>
 </div>
-<div class="section" id="section-14">
-<h3><a class="toc-backref" href="#toc-entry-22">14.0.3.6.5 (2021-04-23)</a></h3>
+<div class="section" id="section-15">
+<h3><a class="toc-backref" href="#toc-entry-24">14.0.3.6.5 (2021-04-23)</a></h3>
 <p><strong>Bugfixes</strong></p>
 <ul class="simple">
 <li>While duplicating a MIS report instance, comparison columns are
@@ -688,8 +704,8 @@ old source_cmpcol_from_id and source_cmpcol_to_id from the original
 record. (<a class="reference external" href="https://github.com/OCA/mis-builder/issues/343">#343</a>)</li>
 </ul>
 </div>
-<div class="section" id="section-15">
-<h3><a class="toc-backref" href="#toc-entry-23">14.0.3.6.4 (2021-04-06)</a></h3>
+<div class="section" id="section-16">
+<h3><a class="toc-backref" href="#toc-entry-25">14.0.3.6.4 (2021-04-06)</a></h3>
 <p><strong>Features</strong></p>
 <ul class="simple">
 <li>The drilldown action name displayed on the breadcrumb has been
@@ -701,8 +717,8 @@ interactive view.
 (<a class="reference external" href="https://github.com/OCA/mis-builder/issues/320">#320</a>)</li>
 </ul>
 </div>
-<div class="section" id="section-16">
-<h3><a class="toc-backref" href="#toc-entry-24">13.0.3.6.3 (2020-08-28)</a></h3>
+<div class="section" id="section-17">
+<h3><a class="toc-backref" href="#toc-entry-26">13.0.3.6.3 (2020-08-28)</a></h3>
 <p><strong>Bugfixes</strong></p>
 <ul class="simple">
 <li>Having a “Compare columns” added on a KPI with an associated style
@@ -716,8 +732,8 @@ the percentages when exporting to XLSX.
 <a class="reference external" href="https://github.com/OCA/mis-builder/issues/296">#296</a></li>
 </ul>
 </div>
-<div class="section" id="section-17">
-<h3><a class="toc-backref" href="#toc-entry-25">13.0.3.6.2 (2020-04-22)</a></h3>
+<div class="section" id="section-18">
+<h3><a class="toc-backref" href="#toc-entry-27">13.0.3.6.2 (2020-04-22)</a></h3>
 <p><strong>Bugfixes</strong></p>
 <ul class="simple">
 <li>The “Settings” button is now displayed for users with the “Show full
@@ -725,16 +741,16 @@ accounting features” right when previewing a report.
 (<a class="reference external" href="https://github.com/OCA/mis-builder/issues/281">#281</a>)</li>
 </ul>
 </div>
-<div class="section" id="section-18">
-<h3><a class="toc-backref" href="#toc-entry-26">13.0.3.6.1 (2020-04-22)</a></h3>
+<div class="section" id="section-19">
+<h3><a class="toc-backref" href="#toc-entry-28">13.0.3.6.1 (2020-04-22)</a></h3>
 <p><strong>Bugfixes</strong></p>
 <ul class="simple">
 <li>Fix <tt class="docutils literal">TypeError: 'module' object is not iterable</tt> when using budgets
 by account. (<a class="reference external" href="https://github.com/OCA/mis-builder/issues/276">#276</a>)</li>
 </ul>
 </div>
-<div class="section" id="section-19">
-<h3><a class="toc-backref" href="#toc-entry-27">13.0.3.6.0 (2020-03-28)</a></h3>
+<div class="section" id="section-20">
+<h3><a class="toc-backref" href="#toc-entry-29">13.0.3.6.0 (2020-03-28)</a></h3>
 <p><strong>Features</strong></p>
 <ul class="simple">
 <li>Add column-level filters on analytic account and analytic tags. These
@@ -752,12 +768,12 @@ balance_sheet.total_assets).
 (<a class="reference external" href="https://github.com/OCA/mis-builder/issues/155">#155</a>)</li>
 </ul>
 </div>
-<div class="section" id="section-20">
-<h3><a class="toc-backref" href="#toc-entry-28">13.0.3.5.0 (2020-01-??)</a></h3>
+<div class="section" id="section-21">
+<h3><a class="toc-backref" href="#toc-entry-30">13.0.3.5.0 (2020-01-??)</a></h3>
 <p>Migration to odoo 13.0.</p>
 </div>
-<div class="section" id="section-21">
-<h3><a class="toc-backref" href="#toc-entry-29">12.0.3.5.0 (2019-10-26)</a></h3>
+<div class="section" id="section-22">
+<h3><a class="toc-backref" href="#toc-entry-31">12.0.3.5.0 (2019-10-26)</a></h3>
 <p><strong>Features</strong></p>
 <ul class="simple">
 <li>The <tt class="docutils literal">account_id</tt> field of the model selected in ‘Move lines source’
@@ -796,8 +812,8 @@ replacing it with %.
 (<a class="reference external" href="https://github.com/oca/mis-builder/issues/220">#220</a>)</li>
 </ul>
 </div>
-<div class="section" id="section-22">
-<h3><a class="toc-backref" href="#toc-entry-30">12.0.3.4.0 (2019-07-09)</a></h3>
+<div class="section" id="section-23">
+<h3><a class="toc-backref" href="#toc-entry-32">12.0.3.4.0 (2019-07-09)</a></h3>
 <p><strong>Features</strong></p>
 <ul class="simple">
 <li>New year-to-date mode for defining periods.
@@ -821,8 +837,8 @@ non-multi expressions yield tuples of incorrect lenght.
 (<a class="reference external" href="https://github.com/oca/mis-builder/issues/192">#192</a>)</li>
 </ul>
 </div>
-<div class="section" id="section-23">
-<h3><a class="toc-backref" href="#toc-entry-31">12.0.3.3.0 (2019-01-26)</a></h3>
+<div class="section" id="section-24">
+<h3><a class="toc-backref" href="#toc-entry-33">12.0.3.3.0 (2019-01-26)</a></h3>
 <p><strong>Features</strong></p>
 <p><em>Dynamic analytic filters in report preview are not yet available in 11,
 this requires an update to the JS widget that proved difficult to
@@ -872,8 +888,8 @@ inherit” is checked, as for all other syle elements.
 analytic filters, the underlying model must now have an
 <tt class="docutils literal">analytic_account_id</tt> field.</p>
 </div>
-<div class="section" id="section-24">
-<h3><a class="toc-backref" href="#toc-entry-32">11.0.3.2.2 (2018-06-30)</a></h3>
+<div class="section" id="section-25">
+<h3><a class="toc-backref" href="#toc-entry-34">11.0.3.2.2 (2018-06-30)</a></h3>
 <ul class="simple">
 <li>[FIX] Fix bug in company_default_get call returning id instead of
 recordset (<a class="reference external" href="https://github.com/OCA/mis-builder/pull/103">#103</a>)</li>
@@ -882,16 +898,16 @@ that serve as basis for other formulas, but do not need to be
 displayed). (<a class="reference external" href="https://github.com/OCA/mis-builder/issues/46">#46</a>)</li>
 </ul>
 </div>
-<div class="section" id="section-25">
-<h3><a class="toc-backref" href="#toc-entry-33">11.0.3.2.1 (2018-05-29)</a></h3>
+<div class="section" id="section-26">
+<h3><a class="toc-backref" href="#toc-entry-35">11.0.3.2.1 (2018-05-29)</a></h3>
 <ul class="simple">
 <li>[FIX] Missing comparison operator for AccountingNone leading to errors
 in pbal computations
 (<a class="reference external" href="https://github.com/OCA/mis-builder/issue/93">#93</a>)</li>
 </ul>
 </div>
-<div class="section" id="section-26">
-<h3><a class="toc-backref" href="#toc-entry-34">10.0.3.2.0 (2018-05-02)</a></h3>
+<div class="section" id="section-27">
+<h3><a class="toc-backref" href="#toc-entry-36">10.0.3.2.0 (2018-05-02)</a></h3>
 <ul class="simple">
 <li>[FIX] make subkpi ordering deterministic
 (<a class="reference external" href="https://github.com/OCA/mis-builder/issues/71">#71</a>)</li>
@@ -905,13 +921,13 @@ resp positive balances)
 (<a class="reference external" href="https://github.com/OCA/mis-builder/issues/86">#86</a>)</li>
 </ul>
 </div>
-<div class="section" id="section-27">
-<h3><a class="toc-backref" href="#toc-entry-35">11.0.3.1.2 (2018-02-04)</a></h3>
+<div class="section" id="section-28">
+<h3><a class="toc-backref" href="#toc-entry-37">11.0.3.1.2 (2018-02-04)</a></h3>
 <p>Migration to Odoo 11. No new feature.
 (<a class="reference external" href="https://github.com/OCA/mis-builder/pull/67">#67</a>)</p>
 </div>
-<div class="section" id="section-28">
-<h3><a class="toc-backref" href="#toc-entry-36">10.0.3.1.1 (2017-11-14)</a></h3>
+<div class="section" id="section-29">
+<h3><a class="toc-backref" href="#toc-entry-38">10.0.3.1.1 (2017-11-14)</a></h3>
 <p>New features:</p>
 <ul class="simple">
 <li>[ADD] month and year relative periods, easier to use than date ranges
@@ -948,24 +964,24 @@ created (not yet saved) report instances.
 <li>Alternative move line data sources must have a company_id field.</li>
 </ul>
 </div>
-<div class="section" id="section-29">
-<h3><a class="toc-backref" href="#toc-entry-37">10.0.3.0.4 (2017-10-14)</a></h3>
+<div class="section" id="section-30">
+<h3><a class="toc-backref" href="#toc-entry-39">10.0.3.0.4 (2017-10-14)</a></h3>
 <p>Bug fix:</p>
 <ul class="simple">
 <li>[FIX] issue with initial balance rounding.
 <a class="reference external" href="https://github.com/OCA/mis-builder/issues/30">#30</a></li>
 </ul>
 </div>
-<div class="section" id="section-30">
-<h3><a class="toc-backref" href="#toc-entry-38">10.0.3.0.3 (2017-10-03)</a></h3>
+<div class="section" id="section-31">
+<h3><a class="toc-backref" href="#toc-entry-40">10.0.3.0.3 (2017-10-03)</a></h3>
 <p>Bug fix:</p>
 <ul class="simple">
 <li>[FIX] fix error saving KPI on newly created reports.
 <a class="reference external" href="https://github.com/OCA/mis-builder/issues/18">#18</a></li>
 </ul>
 </div>
-<div class="section" id="section-31">
-<h3><a class="toc-backref" href="#toc-entry-39">10.0.3.0.2 (2017-10-01)</a></h3>
+<div class="section" id="section-32">
+<h3><a class="toc-backref" href="#toc-entry-41">10.0.3.0.2 (2017-10-01)</a></h3>
 <p>New features:</p>
 <ul class="simple">
 <li>[ADD] Alternative move line source per report column. This makes mis
@@ -1010,7 +1026,7 @@ user</li>
 </ul>
 </div>
 <div class="section" id="unreleased">
-<h3><a class="toc-backref" href="#toc-entry-40">10.0.2.0.3 (unreleased)</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-42">10.0.2.0.3 (unreleased)</a></h3>
 <ul class="simple">
 <li>[IMP] more robust behaviour in presence of missing expressions</li>
 <li>[FIX] indent style</li>
@@ -1022,24 +1038,24 @@ generating reports with no objects</li>
 <li>[IMP] provide full access to mis builder style for group Adviser.</li>
 </ul>
 </div>
-<div class="section" id="section-32">
-<h3><a class="toc-backref" href="#toc-entry-41">9.0.2.0.2 (2016-09-27)</a></h3>
+<div class="section" id="section-33">
+<h3><a class="toc-backref" href="#toc-entry-43">9.0.2.0.2 (2016-09-27)</a></h3>
 <ul class="simple">
 <li>[IMP] Add refresh button in mis report preview.</li>
 <li>[IMP] Widget code changes to allow to add fields in the widget more
 easily.</li>
 </ul>
 </div>
-<div class="section" id="section-33">
-<h3><a class="toc-backref" href="#toc-entry-42">9.0.2.0.1 (2016-05-26)</a></h3>
+<div class="section" id="section-34">
+<h3><a class="toc-backref" href="#toc-entry-44">9.0.2.0.1 (2016-05-26)</a></h3>
 <ul class="simple">
 <li>[IMP] remove unused argument in declare_and_compute_period() for a
 cleaner API. This is a breaking API changing merged in urgency before
 it is used by other modules.</li>
 </ul>
 </div>
-<div class="section" id="section-34">
-<h3><a class="toc-backref" href="#toc-entry-43">9.0.2.0.0 (2016-05-24)</a></h3>
+<div class="section" id="section-35">
+<h3><a class="toc-backref" href="#toc-entry-45">9.0.2.0.0 (2016-05-24)</a></h3>
 <p>Part of the work for this release has been done at the Sorrento sprint
 April 26-29, 2016. The rest (ie a major refactoring) has been done in
 the weeks after.</p>
@@ -1087,8 +1103,8 @@ flexible alternative to fiscal periods</li>
 consolidation accounts have been removed</li>
 </ul>
 </div>
-<div class="section" id="section-35">
-<h3><a class="toc-backref" href="#toc-entry-44">8.0.1.0.0 (2016-04-27)</a></h3>
+<div class="section" id="section-36">
+<h3><a class="toc-backref" href="#toc-entry-46">8.0.1.0.0 (2016-04-27)</a></h3>
 <ul class="simple">
 <li>The copy of a MIS Report Instance now copies period.
 <a class="reference external" href="https://github.com/OCA/account-financial-reporting/pull/181">https://github.com/OCA/account-financial-reporting/pull/181</a></li>
@@ -1112,13 +1128,13 @@ previews. <a class="reference external" href="https://github.com/OCA/account-fin
 <a class="reference external" href="https://github.com/OCA/account-financial-reporting/pull/131">https://github.com/OCA/account-financial-reporting/pull/131</a></li>
 </ul>
 </div>
-<div class="section" id="section-36">
-<h3><a class="toc-backref" href="#toc-entry-45">8.0.0.2.0</a></h3>
+<div class="section" id="section-37">
+<h3><a class="toc-backref" href="#toc-entry-47">8.0.0.2.0</a></h3>
 <p>Pre-history. Or rather, you need to look at the git log.</p>
 </div>
 </div>
 <div class="section" id="bug-tracker">
-<h2><a class="toc-backref" href="#toc-entry-46">Bug Tracker</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-48">Bug Tracker</a></h2>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/mis-builder/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -1126,15 +1142,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h2><a class="toc-backref" href="#toc-entry-47">Credits</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-49">Credits</a></h2>
 <div class="section" id="authors">
-<h3><a class="toc-backref" href="#toc-entry-48">Authors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-50">Authors</a></h3>
 <ul class="simple">
 <li>ACSONE SA/NV</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h3><a class="toc-backref" href="#toc-entry-49">Contributors</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-51">Contributors</a></h3>
 <ul class="simple">
 <li>Stéphane Bidoul &lt;<a class="reference external" href="mailto:stephane.bidoul&#64;acsone.eu">stephane.bidoul&#64;acsone.eu</a>&gt;</li>
 <li>Laetitia Gangloff &lt;<a class="reference external" href="mailto:laetitia.gangloff&#64;acsone.eu">laetitia.gangloff&#64;acsone.eu</a>&gt;</li>
@@ -1169,7 +1185,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h3><a class="toc-backref" href="#toc-entry-50">Maintainers</a></h3>
+<h3><a class="toc-backref" href="#toc-entry-52">Maintainers</a></h3>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/mis_builder/tests/__init__.py
+++ b/mis_builder/tests/__init__.py
@@ -16,3 +16,4 @@ from . import test_simple_array
 from . import test_target_move
 from . import test_utc_midnight
 from . import test_mis_report_instance_annotation
+from . import test_partner_detail

--- a/mis_builder/tests/test_partner_detail.py
+++ b/mis_builder/tests/test_partner_detail.py
@@ -1,0 +1,150 @@
+# Copyright 2026 Odoo Community Association (OCA)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+import odoo.tests.common as common
+from odoo import Command
+
+from ..models.mis_report import DETAIL_PARTNER
+
+
+class TestMisReportPartnerDetail(common.TransactionCase):
+    """Test KPI expansion by partner."""
+
+    def _create_move(self, date, amount, debit_acc, credit_acc, partner):
+        move = self.move_model.create(
+            {
+                "journal_id": self.journal.id,
+                "date": date,
+                "partner_id": partner.id if partner else False,
+                "line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "/",
+                            "debit": amount,
+                            "account_id": debit_acc.id,
+                            "partner_id": partner.id if partner else False,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "/",
+                            "credit": amount,
+                            "account_id": credit_acc.id,
+                            "partner_id": partner.id if partner else False,
+                        },
+                    ),
+                ],
+            }
+        )
+        move._post()
+        return move
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env["res.company"].create({"name": "Partner Detail Co"})
+        cls.env.user.company_id = cls.company
+
+    def setUp(self):
+        super().setUp()
+        self.account_model = self.env["account.account"]
+        self.move_model = self.env["account.move"]
+        self.journal_model = self.env["account.journal"]
+        self.partner_a = self.env["res.partner"].create({"name": "Customer A"})
+        self.partner_b = self.env["res.partner"].create({"name": "Customer B"})
+        self.account_ar = self.account_model.create(
+            {
+                "company_ids": [Command.link(self.company.id)],
+                "code": "400AR",
+                "name": "Receivable",
+                "account_type": "asset_receivable",
+                "reconcile": True,
+            }
+        )
+        self.account_in = self.account_model.create(
+            {
+                "company_ids": [Command.link(self.company.id)],
+                "code": "700IN",
+                "name": "Income",
+                "account_type": "income",
+            }
+        )
+        self.journal = self.journal_model.create(
+            {
+                "company_id": self.company.id,
+                "name": "Sale journal",
+                "code": "VEN",
+                "type": "sale",
+            }
+        )
+        self._create_move(
+            "2017-01-10", 10, self.account_ar, self.account_in, self.partner_a
+        )
+        self._create_move(
+            "2017-01-20", 7, self.account_ar, self.account_in, self.partner_b
+        )
+        self._create_move("2017-01-25", 3, self.account_ar, self.account_in, False)
+
+        self.report = self.env["mis.report"].create({"name": "partner detail report"})
+        self.kpi = self.env["mis.report.kpi"].create(
+            {
+                "report_id": self.report.id,
+                "name": "ar",
+                "description": "Receivable",
+                "expression": "bale[400AR]",
+                "detail_by": DETAIL_PARTNER,
+            }
+        )
+        self.instance = self.env["mis.report.instance"].create(
+            {
+                "name": "partner detail instance",
+                "report_id": self.report.id,
+                "comparison_mode": False,
+                "date_from": "2017-01-01",
+                "date_to": "2017-01-31",
+            }
+        )
+
+    def test_auto_expand_accounts_compat(self):
+        kpi = self.env["mis.report.kpi"].create(
+            {
+                "report_id": self.report.id,
+                "name": "legacy",
+                "description": "Legacy",
+                "expression": "AccountingNone",
+                "auto_expand_accounts": True,
+            }
+        )
+        self.assertEqual(kpi.detail_by, "account")
+        self.assertTrue(kpi.auto_expand_accounts)
+
+    def test_partner_detail_rows(self):
+        matrix = self.instance._compute_matrix()
+        rows = list(matrix.iter_rows())
+        # parent KPI + 3 partner detail rows (A, B, no partner)
+        self.assertEqual(len(rows), 4)
+        self.assertIsNone(rows[0].detail_id)
+        by_partner = {r.detail_id: r for r in rows[1:]}
+        self.assertEqual(set(by_partner), {self.partner_a.id, self.partner_b.id, 0})
+
+        def cell_val(row):
+            return next(c for c in row.iter_cells() if c).val
+
+        self.assertEqual(cell_val(rows[0]), 20)
+        self.assertEqual(cell_val(by_partner[self.partner_a.id]), 10)
+        self.assertEqual(cell_val(by_partner[self.partner_b.id]), 7)
+        self.assertEqual(cell_val(by_partner[0]), 3)
+
+    def test_drilldown_partner(self):
+        matrix = self.instance._compute_matrix()
+        detail_row = next(
+            r for r in matrix.iter_rows() if r.detail_id == self.partner_a.id
+        )
+        cell = next(c for c in detail_row.iter_cells() if c)
+        action = self.instance.drilldown(cell.drilldown_arg)
+        self.assertEqual(action["res_model"], "account.move.line")
+        self.assertIn(("partner_id", "=", self.partner_a.id), action["domain"])

--- a/mis_builder/views/mis_report.xml
+++ b/mis_builder/views/mis_report.xml
@@ -163,10 +163,11 @@
                             />
                         </group>
                         <group col="4" string="Auto expand">
-                            <field name="auto_expand_accounts" />
+                            <field name="detail_by" />
+                            <field name="auto_expand_accounts" invisible="1" />
                             <field
                                 name="auto_expand_accounts_style_id"
-                                invisible="auto_expand_accounts != True"
+                                invisible="detail_by == 'none'"
                             />
                         </group>
                     </page>


### PR DESCRIPTION
## Summary
- Add KPI `detail_by` selection (`none` / `account` / `partner`) so report rows can expand one line per partner, not only per account.
- Keep `auto_expand_accounts` as a stored compute/inverse for backward compatibility, with a post-migration mapping existing flags to `detail_by=account`.
- Extend AEP/evaluator/matrix/drilldown for partner-level queries (sentinel `0` = empty partner).

## Test plan
- [ ] Install/upgrade `mis_builder` to `19.0.1.1.0` and confirm KPIs with `auto_expand_accounts` still expand by account
- [ ] Create a KPI with `detail_by=partner` on receivable/payable expressions and verify one row per partner (+ “(No partner)” when empty)
- [ ] Drilldown from a partner detail cell and confirm domain includes `partner_id`
- [ ] Run `mis_builder.tests.test_partner_detail` and existing auto-expand tests (`test_data_sources`)


Made with [Cursor](https://cursor.com)