### PR TITLE
[19.0][IMP] mis_builder: Improve drilldown navigation with cache report support

### DIFF
--- a/mis_builder/README.rst
+++ b/mis_builder/README.rst
@@ -83,6 +83,18 @@ To configure this module, you need to:
   the group to read or the group to update annotations can see those
   annotations.
 
+- In the **Widget** tab of a MIS Report Instance, you can configure
+  interactive widget options:
+
+  - **Show filters box**: Displays an inline search bar to filter report
+    lines. Active search filters and pivot dates are preserved when
+    navigating to drilldown details and returning via breadcrumbs.
+  - **Cache report on drilldown**: Caches computed report data in
+    browser memory during drilldown navigation. Returning via
+    breadcrumbs renders the report instantly from memory without
+    triggering a new server computation. Modifying filters or pivot
+    dates automatically invalidates the cache and fetches fresh data.
+
 .. |image1| image:: https://raw.githubusercontent.com/OCA/mis-builder/10.0/mis_builder/static/description/ex_report_template.png
 .. |image2| image:: https://raw.githubusercontent.com/OCA/mis-builder/10.0/mis_builder/static/description/ex_report_settings.png
 .. |image3| image:: https://raw.githubusercontent.com/OCA/mis-builder/10.0/mis_builder/static/description/ex_report_preview.png
@@ -768,6 +780,7 @@ Contributors
 - Miquel Pascual <mpascual@apsl.net>
 - Antoni Marroig <amarroig@apsl.net>
 - Chau Le <chaulb@trobz.com>
+- Pierre Verkest <pierre@verkest.fr>
 
 Maintainers
 -----------

--- a/mis_builder/__manifest__.py
+++ b/mis_builder/__manifest__.py
@@ -41,6 +41,7 @@
         ],
         "web.assets_tests": [
             "mis_builder/static/tests/tours/mis_report_drilldown_tour.esm.js",
+            "mis_builder/static/tests/tours/mis_report_back_button_tour.esm.js",
         ],
     },
     "qweb": ["static/src/xml/mis_report_widget.xml"],

--- a/mis_builder/__manifest__.py
+++ b/mis_builder/__manifest__.py
@@ -39,6 +39,9 @@
         "web.report_assets_common": [
             "mis_builder/static/src/scss/report.scss",
         ],
+        "web.assets_tests": [
+            "mis_builder/static/tests/tours/mis_report_drilldown_tour.esm.js",
+        ],
     },
     "qweb": ["static/src/xml/mis_report_widget.xml"],
     "installable": True,

--- a/mis_builder/__manifest__.py
+++ b/mis_builder/__manifest__.py
@@ -42,6 +42,7 @@
         "web.assets_tests": [
             "mis_builder/static/tests/tours/mis_report_drilldown_tour.esm.js",
             "mis_builder/static/tests/tours/mis_report_back_button_tour.esm.js",
+            "mis_builder/static/tests/tours/mis_report_back_button_no_filters_tour.esm.js",
         ],
     },
     "qweb": ["static/src/xml/mis_report_widget.xml"],

--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -585,6 +585,15 @@ class MisReportInstance(models.Model):
         string="Show Pivot Date",
         help="Show the Pivot Date in the report widget filter bar.",
     )
