### PR TITLE
[19.0][FIX] mis_builder: collect the subreport tests

### DIFF
--- a/mis_builder/readme/newsfragments/831.misc
+++ b/mis_builder/readme/newsfragments/831.misc
@@ -1,0 +1,2 @@
+The subreport unit tests are now part of the test suite. `test_subreport.py`
+had never been imported in `tests/__init__.py`, so it was never collected.

--- a/mis_builder/tests/__init__.py
+++ b/mis_builder/tests/__init__.py
@@ -13,6 +13,7 @@ from . import test_period_dates
 from . import test_pro_rata_read_group
 from . import test_render
 from . import test_simple_array
+from . import test_subreport
 from . import test_target_move
 from . import test_utc_midnight
 from . import test_mis_report_instance_annotation


### PR DESCRIPTION
## Description

`mis_builder/tests/test_subreport.py` has never been imported in `mis_builder/tests/__init__.py`. It was added by 5466f35c ([ADD] subreports, 2020-02-10), which registered the model and the security rules but not the test module, so Odoo has never collected its four tests. f2f82a54 ([IMP] Rework the analytic filtering mechanism, 2023) even kept adapting the file, without it ever running.

This adds the missing import. Nothing else changes.

No preliminary issue was opened, as the change is a single import.

## Test

The four tests pass unchanged, so no adaptation was needed:

```yml
    odoo.tests.result: 0 failed, 0 error(s) of 4 tests
```

The full module suite goes from 119 to 123 collected tests, still green:

```yml
    odoo.tests.stats:  mis_builder: 123 tests 23.69s 12221 queries
    odoo.tests.result: 0 failed, 0 error(s)
```

## Target branch

19.0. The "Target branch" section of the PR template is out of date: it still refers to versions 9 to 12 and asks to target 10.0.

## CLA

Signed.

## Changelog entry

`mis_builder/readme/newsfragments/831.misc`.