### PR TITLE
[19.0][IMP] mis_builder: Preserve filters and pivot date on report drilldown

### DIFF
--- a/mis_builder/__manifest__.py
+++ b/mis_builder/__manifest__.py
@@ -39,6 +39,9 @@
         "web.report_assets_common": [
             "mis_builder/static/src/scss/report.scss",
         ],
+        "web.assets_tests": [
+            "mis_builder/static/tests/tours/mis_report_drilldown_tour.esm.js",
+        ],
     },
     "qweb": ["static/src/xml/mis_report_widget.xml"],
     "installable": True,

--- a/mis_builder/static/description/index.html
+++ b/mis_builder/static/description/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="generator" content="Docutils: https://docutils.sourceforge.io/" />
-<title>README.rst</title>
+<title>MIS Builder</title>
 <style type="text/css">
 
 /*

--- a/mis_builder/static/src/components/mis_report_widget.esm.js
+++ b/mis_builder/static/src/components/mis_report_widget.esm.js
@@ -1,36 +1,64 @@
 import {Component, onMounted, onWillStart, useState, useSubEnv} from "@odoo/owl";
+import {parseDate, serializeDate} from "@web/core/l10n/dates";
 import {useBus, useService} from "@web/core/utils/hooks";
+import {AnnotationDialog} from "../annotation_dialog/annotation_dialog.esm";
 import {DateTimeInput} from "@web/core/datetime/datetime_input";
+import {FormController} from "@web/views/form/form_controller";
 import {SearchBar} from "@web/search/search_bar/search_bar";
 import {SearchModel} from "@web/search/search_model";
-import {parseDate} from "@web/core/l10n/dates";
-import {registry} from "@web/core/registry";
-import {AnnotationDialog} from "../annotation_dialog/annotation_dialog.esm";
 import {_t} from "@web/core/l10n/translation";
+import {patch} from "@web/core/utils/patch";
+import {registry} from "@web/core/registry";
+import {useSetupAction} from "@web/search/action_hook";
+
+// Patch FormController to forward restored controller state to env.config
+// for mis.report.instance form views.
+// When returning from drilldown via breadcrumbs, ActionService restores FormController
+// and passes saved exportedState via props.state. FormController does not propagate
+// props.state to env.config.state by default, so patching it here ensures child components
+// (like MisReportWidget) can access searchState in willStart() during view restoration.
+patch(FormController.prototype, {
+    setup() {
+        super.setup();
+        if (this.props.state && this.props.resModel === "mis.report.instance") {
+            this.env.config.state = this.props.state;
+        }
+    },
+});
 
 export class MisReportWidget extends Component {
     setup() {
         super.setup();
-        this.orm = useService("orm");
         this.action = useService("action");
-        this.view = useService("view");
+        this.orm = useService("orm");
         this.dialog = useService("dialog");
+        this.notification = useService("notification");
+        this.view = useService("view");
         this.JSON = JSON;
+
         this.state = useState({
-            mis_report_data: {header: [], body: [], notes: {}},
+            mis_report_data: null,
             pivot_date: null,
             can_edit_annotation: false,
-            can_read_annotation: false,
         });
+
         this.searchModel = new SearchModel(this.env, {
             orm: this.orm,
             view: this.view,
             dialog: this.dialog,
         });
         useSubEnv({searchModel: this.searchModel});
-        useBus(this.env.searchModel, "update", async () => {
-            await this.env.searchModel.sectionsPromise;
+        useBus(this.searchModel, "update", async () => {
+            await this.searchModel.sectionsPromise;
             this.refresh();
+        });
+        useSetupAction({
+            getLocalState: () => ({
+                searchState: this.searchModel ? this.searchModel.exportState() : null,
+                pivotDate: this.state.pivot_date
+                    ? serializeDate(this.state.pivot_date)
+                    : null,
+            }),
         });
         onWillStart(this.willStart);
 
@@ -39,6 +67,15 @@ export class MisReportWidget extends Component {
 
     // Lifecycle
     async willStart() {
+        const state =
+            this.props.state ||
+            this.env.config?.state ||
+            this.action.currentController?.props?.state ||
+            this.action.currentController?.exportedState;
+
+        const searchState = state?.searchState;
+        const pivotDateStr = state?.pivotDate;
+
         const [result] = await this.orm.read(
             "mis.report.instance",
             [this._instanceId()],
@@ -60,15 +97,20 @@ export class MisReportWidget extends Component {
         this.widget_show_filters = result.widget_show_filters;
         this.widget_show_settings_button = result.widget_show_settings_button;
         this.widget_search_view_id = result.widget_search_view_id?.[0];
-        this.state.pivot_date = parseDate(result.pivot_date);
+        this.state.pivot_date = pivotDateStr
+            ? parseDate(pivotDateStr)
+            : parseDate(result.pivot_date);
         this.widget_show_pivot_date = result.widget_show_pivot_date;
 
         if (this.showSearchBar) {
-            // Initialize the search model
-            await this.searchModel.load({
+            const config = {
                 resModel: this.source_aml_model_name,
                 searchViewId: this.widget_search_view_id,
-            });
+            };
+            if (searchState) {
+                config.state = searchState;
+            }
+            await this.searchModel.load(config);
         }
 
         this.wide_display = result.wide_display_by_default;
@@ -105,6 +147,9 @@ export class MisReportWidget extends Component {
         if (this.props.value) {
             return this.props.value;
         }
+        if (this.props.record?.resId) {
+            return this.props.record.resId;
+        }
 
         /*
          * This trick is needed because in a dashboard the view does
@@ -112,7 +157,7 @@ export class MisReportWidget extends Component {
          * of Odoo dashboards that are not designed to contain forms but
          * rather tree views or charts.
          */