+    widget_cache_report_on_drill_down = fields.Boolean(
+        default=False,
+        string="Cache report on drilldown",
+        help=(
+            "Cache computed report data in browser memory during drilldown "
+            "navigation to prevent recomputing the report when returning via "
+            "breadcrumbs."
+        ),
+    )
     widget_search_view_id = fields.Many2one(
         comodel_name="ir.ui.view",
         domain='[("type", "=", "search"), ("model", "=", source_aml_model_name)]',

--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -781,16 +781,12 @@ class MisReportInstance(models.Model):
 
     def preview(self):
         self.ensure_one()
-        view_id = self.env.ref("mis_builder.mis_report_instance_result_view_form")
-        return {
-            "type": "ir.actions.act_window",
-            "res_model": "mis.report.instance",
-            "res_id": self.id,
-            "view_mode": "form",
-            "view_id": view_id.id,
-            "target": "current",
-            "context": self.env.context,
-        }
+        action = self.env["ir.actions.actions"]._for_xml_id(
+            "mis_builder.mis_report_instance_preview_action"
+        )
+        action["res_id"] = self.id
+        action["context"] = self.env.context
+        return action
 
     def print_pdf(self):
         self.ensure_one()

--- a/mis_builder/readme/CONTRIBUTORS.md
+++ b/mis_builder/readme/CONTRIBUTORS.md
@@ -28,3 +28,4 @@
 - Miquel Pascual  \<<mpascual@apsl.net>\>
 - Antoni Marroig  \<<amarroig@apsl.net>\>
 - Chau Le \<<chaulb@trobz.com>\>
+- Pierre Verkest \<<pierre@verkest.fr>\>

--- a/mis_builder/readme/USAGE.md
+++ b/mis_builder/readme/USAGE.md
@@ -19,3 +19,7 @@ To configure this module, you need to:
 ![](https://raw.githubusercontent.com/OCA/mis-builder/10.0/mis_builder/static/description/ex_report_preview.png)
 
 - On the MIS Reports view, you can add annotations on each cells (except cells coming from the option "details by account"). Added notes will be pinted when exporting to PDF and Excel. Only users having either the group to read or the group to update annotations can see those annotations.
+
+- In the **Widget** tab of a MIS Report Instance, you can configure interactive widget options:
+  - **Show filters box**: Displays an inline search bar to filter report lines. Active search filters and pivot dates are preserved when navigating to drilldown details and returning via breadcrumbs.
+  - **Cache report on drilldown**: Caches computed report data in browser memory during drilldown navigation. Returning via breadcrumbs renders the report instantly from memory without triggering a new server computation. Modifying filters or pivot dates automatically invalidates the cache and fetches fresh data.

--- a/mis_builder/static/description/index.html
+++ b/mis_builder/static/description/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="generator" content="Docutils: https://docutils.sourceforge.io/" />
-<title>README.rst</title>
+<title>MIS Builder</title>
 <style type="text/css">
 
 /*

--- a/mis_builder/static/description/index.html
+++ b/mis_builder/static/description/index.html
@@ -482,6 +482,18 @@ cells coming from the option “details by account”). Added notes will
 be pinted when exporting to PDF and Excel. Only users having either
 the group to read or the group to update annotations can see those
 annotations.</li>
+<li>In the <strong>Widget</strong> tab of a MIS Report Instance, you can configure
+interactive widget options:<ul>
+<li><strong>Show filters box</strong>: Displays an inline search bar to filter report
+lines. Active search filters and pivot dates are preserved when
+navigating to drilldown details and returning via breadcrumbs.</li>
+<li><strong>Cache report on drilldown</strong>: Caches computed report data in
+browser memory during drilldown navigation. Returning via
+breadcrumbs renders the report instantly from memory without
+triggering a new server computation. Modifying filters or pivot
+dates automatically invalidates the cache and fetches fresh data.</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="development">
@@ -1166,6 +1178,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Miquel Pascual &lt;<a class="reference external" href="mailto:mpascual&#64;apsl.net">mpascual&#64;apsl.net</a>&gt;</li>
 <li>Antoni Marroig &lt;<a class="reference external" href="mailto:amarroig&#64;apsl.net">amarroig&#64;apsl.net</a>&gt;</li>
 <li>Chau Le &lt;<a class="reference external" href="mailto:chaulb&#64;trobz.com">chaulb&#64;trobz.com</a>&gt;</li>
+<li>Pierre Verkest &lt;<a class="reference external" href="mailto:pierre&#64;verkest.fr">pierre&#64;verkest.fr</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/mis_builder/static/src/components/mis_report_widget.esm.js
+++ b/mis_builder/static/src/components/mis_report_widget.esm.js
@@ -86,10 +86,14 @@ export class MisReportWidget extends Component {
 
     exportState() {
         return {
-            searchState: this.searchModel ? this.searchModel.exportState() : null,
-            pivotDate: this.state.pivot_date
-                ? serializeDate(this.state.pivot_date)
-                : null,
+            searchState:
+                this.showSearchBar && this.searchModel && this.searchModel.sections
+                    ? this.searchModel.exportState()
+                    : null,
+            pivotDate:
+                this.showPivotDate && this.state.pivot_date
+                    ? serializeDate(this.state.pivot_date)
+                    : null,
             cachedReportData:
                 this.widget_cache_report_on_drill_down && this.state.mis_report_data
                     ? this.state.mis_report_data

--- a/mis_builder/static/src/components/mis_report_widget.esm.js
+++ b/mis_builder/static/src/components/mis_report_widget.esm.js
@@ -11,17 +11,17 @@ import {patch} from "@web/core/utils/patch";
 import {registry} from "@web/core/registry";
 import {useSetupAction} from "@web/search/action_hook";
 
-// Patch FormController to forward restored controller state to env.config
+// Patch FormController to forward restored globalState to env.config
 // for mis.report.instance form views.
-// When returning from drilldown via breadcrumbs, ActionService restores FormController
-// and passes saved exportedState via props.state. FormController does not propagate
-// props.state to env.config.state by default, so patching it here ensures child components
-// (like MisReportWidget) can access searchState in willStart() during view restoration.
+// When returning from drilldown via breadcrumbs or browser back button (popstate),
+// ActionService restores FormController and passes saved exportedState via props.globalState.
 patch(FormController.prototype, {
     setup() {
         super.setup();
-        if (this.props.state && this.props.resModel === "mis.report.instance") {
-            this.env.config.state = this.props.state;
+        if (this.props.resModel === "mis.report.instance") {
+            if (this.props.globalState) {
+                this.env.config.globalState = this.props.globalState;
+            }
         }
     },
 });
@@ -32,7 +32,6 @@ export class MisReportWidget extends Component {
         this.action = useService("action");
         this.orm = useService("orm");
         this.dialog = useService("dialog");
-        this.notification = useService("notification");
         this.view = useService("view");
         this.JSON = JSON;
 
@@ -53,7 +52,9 @@ export class MisReportWidget extends Component {
             this.refresh();
         });
         useSetupAction({
-            getLocalState: () => this.exportState(),
+            getGlobalState: () => ({
+                misReportState: JSON.stringify(this.exportState()),
+            }),
         });
         onWillStart(this.willStart);
 
@@ -72,14 +73,15 @@ export class MisReportWidget extends Component {
         this.widget_show_pivot_date = result.widget_show_pivot_date;
         this.widget_cache_report_on_drill_down =
             result.widget_cache_report_on_drill_down;
-        this.wide_display = result.wide_display_by_default;
-
-        this.state.can_edit_annotation = result.user_can_edit_annotation;
-        this.state.can_read_annotation = result.user_can_read_annotation;
 
         this._restoreState(state, result);
         await this._setupSearchModel(state?.searchState);
+
+        this.wide_display = result.wide_display_by_default;
+
         this._loadReportData(state?.cachedReportData);
+        this.state.can_edit_annotation = result.user_can_edit_annotation;
+        this.state.can_read_annotation = result.user_can_read_annotation;
     }
 
     exportState() {
@@ -103,13 +105,15 @@ export class MisReportWidget extends Component {
     }
 
     _getRestoredState() {
-        return (
-            this.props.state ||
-            this.env.config?.state ||
-            this.action.currentController?.props?.state ||
-            this.action.currentController?.exportedState ||
-            null
-        );
+        const globalState = this.props.globalState || this.env.config?.globalState;
+        if (globalState?.misReportState) {
+            try {
+                return JSON.parse(globalState.misReportState);
+            } catch {
+                return null;
+            }
+        }
+        return this.props.state || this.env.config?.state || null;
     }
 
     async _loadReportInstanceData() {
@@ -212,7 +216,7 @@ export class MisReportWidget extends Component {
         if (this.action.currentController) {
             this.action.currentController.exportedState = {
                 ...(this.action.currentController.exportedState || {}),
-                ...this.exportState(),
+                misReportState: JSON.stringify(this.exportState()),
             };
         }
         const drilldown = JSON.parse(event.target.dataset.drilldown);

--- a/mis_builder/static/src/components/mis_report_widget.esm.js
+++ b/mis_builder/static/src/components/mis_report_widget.esm.js
@@ -1,36 +1,64 @@
 import {Component, onMounted, onWillStart, useState, useSubEnv} from "@odoo/owl";
+import {parseDate, serializeDate} from "@web/core/l10n/dates";
 import {useBus, useService} from "@web/core/utils/hooks";
+import {AnnotationDialog} from "../annotation_dialog/annotation_dialog.esm";
 import {DateTimeInput} from "@web/core/datetime/datetime_input";
+import {FormController} from "@web/views/form/form_controller";
 import {SearchBar} from "@web/search/search_bar/search_bar";
 import {SearchModel} from "@web/search/search_model";
-import {parseDate} from "@web/core/l10n/dates";
-import {registry} from "@web/core/registry";
-import {AnnotationDialog} from "../annotation_dialog/annotation_dialog.esm";
 import {_t} from "@web/core/l10n/translation";
+import {patch} from "@web/core/utils/patch";
+import {registry} from "@web/core/registry";
+import {useSetupAction} from "@web/search/action_hook";
+
+// Patch FormController to forward restored controller state to env.config
+// for mis.report.instance form views.
+// When returning from drilldown via breadcrumbs, ActionService restores FormController
+// and passes saved exportedState via props.state. FormController does not propagate
+// props.state to env.config.state by default, so patching it here ensures child components
+// (like MisReportWidget) can access searchState in willStart() during view restoration.
+patch(FormController.prototype, {
+    setup() {
+        super.setup();
+        if (this.props.state && this.props.resModel === "mis.report.instance") {
+            this.env.config.state = this.props.state;
+        }
+    },
+});
 
 export class MisReportWidget extends Component {
     setup() {
         super.setup();
-        this.orm = useService("orm");
         this.action = useService("action");
-        this.view = useService("view");
+        this.orm = useService("orm");
         this.dialog = useService("dialog");
+        this.notification = useService("notification");
+        this.view = useService("view");
         this.JSON = JSON;
+
         this.state = useState({
-            mis_report_data: {header: [], body: [], notes: {}},
+            mis_report_data: null,
             pivot_date: null,
             can_edit_annotation: false,
-            can_read_annotation: false,
         });
+
         this.searchModel = new SearchModel(this.env, {
             orm: this.orm,
             view: this.view,
             dialog: this.dialog,
         });
         useSubEnv({searchModel: this.searchModel});
-        useBus(this.env.searchModel, "update", async () => {
-            await this.env.searchModel.sectionsPromise;
+        useBus(this.searchModel, "update", async () => {
+            await this.searchModel.sectionsPromise;
             this.refresh();
+        });
+        useSetupAction({
+            getLocalState: () => ({
+                searchState: this.searchModel ? this.searchModel.exportState() : null,
+                pivotDate: this.state.pivot_date
+                    ? serializeDate(this.state.pivot_date)
+                    : null,
+            }),
         });
         onWillStart(this.willStart);
 
@@ -39,6 +67,15 @@ export class MisReportWidget extends Component {
 
     // Lifecycle
     async willStart() {
+        const state =
+            this.props.state ||
+            this.env.config?.state ||
+            this.action.currentController?.props?.state ||
+            this.action.currentController?.exportedState;
+
+        const searchState = state?.searchState;
+        const pivotDateStr = state?.pivotDate;
+
         const [result] = await this.orm.read(
             "mis.report.instance",
             [this._instanceId()],
@@ -60,15 +97,20 @@ export class MisReportWidget extends Component {
         this.widget_show_filters = result.widget_show_filters;
         this.widget_show_settings_button = result.widget_show_settings_button;
         this.widget_search_view_id = result.widget_search_view_id?.[0];
-        this.state.pivot_date = parseDate(result.pivot_date);
+        this.state.pivot_date = pivotDateStr
+            ? parseDate(pivotDateStr)
+            : parseDate(result.pivot_date);
         this.widget_show_pivot_date = result.widget_show_pivot_date;
 
         if (this.showSearchBar) {
-            // Initialize the search model
-            await this.searchModel.load({
+            const config = {
                 resModel: this.source_aml_model_name,
                 searchViewId: this.widget_search_view_id,
-            });
+            };
+            if (searchState) {
+                config.state = searchState;
+            }
+            await this.searchModel.load(config);
         }
 
         this.wide_display = result.wide_display_by_default;
@@ -105,6 +147,9 @@ export class MisReportWidget extends Component {
         if (this.props.value) {
             return this.props.value;
         }
+        if (this.props.record?.resId) {
+            return this.props.record.resId;
+        }
 
         /*
          * This trick is needed because in a dashboard the view does
@@ -112,7 +157,7 @@ export class MisReportWidget extends Component {
          * of Odoo dashboards that are not designed to contain forms but
          * rather tree views or charts.
          */
-        const context = this.props.record.context;
+        const context = this.props.record?.context || {};
         if (context.active_model === "mis.report.instance") {
             return context.active_id;
         }
@@ -130,6 +175,15 @@ export class MisReportWidget extends Component {
     }
 
     async drilldown(event) {
+        if (this.action.currentController) {
+            this.action.currentController.exportedState = {
+                ...(this.action.currentController.exportedState || {}),
+                searchState: this.searchModel ? this.searchModel.exportState() : null,
+                pivotDate: this.state.pivot_date
+                    ? serializeDate(this.state.pivot_date)
+                    : null,
+            };
+        }
         const drilldown = JSON.parse(event.target.dataset.drilldown);
         const action = await this.orm.call(
             "mis.report.instance",
@@ -232,6 +286,9 @@ export class MisReportWidget extends Component {
 
     onDateTimeChanged(ev) {
         this.state.pivot_date = ev;
+        if (this.props.record) {
+            this.props.record._misReportPivotDate = serializeDate(ev);
+        }
         this.refresh();
     }
 
@@ -242,13 +299,13 @@ export class MisReportWidget extends Component {
 
     async resize_sheet() {
         var sheet_element = document.getElementsByClassName("o_form_sheet_bg")[0];
-        sheet_element.classList.toggle(
+        sheet_element?.classList.toggle(
             "oe_mis_builder_report_wide_sheet",
             this.wide_display
         );
         var button_resize_element = document.getElementById("icon_resize");
-        button_resize_element.classList.toggle("fa-expand", !this.wide_display);
-        button_resize_element.classList.toggle("fa-compress", this.wide_display);
+        button_resize_element?.classList.toggle("fa-expand", !this.wide_display);
+        button_resize_element?.classList.toggle("fa-compress", this.wide_display);
     }
 }
 

--- a/mis_builder/static/src/components/mis_report_widget.esm.js
+++ b/mis_builder/static/src/components/mis_report_widget.esm.js
@@ -53,12 +53,7 @@ export class MisReportWidget extends Component {
             this.refresh();
         });
         useSetupAction({
-            getLocalState: () => ({
-                searchState: this.searchModel ? this.searchModel.exportState() : null,
-                pivotDate: this.state.pivot_date
-                    ? serializeDate(this.state.pivot_date)
-                    : null,
-            }),
+            getLocalState: () => this.exportState(),
         });
         onWillStart(this.willStart);
 
@@ -67,15 +62,57 @@ export class MisReportWidget extends Component {
 
     // Lifecycle
     async willStart() {
-        const state =
+        const state = this._getRestoredState();
+        const result = await this._loadReportInstanceData();
+
+        this.source_aml_model_name = result.source_aml_model_name;
+        this.widget_show_filters = result.widget_show_filters;
+        this.widget_show_settings_button = result.widget_show_settings_button;
+        this.widget_search_view_id = result.widget_search_view_id?.[0];
+        this.widget_show_pivot_date = result.widget_show_pivot_date;
+        this.widget_cache_report_on_drill_down =
+            result.widget_cache_report_on_drill_down;
+        this.wide_display = result.wide_display_by_default;
+
+        this.state.can_edit_annotation = result.user_can_edit_annotation;
+        this.state.can_read_annotation = result.user_can_read_annotation;
+
+        this._restoreState(state, result);
+        await this._setupSearchModel(state?.searchState);
+        this._loadReportData(state?.cachedReportData);
+    }
+
+    exportState() {
+        return {
+            searchState: this.searchModel ? this.searchModel.exportState() : null,
+            pivotDate: this.state.pivot_date
+                ? serializeDate(this.state.pivot_date)
+                : null,
+            cachedReportData:
+                this.widget_cache_report_on_drill_down && this.state.mis_report_data
+                    ? this.state.mis_report_data
+                    : null,
+        };
+    }
+
+    _restoreState(state, result) {
+        const pivotDateStr = state?.pivotDate;
+        this.state.pivot_date = pivotDateStr
+            ? parseDate(pivotDateStr)
+            : parseDate(result.pivot_date);
+    }
+
+    _getRestoredState() {
+        return (
             this.props.state ||
             this.env.config?.state ||
             this.action.currentController?.props?.state ||
-            this.action.currentController?.exportedState;
+            this.action.currentController?.exportedState ||
+            null
+        );
+    }
 
-        const searchState = state?.searchState;
-        const pivotDateStr = state?.pivotDate;
-
+    async _loadReportInstanceData() {
         const [result] = await this.orm.read(
             "mis.report.instance",
             [this._instanceId()],
@@ -86,39 +123,36 @@ export class MisReportWidget extends Component {
                 "widget_search_view_id",
                 "pivot_date",
                 "widget_show_pivot_date",
+                "widget_cache_report_on_drill_down",
                 "wide_display_by_default",
                 "user_can_read_annotation",
                 "user_can_edit_annotation",
             ],
             {context: this.context}
         );
+        return result;
+    }
 
-        this.source_aml_model_name = result.source_aml_model_name;
-        this.widget_show_filters = result.widget_show_filters;
-        this.widget_show_settings_button = result.widget_show_settings_button;
-        this.widget_search_view_id = result.widget_search_view_id?.[0];
-        this.state.pivot_date = pivotDateStr
-            ? parseDate(pivotDateStr)
-            : parseDate(result.pivot_date);
-        this.widget_show_pivot_date = result.widget_show_pivot_date;
-
-        if (this.showSearchBar) {
-            const config = {
-                resModel: this.source_aml_model_name,
-                searchViewId: this.widget_search_view_id,
-            };
-            if (searchState) {
-                config.state = searchState;
-            }
-            await this.searchModel.load(config);
+    async _setupSearchModel(searchState) {
+        if (!this.showSearchBar) {
+            return;
         }
+        const config = {
+            resModel: this.source_aml_model_name,
+            searchViewId: this.widget_search_view_id,
+        };
+        if (searchState) {
+            config.state = searchState;
+        }
+        await this.searchModel.load(config);
+    }
 
-        this.wide_display = result.wide_display_by_default;
-
-        // Compute the report
-        this.refresh();
-        this.state.can_edit_annotation = result.user_can_edit_annotation;
-        this.state.can_read_annotation = result.user_can_read_annotation;
+    _loadReportData(cachedReportData) {
+        if (this.widget_cache_report_on_drill_down && cachedReportData) {
+            this.state.mis_report_data = cachedReportData;
+        } else {
+            this.refresh();
+        }
     }
 
     async _onMounted() {
@@ -178,10 +212,7 @@ export class MisReportWidget extends Component {
         if (this.action.currentController) {
             this.action.currentController.exportedState = {
                 ...(this.action.currentController.exportedState || {}),
-                searchState: this.searchModel ? this.searchModel.exportState() : null,
-                pivotDate: this.state.pivot_date
-                    ? serializeDate(this.state.pivot_date)
-                    : null,
+                ...this.exportState(),
             };
         }
         const drilldown = JSON.parse(event.target.dataset.drilldown);

--- a/mis_builder/static/tests/tours/mis_report_back_button_no_filters_tour.esm.js
+++ b/mis_builder/static/tests/tours/mis_report_back_button_no_filters_tour.esm.js
@@ -1,0 +1,27 @@
+import {registry} from "@web/core/registry";
+
+registry.category("web_tour.tours").add("mis_report_back_button_no_filters_tour", {
+    steps: () => [
+        {
+            trigger: ".o_data_row:contains('Test Instance Drilldown')",
+        },
+        {
+            trigger:
+                ".o_data_row:contains('Test Instance Drilldown') button[name='preview']",
+            run: "click",
+        },
+        {
+            trigger: "a.mis_builder_drilldown",
+            run: "click",
+        },
+        {
+            trigger: "tr.o_data_row td:contains('Line 1')",
+            run: () => {
+                window.history.back();
+            },
+        },
+        {
+            trigger: "a.mis_builder_drilldown",
+        },
+    ],
+});

--- a/mis_builder/static/tests/tours/mis_report_back_button_tour.esm.js
+++ b/mis_builder/static/tests/tours/mis_report_back_button_tour.esm.js
@@ -1,0 +1,46 @@
+import {registry} from "@web/core/registry";
+
+registry.category("web_tour.tours").add("mis_report_back_button_tour", {
+    steps: () => [
+        {
+            trigger: ".o_data_row:contains('Test Instance Drilldown')",
+        },
+        {
+            trigger:
+                ".o_data_row:contains('Test Instance Drilldown') button[name='preview']",
+            run: "click",
+        },
+        {
+            trigger: ".o_searchview_input",
+            run: "click",
+        },
+        {
+            trigger: ".o_searchview_input",
+            run: "edit Line",
+        },
+        {
+            trigger:
+                ".o_searchview_autocomplete .dropdown-item, .o_searchview_autocomplete a",
+            run: "click",
+        },
+        {
+            trigger: ".o_searchview_facet",
+        },
+        {
+            trigger: "a.mis_builder_drilldown",
+            run: "click",
+        },
+        {
+            trigger: "tr.o_data_row td:contains('Line 1')",
+            run: () => {
+                window.history.back();
+            },
+        },
+        {
+            trigger: ".o_searchview_facet",
+        },
+        {
+            trigger: "a.mis_builder_drilldown",
+        },
+    ],
+});

--- a/mis_builder/static/tests/tours/mis_report_drilldown_tour.esm.js
+++ b/mis_builder/static/tests/tours/mis_report_drilldown_tour.esm.js
@@ -1,0 +1,32 @@
+import {registry} from "@web/core/registry";
+
+registry.category("web_tour.tours").add("mis_report_drilldown_tour", {
+    steps: () => [
+        {
+            trigger: ".o_searchview_input",
+            run: "edit Line",
+        },
+        {
+            trigger:
+                ".o_searchview_autocomplete .dropdown-item, .o_searchview_autocomplete a",
+            run: "click",
+        },
+        {
+            trigger: ".o_searchview_facet",
+        },
+        {
+            trigger: "a.mis_builder_drilldown",
+            run: "click",
+        },
+        {
+            trigger: ".o_list_renderer, .o_list_view",
+        },
+        {
+            trigger: ".breadcrumb .breadcrumb-item a, .breadcrumb .o_back_button",
+            run: "click",
+        },
+        {
+            trigger: ".o_searchview_facet",
+        },
+    ],
+});

--- a/mis_builder/tests/test_mis_report_widget_tour.py
+++ b/mis_builder/tests/test_mis_report_widget_tour.py
@@ -9,19 +9,18 @@ from odoo.tests import tagged
 
 @tagged("at_install", "post_install")
 class TestMisReportWidgetTour(common.HttpCase):
-    def setUp(self):
-        super().setUp()
-        aml_model_id = self.env.ref("account.model_account_move_line").id
-        aml_date_field_id = self.env.ref("account.field_account_move_line__date").id
-        aml_debit_field_id = self.env.ref("account.field_account_move_line__debit").id
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        aml_model_id = cls.env.ref("account.model_account_move_line").id
+        aml_date_field_id = cls.env.ref("account.field_account_move_line__date").id
+        aml_debit_field_id = cls.env.ref("account.field_account_move_line__debit").id
 
-        journal = self.env["account.journal"].search(
-            [("type", "=", "general")], limit=1
-        )
-        account = self.env["account.account"].search([("code", "!=", False)], limit=1)
+        journal = cls.env["account.journal"].search([("type", "=", "general")], limit=1)
+        account = cls.env["account.account"].search([("code", "!=", False)], limit=1)
         account.name = "Line Account"
 
-        move = self.env["account.move"].create(
+        move = cls.env["account.move"].create(
             {
                 "journal_id": journal.id,
                 "date": "2026-06-01",
@@ -53,7 +52,7 @@ class TestMisReportWidgetTour(common.HttpCase):
         )
         move.action_post()
 
-        self.report = self.env["mis.report"].create(
+        cls.report = cls.env["mis.report"].create(
             {
                 "name": "Test Drilldown Report",
                 "move_lines_source": aml_model_id,
@@ -86,12 +85,12 @@ class TestMisReportWidgetTour(common.HttpCase):
             }
         )
 
-        search_view = self.env.ref("account.view_account_move_line_filter")
+        search_view = cls.env.ref("account.view_account_move_line_filter")
 
-        self.report_instance = self.env["mis.report.instance"].create(
+        cls.report_instance = cls.env["mis.report.instance"].create(
             {
                 "name": "Test Instance Drilldown",
-                "report_id": self.report.id,
+                "report_id": cls.report.id,
                 "widget_show_filters": True,
                 "widget_search_view_id": search_view.id,
                 "comparison_mode": True,
@@ -168,3 +167,21 @@ class TestMisReportWidgetTour(common.HttpCase):
         # 2. Filter search input update
         # Return via breadcrumbs uses cached data, skipping compute()
         self.assertEqual(len(compute_calls), 2)
+
+    def test_mis_report_back_button_tour(self):
+        search_view = self.env.ref("account.view_account_move_line_filter")
+        self.report_instance.write(
+            {
+                "widget_show_filters": True,
+                "widget_search_view_id": search_view.id,
+            }
+        )
+        action = self.env.ref("mis_builder.mis_report_instance_view_action")
+        domain = f"[('id', '=', {self.report_instance.id})]"
+        url = (
+            f"/web#action={action.id}"
+            f"&model=mis.report.instance"
+            f"&view_type=list"
+            f"&domain={domain}"
+        )
+        self.start_tour(url, "mis_report_back_button_tour", login="admin")

--- a/mis_builder/tests/test_mis_report_widget_tour.py
+++ b/mis_builder/tests/test_mis_report_widget_tour.py
@@ -1,6 +1,8 @@
 # Copyright 2026 APyCOD (<https://apycod.com>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
+from unittest.mock import patch
+
 import odoo.tests.common as common
 from odoo.tests import tagged
 
@@ -112,6 +114,7 @@ class TestMisReportWidgetTour(common.HttpCase):
         )
 
     def test_mis_report_drilldown_tour(self):
+        self.report_instance.widget_cache_report_on_drill_down = False
         view_id = self.env.ref("mis_builder.mis_report_instance_result_view_form").id
         url = (
             f"/web#id={self.report_instance.id}"
@@ -119,4 +122,49 @@ class TestMisReportWidgetTour(common.HttpCase):
             f"&view_type=form"
             f"&view_id={view_id}"
         )
-        self.start_tour(url, "mis_report_drilldown_tour", login="admin")
+        compute_calls = []
+        model_cls = type(self.report_instance)
+        orig_compute = model_cls.compute
+
+        def mock_compute(instance_self, *args, **kwargs):
+            compute_calls.append(instance_self.id)
+            return orig_compute(instance_self, *args, **kwargs)
+
+        with patch.object(
+            model_cls, "compute", side_effect=mock_compute, autospec=True
+        ):
+            self.start_tour(url, "mis_report_drilldown_tour", login="admin")
+
+        # Without cache: compute() is called 3 times:
+        # 1. Initial form view load
+        # 2. Filter search input update
+        # 3. Return via breadcrumbs (recomputed)
+        self.assertEqual(len(compute_calls), 3)
+
+    def test_mis_report_drilldown_cache_tour(self):
+        self.report_instance.widget_cache_report_on_drill_down = True
+        view_id = self.env.ref("mis_builder.mis_report_instance_result_view_form").id
+        url = (
+            f"/web#id={self.report_instance.id}"
+            f"&model=mis.report.instance"
+            f"&view_type=form"
+            f"&view_id={view_id}"
+        )
+        compute_calls = []
+        model_cls = type(self.report_instance)
+        orig_compute = model_cls.compute
+
+        def mock_compute(instance_self, *args, **kwargs):
+            compute_calls.append(instance_self.id)
+            return orig_compute(instance_self, *args, **kwargs)
+
+        with patch.object(
+            model_cls, "compute", side_effect=mock_compute, autospec=True
+        ):
+            self.start_tour(url, "mis_report_drilldown_tour", login="admin")
+
+        # With cache: compute() is called 2 times:
+        # 1. Initial form view load
+        # 2. Filter search input update
+        # Return via breadcrumbs uses cached data, skipping compute()
+        self.assertEqual(len(compute_calls), 2)

--- a/mis_builder/tests/test_mis_report_widget_tour.py
+++ b/mis_builder/tests/test_mis_report_widget_tour.py
@@ -1,0 +1,122 @@
+# Copyright 2026 APyCOD (<https://apycod.com>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+import odoo.tests.common as common
+from odoo.tests import tagged
+
+
+@tagged("at_install", "post_install")
+class TestMisReportWidgetTour(common.HttpCase):
+    def setUp(self):
+        super().setUp()
+        aml_model_id = self.env.ref("account.model_account_move_line").id
+        aml_date_field_id = self.env.ref("account.field_account_move_line__date").id
+        aml_debit_field_id = self.env.ref("account.field_account_move_line__debit").id
+
+        journal = self.env["account.journal"].search(
+            [("type", "=", "general")], limit=1
+        )
+        account = self.env["account.account"].search([("code", "!=", False)], limit=1)
+        account.name = "Line Account"
+
+        move = self.env["account.move"].create(
+            {
+                "journal_id": journal.id,
+                "date": "2026-06-01",
+                "line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "Line 1",
+                            "account_id": account.id,
+                            "debit": 100.0,
+                            "credit": 0.0,
+                            "date": "2026-06-01",
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "Line 2",
+                            "account_id": account.id,
+                            "debit": 0.0,
+                            "credit": 100.0,
+                            "date": "2026-06-01",
+                        },
+                    ),
+                ],
+            }
+        )
+        move.action_post()
+
+        self.report = self.env["mis.report"].create(
+            {
+                "name": "Test Drilldown Report",
+                "move_lines_source": aml_model_id,
+                "query_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "aml",
+                            "model_id": aml_model_id,
+                            "field_ids": [(4, aml_debit_field_id, None)],
+                            "date_field": aml_date_field_id,
+                            "aggregate": "sum",
+                        },
+                    )
+                ],
+                "kpi_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "kpi1",
+                            "description": "KPI 1",
+                            "expression": f"deb[{account.code}]",
+                            "type": "num",
+                            "sequence": 1,
+                        },
+                    )
+                ],
+            }
+        )
+
+        search_view = self.env.ref("account.view_account_move_line_filter")
+
+        self.report_instance = self.env["mis.report.instance"].create(
+            {
+                "name": "Test Instance Drilldown",
+                "report_id": self.report.id,
+                "widget_show_filters": True,
+                "widget_search_view_id": search_view.id,
+                "comparison_mode": True,
+                "pivot_date": "2026-06-01",
+                "date_from": "2026-01-01",
+                "date_to": "2026-12-31",
+                "period_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "2026",
+                            "mode": "fix",
+                            "manual_date_from": "2026-01-01",
+                            "manual_date_to": "2026-12-31",
+                        },
+                    )
+                ],
+            }
+        )
+
+    def test_mis_report_drilldown_tour(self):
+        view_id = self.env.ref("mis_builder.mis_report_instance_result_view_form").id
+        url = (
+            f"/web#id={self.report_instance.id}"
+            f"&model=mis.report.instance"
+            f"&view_type=form"
+            f"&view_id={view_id}"
+        )
+        self.start_tour(url, "mis_report_drilldown_tour", login="admin")

--- a/mis_builder/tests/test_mis_report_widget_tour.py
+++ b/mis_builder/tests/test_mis_report_widget_tour.py
@@ -185,3 +185,20 @@ class TestMisReportWidgetTour(common.HttpCase):
             f"&domain={domain}"
         )
         self.start_tour(url, "mis_report_back_button_tour", login="admin")
+
+    def test_mis_report_back_button_no_filters_tour(self):
+        self.report_instance.write(
+            {
+                "widget_show_filters": False,
+                "widget_search_view_id": False,
+            }
+        )
+        action = self.env.ref("mis_builder.mis_report_instance_view_action")
+        domain = f"[('id', '=', {self.report_instance.id})]"
+        url = (
+            f"/web#action={action.id}"
+            f"&model=mis.report.instance"
+            f"&view_type=list"
+            f"&domain={domain}"
+        )
+        self.start_tour(url, "mis_report_back_button_no_filters_tour", login="admin")

--- a/mis_builder/views/mis_report_instance.xml
+++ b/mis_builder/views/mis_report_instance.xml
@@ -221,6 +221,22 @@
         <field name="domain">[('temporary', '=', False)]</field>
         <field name="path">mis-report-instances</field>
     </record>
+    <record model="ir.actions.act_window" id="mis_report_instance_preview_action">
+        <field name="name">MIS Report Preview</field>
+        <field name="res_model">mis.report.instance</field>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="mis_report_instance_result_view_form" />
+        <field name="path">mis-report-instance-preview</field>
+    </record>
+    <record
+        model="ir.actions.act_window.view"
+        id="mis_report_instance_preview_action_view"
+    >
+        <field name="sequence" eval="1" />
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="mis_report_instance_result_view_form" />
+        <field name="act_window_id" ref="mis_report_instance_preview_action" />
+    </record>
     <menuitem
         id="mis_report_finance_menu"
         parent="account.menu_finance_reports"

--- a/mis_builder/views/mis_report_instance.xml
+++ b/mis_builder/views/mis_report_instance.xml
@@ -205,6 +205,7 @@
                                 />
                                 <field name="widget_show_settings_button" />
                                 <field name="widget_show_pivot_date" />
+                                <field name="widget_cache_report_on_drill_down" />
                             </group>
                         </page>
                     </notebook>

--- a/mis_builder/views/mis_report_instance.xml
+++ b/mis_builder/views/mis_report_instance.xml
@@ -202,6 +202,7 @@
                                 <field
                                     name="widget_search_view_id"
                                     invisible="not widget_show_filters"
+                                    required="widget_show_filters"
                                 />
                                 <field name="widget_show_settings_button" />
                                 <field name="widget_show_pivot_date" />


### PR DESCRIPTION
When navigating away from a MIS report via drilldown links and returning using the breadcrumb, active search filters and pivot date were lost.

- First commit preserves the report widget state across view navigation (only using breadcrumb)
- second commit Allow caching computed report data in browser memory during drilldown
navigation to prevent recomputing the report when returning via breadcrumbs (this feature is opt out by default for consistency with current version).
- third commit fix navigation while using browser navigation back button (before this commit we get the config view instead of the preview form)



https://github.com/user-attachments/assets/d2ba095d-5434-4902-8b62-28377b19d128



* commit 8882b31 is to fix an issue when search bar widget is not displayed (internal issue ref #98869)