### PR TITLE
[18.0][FIX] mis_builder: add to dashboard permission

### DIFF
--- a/mis_builder/models/__init__.py
+++ b/mis_builder/models/__init__.py
@@ -1,6 +1,7 @@
 # Copyright 2014 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
+from . import ir_actions
 from . import mis_report
 from . import mis_report_subreport
 from . import mis_report_instance

--- a/mis_builder/models/ir_actions.py
+++ b/mis_builder/models/ir_actions.py
@@ -1,0 +1,30 @@
+# Copyright 2026 Ecosoft
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models
+from odoo.osv import expression
+
+
+class IrActionsActWindow(models.Model):
+    _inherit = "ir.actions.act_window"
+
+    @api.model
+    def _mis_builder_dashboard_domain(self):
+        return [
+            ("res_model", "=", "board.board"),
+            ("view_id", "!=", False),
+            "|",
+            ("groups_id", "=", False),
+            ("groups_id", "in", self.env.user._get_group_ids()),
+        ]
+
+    @api.model
+    def name_search(self, name="", args=None, operator="ilike", limit=100):
+        if not self.env.context.get("mis_builder_dashboard_selection"):
+            return super().name_search(name, args, operator, limit)
+        domain = expression.AND([self._mis_builder_dashboard_domain(), args or []])
+        # Window actions are technical records that regular users cannot read.
+        # Sudo only this selector and keep the available actions tightly scoped.
+        return super(IrActionsActWindow, self.sudo()).name_search(
+            name, domain, operator, limit
+        )

--- a/mis_builder/tests/__init__.py
+++ b/mis_builder/tests/__init__.py
@@ -6,6 +6,7 @@ from . import test_aep
 from . import test_multi_company_aep
 from . import test_aggregate
 from . import test_data_sources
+from . import test_dashboard
 from . import test_kpi_data
 from . import test_mis_report_instance
 from . import test_mis_safe_eval