-        const context = this.props.record.context;
+        const context = this.props.record?.context || {};
         if (context.active_model === "mis.report.instance") {
             return context.active_id;
         }
@@ -130,6 +175,15 @@ export class MisReportWidget extends Component {
     }
 
     async drilldown(event) {
+        if (this.action.currentController) {
+            this.action.currentController.exportedState = {
+                ...(this.action.currentController.exportedState || {}),
+                searchState: this.searchModel ? this.searchModel.exportState() : null,
+                pivotDate: this.state.pivot_date
+                    ? serializeDate(this.state.pivot_date)
+                    : null,
+            };
+        }
         const drilldown = JSON.parse(event.target.dataset.drilldown);
         const action = await this.orm.call(
             "mis.report.instance",
@@ -232,6 +286,9 @@ export class MisReportWidget extends Component {
 
     onDateTimeChanged(ev) {
         this.state.pivot_date = ev;
+        if (this.props.record) {
+            this.props.record._misReportPivotDate = serializeDate(ev);
+        }
         this.refresh();
     }
 
@@ -242,13 +299,13 @@ export class MisReportWidget extends Component {
 
     async resize_sheet() {
         var sheet_element = document.getElementsByClassName("o_form_sheet_bg")[0];
-        sheet_element.classList.toggle(
+        sheet_element?.classList.toggle(
             "oe_mis_builder_report_wide_sheet",
             this.wide_display
         );
         var button_resize_element = document.getElementById("icon_resize");
-        button_resize_element.classList.toggle("fa-expand", !this.wide_display);
-        button_resize_element.classList.toggle("fa-compress", this.wide_display);
+        button_resize_element?.classList.toggle("fa-expand", !this.wide_display);
+        button_resize_element?.classList.toggle("fa-compress", this.wide_display);
     }
 }
 

--- a/mis_builder/static/tests/tours/mis_report_drilldown_tour.esm.js
+++ b/mis_builder/static/tests/tours/mis_report_drilldown_tour.esm.js
@@ -1,0 +1,32 @@
+import {registry} from "@web/core/registry";
+
+registry.category("web_tour.tours").add("mis_report_drilldown_tour", {
+    steps: () => [
+        {
+            trigger: ".o_searchview_input",
+            run: "edit Line",
+        },
+        {
+            trigger:
+                ".o_searchview_autocomplete .dropdown-item, .o_searchview_autocomplete a",
+            run: "click",
+        },
+        {
+            trigger: ".o_searchview_facet",
+        },
+        {
+            trigger: "a.mis_builder_drilldown",
+            run: "click",
+        },
+        {
+            trigger: ".o_list_renderer, .o_list_view",
+        },
+        {
+            trigger: ".breadcrumb .breadcrumb-item a, .breadcrumb .o_back_button",
+            run: "click",
+        },
+        {
+            trigger: ".o_searchview_facet",
+        },
+    ],
+});

--- a/mis_builder/tests/test_mis_report_widget_tour.py
+++ b/mis_builder/tests/test_mis_report_widget_tour.py
@@ -1,0 +1,122 @@
+# Copyright 2026 APyCOD (<https://apycod.com>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+import odoo.tests.common as common
+from odoo.tests import tagged
+
+
+@tagged("at_install", "post_install")
+class TestMisReportWidgetTour(common.HttpCase):
+    def setUp(self):
+        super().setUp()
+        aml_model_id = self.env.ref("account.model_account_move_line").id
+        aml_date_field_id = self.env.ref("account.field_account_move_line__date").id
+        aml_debit_field_id = self.env.ref("account.field_account_move_line__debit").id
+
+        journal = self.env["account.journal"].search(
+            [("type", "=", "general")], limit=1
+        )
+        account = self.env["account.account"].search([("code", "!=", False)], limit=1)
+        account.name = "Line Account"
+
+        move = self.env["account.move"].create(
+            {
+                "journal_id": journal.id,
+                "date": "2026-06-01",
+                "line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "Line 1",
+                            "account_id": account.id,
+                            "debit": 100.0,
+                            "credit": 0.0,
+                            "date": "2026-06-01",
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "Line 2",
+                            "account_id": account.id,
+                            "debit": 0.0,
+                            "credit": 100.0,
+                            "date": "2026-06-01",
+                        },
+                    ),
+                ],
+            }
+        )
+        move.action_post()
+
+        self.report = self.env["mis.report"].create(
+            {
+                "name": "Test Drilldown Report",
+                "move_lines_source": aml_model_id,
+                "query_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "aml",
+                            "model_id": aml_model_id,
+                            "field_ids": [(4, aml_debit_field_id, None)],
+                            "date_field": aml_date_field_id,
+                            "aggregate": "sum",
+                        },
+                    )
+                ],
+                "kpi_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "kpi1",
+                            "description": "KPI 1",
+                            "expression": f"deb[{account.code}]",
+                            "type": "num",
+                            "sequence": 1,
+                        },
+                    )
+                ],
+            }
+        )
+
+        search_view = self.env.ref("account.view_account_move_line_filter")
+
+        self.report_instance = self.env["mis.report.instance"].create(
+            {
+                "name": "Test Instance Drilldown",
+                "report_id": self.report.id,
+                "widget_show_filters": True,
+                "widget_search_view_id": search_view.id,
+                "comparison_mode": True,
+                "pivot_date": "2026-06-01",
+                "date_from": "2026-01-01",
+                "date_to": "2026-12-31",
+                "period_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "2026",
+                            "mode": "fix",
+                            "manual_date_from": "2026-01-01",
+                            "manual_date_to": "2026-12-31",
+                        },
+                    )
+                ],
+            }
+        )
+
+    def test_mis_report_drilldown_tour(self):
+        view_id = self.env.ref("mis_builder.mis_report_instance_result_view_form").id
+        url = (
+            f"/web#id={self.report_instance.id}"
+            f"&model=mis.report.instance"
+            f"&view_type=form"
+            f"&view_id={view_id}"
+        )
+        self.start_tour(url, "mis_report_drilldown_tour", login="admin")


### PR DESCRIPTION
When navigating away from a MIS report via drilldown links and returning using the breadcrumb, active search filters and pivot date were lost.

This commit preserves the report widget state across view navigation:
- Register `useSetupAction` in `MisReportWidget` to export search model state and pivot date when leaving the controller.
- Forward `props.state` to `env.config.state` in `FormController` so that restored controller state is accessible during component `willStart`.
- Hydrate `searchModel` and `pivot_date` upon view restoration.
- Add JS tour `mis_report_drilldown_tour` and HttpCase test `TestMisReportWidgetTour` to validate filter preservation end-to-end.
