### PR TITLE
[FIX] mis_builder: multi company reports

### DIFF
--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -644,10 +644,8 @@ class MisReportInstance(models.Model):
     def _compute_query_company_ids(self):
         for rec in self:
             if rec.multi_company:
-                if not rec.company_ids:
-                    rec.query_company_ids = self.env.companies
-                else:
-                    rec.query_company_ids = rec.company_ids & self.env.companies
+                company_ids = rec.sudo().company_ids & self.env.companies
+                rec.query_company_ids = company_ids or self.env.companies
             else:
                 rec.query_company_ids = rec.company_id or self.env.company
 

--- a/mis_builder/tests/test_mis_report_instance.py
+++ b/mis_builder/tests/test_mis_report_instance.py
@@ -753,3 +753,53 @@ class TestMisReportInstance(common.HttpCase):
     def test_copy_mis_report_instance(self):
         new_instance = self.report_instance.copy()
         self.assertEqual(new_instance.name, f"{self.report_instance.name} (copy)")
+
+    def test_single_company_user_can_preview_multi_company_report(self):
+        c1 = self.env["res.company"].create({"name": "Company 1"})
+        c2 = self.env["res.company"].create({"name": "Company 2"})
+        single_user = common.new_test_user(
+            self.env,
+            "single_comp_user",
+            groups="base.group_user,account.group_account_readonly",
+            company_id=c1.id,
+            company_ids=[(6, 0, [c1.id])],
+        )
+        report_instance = self.env["mis.report.instance"].create(
+            {
+                "name": "Multi Company Report",
+                "report_id": self.report.id,
+                "multi_company": True,
+                "company_ids": [(6, 0, [c1.id, c2.id])],
+            }
+        )
+        res = (
+            report_instance.with_user(single_user)
+            .with_context(allowed_company_ids=[c1.id])
+            .preview()
+        )
+        self.assertEqual(res["res_id"], report_instance.id)
+
+    def test_single_company_user_can_compute_multi_company_report(self):
+        c1 = self.env["res.company"].create({"name": "Company 1"})
+        c2 = self.env["res.company"].create({"name": "Company 2"})
+        single_user = common.new_test_user(
+            self.env,
+            "single_comp_user",
+            groups="base.group_user,account.group_account_readonly",
+            company_id=c1.id,
+            company_ids=[(6, 0, [c1.id])],
+        )
+        report_instance = self.env["mis.report.instance"].create(
+            {
+                "name": "Multi Company Report",
+                "report_id": self.report.id,
+                "multi_company": True,
+                "company_ids": [(6, 0, [c1.id, c2.id])],
+            }
+        )
+        matrix = (
+            report_instance.with_user(single_user)
+            .with_context(allowed_company_ids=[c1.id])
+            .compute()
+        )
+        self.assertIn("body", matrix)


### PR DESCRIPTION
This PR fix an issue to preview multi-company report:

To reproduce/test:
- create at least two companies
- setup multi-company mis report that belongs to those two company
- create a user that belongs one of them
- connect with the freshly created user and open the preview of the document

before this commit we get an access error on res.company model because the user is not allow to read the second company 
after this PR user can open the preview without issue