### PR TITLE
[19.0][FIX] mis_builder: extend the MIS Builder menu in accounting to the Accounting Read Only group

### DIFF
--- a/mis_builder/views/mis_report_instance.xml
+++ b/mis_builder/views/mis_report_instance.xml
@@ -225,7 +225,7 @@
         parent="account.menu_finance_reports"
         name="MIS Reporting"
         sequence="101"
-        groups="account.group_account_manager"
+        groups="account.group_account_readonly"
     />
     <menuitem
         id="mis_report_instance_view_menu"


### PR DESCRIPTION
FWP from 18.0: https://github.com/OCA/mis-builder/pull/822

Define the appropriate group in the menu

A user with the "Show Accounting Features - Read-only" group (`account.group_account_readonly`) should be able to view the menu

Please @pedrobaeza can you review it?

@Tecnativa TT63708