--- a/mis_builder/tests/test_dashboard.py
+++ b/mis_builder/tests/test_dashboard.py
@@ -1,0 +1,88 @@
+# Copyright 2026 Ecosoft Co., Ltd. (https://ecosoft.co.th)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from lxml import etree
+
+from odoo.exceptions import AccessError, ValidationError
+from odoo.tests.common import TransactionCase, new_test_user
+
+
+class TestMisReportDashboard(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user = new_test_user(cls.env, "mis_dashboard_user")
+        cls.report = cls.env["mis.report"].create({"name": "Dashboard report"})
+        cls.report_instance = cls.env["mis.report.instance"].create(
+            {
+                "name": "Dashboard report instance",
+                "report_id": cls.report.id,
+                "company_id": cls.env.company.id,
+            }
+        )
+        cls.dashboard = cls.env.ref("board.open_board_my_dash_action")
+        cls.wizard_model = cls.env[
+            "add.mis.report.instance.dashboard.wizard"
+        ].with_user(cls.user)
+        cls.context = {
+            "active_model": "mis.report.instance",
+            "active_id": cls.report_instance.id,
+        }
+
+    def test_regular_user_can_add_report_to_dashboard(self):
+        with self.assertRaises(AccessError):
+            self.env["ir.actions.act_window"].with_user(self.user).check_access("read")
+
+        wizard_model = self.wizard_model.with_context(**self.context)
+        defaults = wizard_model.default_get(["name", "dashboard_id"])
+        self.assertEqual(defaults["dashboard_id"], self.dashboard.id)
+        selections = (
+            self.env["ir.actions.act_window"]
+            .with_user(self.user)
+            .with_context(mis_builder_dashboard_selection=True)
+            .name_search(args=[("res_model", "=", "board.board")])
+        )
+        self.assertIn((self.dashboard.id, self.dashboard.display_name), selections)
+        wizard = wizard_model.create(defaults)
+        values = wizard.web_read({"dashboard_id": {"fields": {"display_name": {}}}})
+        self.assertEqual(values[0]["dashboard_id"]["id"], self.dashboard.id)
+
+        self.assertEqual(
+            wizard.action_add_to_dashboard(), {"type": "ir.actions.act_window_close"}
+        )
+        customization = (
+            self.env["ir.ui.view.custom"]
+            .sudo()
+            .search(
+                [
+                    ("user_id", "=", self.user.id),
+                    ("ref_id", "=", self.dashboard.view_id.id),
+                ],
+                limit=1,
+            )
+        )
+        self.assertTrue(customization)
+        action_nodes = etree.fromstring(customization.arch).xpath("//action")
+        self.assertEqual(action_nodes[-1].get("string"), self.report_instance.name)
+
+    def test_regular_user_cannot_use_restricted_dashboard_action(self):
+        restricted_dashboard = self.env["ir.actions.act_window"].create(
+            {
+                "name": "Restricted dashboard",
+                "res_model": "board.board",
+                "view_mode": "form",
+                "view_id": self.dashboard.view_id.id,
+                "groups_id": [(6, 0, [self.env.ref("base.group_system").id])],
+            }
+        )
+        wizard = self.env["add.mis.report.instance.dashboard.wizard"].create(
+            {
+                "name": self.report_instance.name,
+                "dashboard_id": restricted_dashboard.id,
+            }
+        )
+
+        with self.assertRaises(ValidationError):
+            wizard.with_user(self.user).with_context(
+                **self.context
+            ).action_add_to_dashboard()

--- a/mis_builder/wizard/mis_builder_dashboard.py
+++ b/mis_builder/wizard/mis_builder_dashboard.py
@@ -5,6 +5,7 @@
 from lxml import etree
 
 from odoo import api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class AddMisReportInstanceDashboard(models.TransientModel):
@@ -14,11 +15,40 @@ class AddMisReportInstanceDashboard(models.TransientModel):
     name = fields.Char(required=True)
 
     dashboard_id = fields.Many2one(
-        "ir.actions.act_window",
-        string="Dashboard",
+        comodel_name="ir.actions.act_window",
         required=True,
         domain="[('res_model', '=', 'board.board')]",
+        context={"mis_builder_dashboard_selection": True},
+        default=lambda self: self._default_dashboard_id(),
     )
+
+    @api.model
+    def _dashboard_domain(self):
+        return self.env["ir.actions.act_window"]._mis_builder_dashboard_domain()
+
+    @api.model
+    def _default_dashboard_id(self):
+        dashboard = self.env.ref("board.open_board_my_dash_action", False)
+        if dashboard and dashboard.sudo().filtered_domain(self._dashboard_domain()):
+            return dashboard.id
+        return False
+
+    def _get_dashboard(self):
+        self.ensure_one()
+        dashboard_id = self.sudo().dashboard_id.id
+        dashboard = (
+            self.env["ir.actions.act_window"]
+            .sudo()
+            .search(
+                [("id", "=", dashboard_id), *self._dashboard_domain()],
+                limit=1,
+            )
+        )
+        if not dashboard:
+            raise ValidationError(
+                self.env._("The selected dashboard is not available to your user.")
+            )
+        return dashboard
 
     @api.model
     def default_get(self, fields_list):
@@ -38,6 +68,7 @@ class AddMisReportInstanceDashboard(models.TransientModel):
         assert active_model == "mis.report.instance"
         active_id = self.env.context.get("active_id")
         assert active_id
+        dashboard = self._get_dashboard()
         # create the act_window corresponding to this report
         self.env.ref("mis_builder.mis_report_instance_result_view_form")
         view = self.env.ref("mis_builder.mis_report_instance_result_view_form")
@@ -58,14 +89,15 @@ class AddMisReportInstanceDashboard(models.TransientModel):
             )
         )
         # add this result in the selected dashboard
-        last_customization = self.env["ir.ui.view.custom"].search(
+        custom_views = self.env["ir.ui.view.custom"].sudo()
+        last_customization = custom_views.search(
             [
                 ("user_id", "=", self.env.uid),
-                ("ref_id", "=", self.dashboard_id.view_id.id),
+                ("ref_id", "=", dashboard.view_id.id),
             ],
             limit=1,
         )
-        arch = self.dashboard_id.view_id.arch
+        arch = dashboard.view_id.arch
         if last_customization:
             arch = last_customization[0].arch
         new_arch = etree.fromstring(arch)
@@ -84,10 +116,10 @@ class AddMisReportInstanceDashboard(models.TransientModel):
                 },
             )
         )
-        self.env["ir.ui.view.custom"].create(
+        custom_views.create(
             {
                 "user_id": self.env.uid,
-                "ref_id": self.dashboard_id.view_id.id,
+                "ref_id": dashboard.view_id.id,
                 "arch": etree.tostring(new_arch, pretty_print=True),
             }
         )


### PR DESCRIPTION
## Description

Step to reproduce:
1. Create new user accountant (without admin access)
2. Go to Invoicing > Reporting > MIS Reports
3. Click Add to dashboard (it required Dashboard field but when we select it will error permission)
<img width="1700" height="427" alt="selection_680" src="https://github.com/user-attachments/assets/68cb041f-d5fb-4947-be6d-174d3f9f9365" />


## Target branch

Version 18
